### PR TITLE
Define core shared type schemas in packages/types

### DIFF
--- a/packages/types/src/agents.ts
+++ b/packages/types/src/agents.ts
@@ -1,0 +1,19 @@
+import type { ProvenanceMetadata } from "./provenance";
+
+export type AgentCategory =
+  | "perception"
+  | "reasoning"
+  | "context"
+  | "ui"
+  | "safety"
+  | "execution";
+
+export interface AgentOutput {
+  agentId: string;
+  agentType: string;
+  category: AgentCategory;
+  output: unknown;
+  confidence: number;
+  provenance: ProvenanceMetadata;
+  timing: { startMs: number; endMs: number; durationMs: number };
+}

--- a/packages/types/src/connectors.ts
+++ b/packages/types/src/connectors.ts
@@ -1,0 +1,9 @@
+import type { TrustLevel } from "./provenance";
+
+export interface ConnectorCapability {
+  connectorId: string;
+  connectorType: string;
+  actions: string[];
+  dataTypes: string[];
+  trustLevel: TrustLevel;
+}

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -1,0 +1,30 @@
+export type WaibEventType =
+  | "user.message.received"
+  | "user.voice.transcribed"
+  | "user.interaction.clicked"
+  | "user.interaction.dragged"
+  | "user.intent.url_received"
+  | "intent.inferred"
+  | "intent.ambiguous"
+  | "context.requested"
+  | "context.source.returned"
+  | "surface.proposed"
+  | "surface.composed"
+  | "policy.check.requested"
+  | "policy.check.result"
+  | "policy.approval.required"
+  | "policy.approval.response"
+  | "execution.requested"
+  | "execution.completed"
+  | "background.task.triggered"
+  | "memory.updated";
+
+export interface WaibEvent {
+  id: string;
+  type: WaibEventType;
+  timestamp: number;
+  source: string;
+  traceId: string;
+  payload: unknown;
+  metadata?: Record<string, unknown>;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,7 @@
-// packages/types
+export * from "./events";
+export * from "./surfaces";
+export * from "./agents";
+export * from "./policy";
+export * from "./provenance";
+export * from "./connectors";
+export * from "./memory";

--- a/packages/types/src/memory.ts
+++ b/packages/types/src/memory.ts
@@ -1,0 +1,16 @@
+export type MemoryCategory =
+  | "profile"
+  | "interaction"
+  | "task"
+  | "relationship"
+  | "system";
+
+export interface MemoryEntry {
+  id: string;
+  category: MemoryCategory;
+  key: string;
+  value: unknown;
+  createdAt: number;
+  updatedAt: number;
+  source: string;
+}

--- a/packages/types/src/policy.ts
+++ b/packages/types/src/policy.ts
@@ -1,0 +1,10 @@
+export type RiskClass = "A" | "B" | "C";
+export type PolicyVerdict = "approved" | "denied" | "approval_required";
+
+export interface PolicyDecision {
+  action: string;
+  riskClass: RiskClass;
+  verdict: PolicyVerdict;
+  reason: string;
+  requiredApproval?: { prompt: string; context: unknown };
+}

--- a/packages/types/src/provenance.ts
+++ b/packages/types/src/provenance.ts
@@ -1,0 +1,13 @@
+export type TrustLevel = "trusted" | "semi-trusted" | "untrusted";
+export type DataState = "raw" | "summarized" | "inferred" | "transformed";
+
+export interface ProvenanceMetadata {
+  sourceType: string;
+  sourceId: string;
+  trustLevel: TrustLevel;
+  timestamp: number;
+  freshness: "realtime" | "recent" | "stale" | "unknown";
+  dataState: DataState;
+  transformations?: string[];
+  relatedEventId?: string;
+}

--- a/packages/types/src/surfaces.ts
+++ b/packages/types/src/surfaces.ts
@@ -1,0 +1,35 @@
+import type { ProvenanceMetadata } from "./provenance";
+
+export interface SurfaceAction {
+  id: string;
+  label: string;
+  actionType: string;
+  riskClass: "A" | "B" | "C";
+  payload?: unknown;
+}
+
+export interface SurfaceAffordance {
+  interaction: string;
+  meaning: string;
+  surfaceTarget?: string;
+}
+
+export interface LayoutHints {
+  width?: "full" | "half" | "third" | "auto";
+  position?: "primary" | "secondary" | "sidebar" | "overlay";
+  prominence?: "hero" | "standard" | "compact" | "minimal";
+}
+
+export interface SurfaceSpec {
+  surfaceType: string;
+  surfaceId: string;
+  title: string;
+  summary?: string;
+  priority: number;
+  data: unknown;
+  actions: SurfaceAction[];
+  affordances: SurfaceAffordance[];
+  layoutHints: LayoutHints;
+  provenance: ProvenanceMetadata;
+  confidence: number;
+}


### PR DESCRIPTION
## Summary
- Add TypeScript type definitions for all core WaibSpace domain types: events, surfaces, agents, policy, provenance, connectors, and memory
- Each type category lives in its own file under `packages/types/src/` with a barrel export from `index.ts`
- Includes `WaibEventType` string literal union covering all 19 known event types
- All types pass `bun run typecheck`

Closes #3

## Test plan
- [x] `bun run typecheck` passes in `packages/types`
- [ ] Verify types are importable from `@waibspace/types` in downstream packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)