### PR TITLE
Initialize Bun workspace monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Environment variables
+.env
+.env.*
+!.env.example
+
+# Logs
+*.log
+
+# OS files
+.DS_Store
+
+# Bun lockfile (optional - uncomment to commit)
+# bun.lockb
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# TypeScript build info
+*.tsbuildinfo

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@waibspace/backend",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "bun --watch src/index.ts",
+    "build": "bun build src/index.ts --outdir dist --target bun",
+    "start": "bun dist/index.js"
+  },
+  "dependencies": {
+    "@waibspace/types": "workspace:*",
+    "@waibspace/event-bus": "workspace:*",
+    "@waibspace/orchestrator": "workspace:*",
+    "@waibspace/agents": "workspace:*",
+    "@waibspace/connectors": "workspace:*",
+    "@waibspace/policy": "workspace:*",
+    "@waibspace/memory": "workspace:*",
+    "@waibspace/surfaces": "workspace:*",
+    "@waibspace/model-provider": "workspace:*"
+  }
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,0 +1,1 @@
+// apps/backend

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@waibspace/frontend",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "bunx --bun vite",
+    "build": "bunx --bun vite build",
+    "preview": "bunx --bun vite preview"
+  },
+  "dependencies": {
+    "@waibspace/types": "workspace:*",
+    "@waibspace/ui-renderer-contract": "workspace:*"
+  }
+}

--- a/apps/frontend/src/index.ts
+++ b/apps/frontend/src/index.ts
@@ -1,0 +1,1 @@
+// apps/frontend

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[install]
+# Use hardlinks for faster installs in the monorepo
+link = "hardlink"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "waibspace",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "dev:frontend": "bun --filter @waibspace/frontend dev",
+    "dev:backend": "bun --filter @waibspace/backend dev",
+    "build": "bun --filter '*' build",
+    "typecheck": "bun --filter '*' typecheck"
+  }
+}

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@waibspace/agents",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@waibspace/types": "workspace:*",
+    "@waibspace/event-bus": "workspace:*",
+    "@waibspace/model-provider": "workspace:*"
+  }
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1,0 +1,1 @@
+// packages/agents

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@waibspace/connectors",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@waibspace/types": "workspace:*"
+  }
+}

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -1,0 +1,1 @@
+// packages/connectors

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@waibspace/event-bus",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@waibspace/types": "workspace:*"
+  }
+}

--- a/packages/event-bus/src/index.ts
+++ b/packages/event-bus/src/index.ts
@@ -1,0 +1,1 @@
+// packages/event-bus

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@waibspace/memory",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@waibspace/types": "workspace:*"
+  }
+}

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,0 +1,1 @@
+// packages/memory

--- a/packages/model-provider/package.json
+++ b/packages/model-provider/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@waibspace/model-provider",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@waibspace/types": "workspace:*"
+  }
+}

--- a/packages/model-provider/src/index.ts
+++ b/packages/model-provider/src/index.ts
@@ -1,0 +1,1 @@
+// packages/model-provider

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@waibspace/orchestrator",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@waibspace/types": "workspace:*",
+    "@waibspace/event-bus": "workspace:*",
+    "@waibspace/policy": "workspace:*"
+  }
+}

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -1,0 +1,1 @@
+// packages/orchestrator

--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@waibspace/policy",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@waibspace/types": "workspace:*"
+  }
+}

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -1,0 +1,1 @@
+// packages/policy

--- a/packages/surfaces/package.json
+++ b/packages/surfaces/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@waibspace/surfaces",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@waibspace/types": "workspace:*",
+    "@waibspace/ui-renderer-contract": "workspace:*"
+  }
+}

--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -1,0 +1,1 @@
+// packages/surfaces

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@waibspace/types",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts"
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,1 @@
+// packages/types

--- a/packages/ui-renderer-contract/package.json
+++ b/packages/ui-renderer-contract/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@waibspace/ui-renderer-contract",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@waibspace/types": "workspace:*"
+  }
+}

--- a/packages/ui-renderer-contract/src/index.ts
+++ b/packages/ui-renderer-contract/src/index.ts
@@ -1,0 +1,1 @@
+// packages/ui-renderer-contract

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["bun-types"]
+  }
+}


### PR DESCRIPTION
## Summary
- Set up root `package.json` with Bun workspaces pointing to `apps/*` and `packages/*`
- Created `package.json` for all 12 workspace packages (`@waibspace/types`, `@waibspace/event-bus`, `@waibspace/orchestrator`, `@waibspace/agents`, `@waibspace/connectors`, `@waibspace/policy`, `@waibspace/memory`, `@waibspace/surfaces`, `@waibspace/model-provider`, `@waibspace/ui-renderer-contract`, `@waibspace/frontend`, `@waibspace/backend`) with cross-package dependencies based on the architecture doc
- Added `bunfig.toml`, `tsconfig.json`, and `.gitignore`
- Verified `bun install` resolves all workspace dependencies successfully

Closes #1

## Test plan
- [ ] Run `bun install` from root — should resolve all 12 workspace packages
- [ ] Verify `node_modules/@waibspace/*` symlinks point to workspace packages
- [ ] Confirm no errors from workspace dependency resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)