### PR TITLE
Configure shared TypeScript setup

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "bun --watch src/index.ts",
     "build": "bun build src/index.ts --outdir dist --target bun",
-    "start": "bun dist/index.js"
+    "start": "bun dist/index.js",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@waibspace/types": "workspace:*",

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/types" },
+    { "path": "../../packages/event-bus" },
+    { "path": "../../packages/orchestrator" },
+    { "path": "../../packages/agents" },
+    { "path": "../../packages/connectors" },
+    { "path": "../../packages/policy" },
+    { "path": "../../packages/memory" },
+    { "path": "../../packages/surfaces" },
+    { "path": "../../packages/model-provider" }
+  ]
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "bunx --bun vite",
     "build": "bunx --bun vite build",
-    "preview": "bunx --bun vite preview"
+    "preview": "bunx --bun vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@waibspace/types": "workspace:*",

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/types" },
+    { "path": "../../packages/ui-renderer-contract" }
+  ]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,140 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "waibspace",
+      "devDependencies": {
+        "bun-types": "^1.3.10",
+        "typescript": "^5.9.3",
+      },
+    },
+    "apps/backend": {
+      "name": "@waibspace/backend",
+      "version": "0.0.1",
+      "dependencies": {
+        "@waibspace/agents": "workspace:*",
+        "@waibspace/connectors": "workspace:*",
+        "@waibspace/event-bus": "workspace:*",
+        "@waibspace/memory": "workspace:*",
+        "@waibspace/model-provider": "workspace:*",
+        "@waibspace/orchestrator": "workspace:*",
+        "@waibspace/policy": "workspace:*",
+        "@waibspace/surfaces": "workspace:*",
+        "@waibspace/types": "workspace:*",
+      },
+    },
+    "apps/frontend": {
+      "name": "@waibspace/frontend",
+      "version": "0.0.1",
+      "dependencies": {
+        "@waibspace/types": "workspace:*",
+        "@waibspace/ui-renderer-contract": "workspace:*",
+      },
+    },
+    "packages/agents": {
+      "name": "@waibspace/agents",
+      "version": "0.0.1",
+      "dependencies": {
+        "@waibspace/event-bus": "workspace:*",
+        "@waibspace/model-provider": "workspace:*",
+        "@waibspace/types": "workspace:*",
+      },
+    },
+    "packages/connectors": {
+      "name": "@waibspace/connectors",
+      "version": "0.0.1",
+      "dependencies": {
+        "@waibspace/types": "workspace:*",
+      },
+    },
+    "packages/event-bus": {
+      "name": "@waibspace/event-bus",
+      "version": "0.0.1",
+      "dependencies": {
+        "@waibspace/types": "workspace:*",
+      },
+    },
+    "packages/memory": {
+      "name": "@waibspace/memory",
+      "version": "0.0.1",
+      "dependencies": {
+        "@waibspace/types": "workspace:*",
+      },
+    },
+    "packages/model-provider": {
+      "name": "@waibspace/model-provider",
+      "version": "0.0.1",
+      "dependencies": {
+        "@waibspace/types": "workspace:*",
+      },
+    },
+    "packages/orchestrator": {
+      "name": "@waibspace/orchestrator",
+      "version": "0.0.1",
+      "dependencies": {
+        "@waibspace/event-bus": "workspace:*",
+        "@waibspace/policy": "workspace:*",
+        "@waibspace/types": "workspace:*",
+      },
+    },
+    "packages/policy": {
+      "name": "@waibspace/policy",
+      "version": "0.0.1",
+      "dependencies": {
+        "@waibspace/types": "workspace:*",
+      },
+    },
+    "packages/surfaces": {
+      "name": "@waibspace/surfaces",
+      "version": "0.0.1",
+      "dependencies": {
+        "@waibspace/types": "workspace:*",
+        "@waibspace/ui-renderer-contract": "workspace:*",
+      },
+    },
+    "packages/types": {
+      "name": "@waibspace/types",
+      "version": "0.0.1",
+    },
+    "packages/ui-renderer-contract": {
+      "name": "@waibspace/ui-renderer-contract",
+      "version": "0.0.1",
+      "dependencies": {
+        "@waibspace/types": "workspace:*",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+
+    "@waibspace/agents": ["@waibspace/agents@workspace:packages/agents"],
+
+    "@waibspace/backend": ["@waibspace/backend@workspace:apps/backend"],
+
+    "@waibspace/connectors": ["@waibspace/connectors@workspace:packages/connectors"],
+
+    "@waibspace/event-bus": ["@waibspace/event-bus@workspace:packages/event-bus"],
+
+    "@waibspace/frontend": ["@waibspace/frontend@workspace:apps/frontend"],
+
+    "@waibspace/memory": ["@waibspace/memory@workspace:packages/memory"],
+
+    "@waibspace/model-provider": ["@waibspace/model-provider@workspace:packages/model-provider"],
+
+    "@waibspace/orchestrator": ["@waibspace/orchestrator@workspace:packages/orchestrator"],
+
+    "@waibspace/policy": ["@waibspace/policy@workspace:packages/policy"],
+
+    "@waibspace/surfaces": ["@waibspace/surfaces@workspace:packages/surfaces"],
+
+    "@waibspace/types": ["@waibspace/types@workspace:packages/types"],
+
+    "@waibspace/ui-renderer-contract": ["@waibspace/ui-renderer-contract@workspace:packages/ui-renderer-contract"],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,5 +9,9 @@
     "dev:backend": "bun --filter @waibspace/backend dev",
     "build": "bun --filter '*' build",
     "typecheck": "bun --filter '*' typecheck"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.10",
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -8,5 +8,8 @@
     "@waibspace/types": "workspace:*",
     "@waibspace/event-bus": "workspace:*",
     "@waibspace/model-provider": "workspace:*"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/agents/tsconfig.json
+++ b/packages/agents/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../types" },
+    { "path": "../event-bus" },
+    { "path": "../model-provider" }
+  ]
+}

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -6,5 +6,8 @@
   "types": "src/index.ts",
   "dependencies": {
     "@waibspace/types": "workspace:*"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/connectors/tsconfig.json
+++ b/packages/connectors/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../types" }
+  ]
+}

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -6,5 +6,8 @@
   "types": "src/index.ts",
   "dependencies": {
     "@waibspace/types": "workspace:*"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/event-bus/tsconfig.json
+++ b/packages/event-bus/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../types" }
+  ]
+}

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -6,5 +6,8 @@
   "types": "src/index.ts",
   "dependencies": {
     "@waibspace/types": "workspace:*"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/memory/tsconfig.json
+++ b/packages/memory/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../types" }
+  ]
+}

--- a/packages/model-provider/package.json
+++ b/packages/model-provider/package.json
@@ -6,5 +6,8 @@
   "types": "src/index.ts",
   "dependencies": {
     "@waibspace/types": "workspace:*"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/model-provider/tsconfig.json
+++ b/packages/model-provider/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../types" }
+  ]
+}

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -8,5 +8,8 @@
     "@waibspace/types": "workspace:*",
     "@waibspace/event-bus": "workspace:*",
     "@waibspace/policy": "workspace:*"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/orchestrator/tsconfig.json
+++ b/packages/orchestrator/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../types" },
+    { "path": "../event-bus" },
+    { "path": "../policy" }
+  ]
+}

--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -6,5 +6,8 @@
   "types": "src/index.ts",
   "dependencies": {
     "@waibspace/types": "workspace:*"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/policy/tsconfig.json
+++ b/packages/policy/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../types" }
+  ]
+}

--- a/packages/surfaces/package.json
+++ b/packages/surfaces/package.json
@@ -7,5 +7,8 @@
   "dependencies": {
     "@waibspace/types": "workspace:*",
     "@waibspace/ui-renderer-contract": "workspace:*"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/surfaces/tsconfig.json
+++ b/packages/surfaces/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../types" },
+    { "path": "../ui-renderer-contract" }
+  ]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.1",
   "type": "module",
   "main": "src/index.ts",
-  "types": "src/index.ts"
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/ui-renderer-contract/package.json
+++ b/packages/ui-renderer-contract/package.json
@@ -6,5 +6,8 @@
   "types": "src/index.ts",
   "dependencies": {
     "@waibspace/types": "workspace:*"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/ui-renderer-contract/tsconfig.json
+++ b/packages/ui-renderer-contract/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../types" }
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"],
+    "paths": {
+      "@waibspace/types": ["./packages/types/src/index.ts"],
+      "@waibspace/event-bus": ["./packages/event-bus/src/index.ts"],
+      "@waibspace/orchestrator": ["./packages/orchestrator/src/index.ts"],
+      "@waibspace/agents": ["./packages/agents/src/index.ts"],
+      "@waibspace/connectors": ["./packages/connectors/src/index.ts"],
+      "@waibspace/policy": ["./packages/policy/src/index.ts"],
+      "@waibspace/memory": ["./packages/memory/src/index.ts"],
+      "@waibspace/surfaces": ["./packages/surfaces/src/index.ts"],
+      "@waibspace/model-provider": ["./packages/model-provider/src/index.ts"],
+      "@waibspace/ui-renderer-contract": ["./packages/ui-renderer-contract/src/index.ts"]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,24 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "esModuleInterop": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "composite": true,
-    "outDir": "dist",
-    "rootDir": "src",
-    "types": ["bun-types"]
-  }
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "references": [
+    { "path": "packages/types" },
+    { "path": "packages/event-bus" },
+    { "path": "packages/orchestrator" },
+    { "path": "packages/agents" },
+    { "path": "packages/connectors" },
+    { "path": "packages/policy" },
+    { "path": "packages/memory" },
+    { "path": "packages/surfaces" },
+    { "path": "packages/model-provider" },
+    { "path": "packages/ui-renderer-contract" },
+    { "path": "apps/backend" },
+    { "path": "apps/frontend" }
+  ],
+  "include": []
 }


### PR DESCRIPTION
## Summary
- Created `tsconfig.base.json` with shared compiler options: `strict`, `ESNext` target/module, `bundler` moduleResolution, `declaration`/`declarationMap`/`sourceMap`, and `@waibspace/*` path aliases
- Updated root `tsconfig.json` to use TypeScript project references for all 12 packages
- Added per-package `tsconfig.json` in all packages/ and apps/ directories, each extending the base config with own `outDir: "./dist"`, `rootDir: "./src"`, `include: ["src"]`, and appropriate dependency references
- Added `typecheck` script (`tsc --noEmit`) to every package.json
- Installed `bun-types` and `typescript` as root devDependencies
- Verified `bun run typecheck` passes across all 12 packages

## Test plan
- [x] `bun run typecheck` passes for all packages from root
- [ ] Verify IDE resolution of `@waibspace/*` imports works correctly
- [ ] Confirm `bun build` still works for apps/backend

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)