### PR TITLE
Implement packages/ui-renderer-contract

### DIFF
--- a/packages/ui-renderer-contract/src/index.ts
+++ b/packages/ui-renderer-contract/src/index.ts
@@ -1,1 +1,3 @@
-// packages/ui-renderer-contract
+export type { ComposedLayout, LayoutDirective, AgentStatus } from "./layout";
+export type { ServerMessage, ClientMessage } from "./messages";
+export { isValidServerMessage, isValidClientMessage } from "./validation";

--- a/packages/ui-renderer-contract/src/layout.ts
+++ b/packages/ui-renderer-contract/src/layout.ts
@@ -1,0 +1,20 @@
+import type { SurfaceSpec } from "@waibspace/types";
+
+export interface LayoutDirective {
+  surfaceId: string;
+  position: number;
+  width: string;
+  prominence: string;
+}
+
+export interface AgentStatus {
+  agentId: string;
+  state: "pending" | "running" | "complete" | "error";
+}
+
+export interface ComposedLayout {
+  surfaces: SurfaceSpec[];
+  layout: LayoutDirective[];
+  timestamp: number;
+  traceId: string;
+}

--- a/packages/ui-renderer-contract/src/messages.ts
+++ b/packages/ui-renderer-contract/src/messages.ts
@@ -1,0 +1,36 @@
+import type { SurfaceSpec } from "@waibspace/types";
+import type { ComposedLayout, AgentStatus } from "./layout";
+
+// Backend → Frontend messages
+export type ServerMessage =
+  | { type: "surface.update"; payload: ComposedLayout }
+  | {
+      type: "surface.partial";
+      payload: { surfaceId: string; spec: SurfaceSpec };
+    }
+  | {
+      type: "approval.request";
+      payload: { approvalId: string; surface: SurfaceSpec };
+    }
+  | { type: "status"; payload: { phase: string; agents: AgentStatus[] } }
+  | { type: "error"; payload: { message: string; code: string } };
+
+// Frontend → Backend messages
+export type ClientMessage =
+  | { type: "user.message"; payload: { text: string } }
+  | {
+      type: "user.interaction";
+      payload: {
+        interaction: string;
+        target: string;
+        surfaceId?: string;
+        surfaceType?: string;
+        context?: unknown;
+        timestamp: number;
+      };
+    }
+  | { type: "user.intent.url"; payload: { path: string; raw: string } }
+  | {
+      type: "approval.response";
+      payload: { approvalId: string; approved: boolean };
+    };

--- a/packages/ui-renderer-contract/src/validation.ts
+++ b/packages/ui-renderer-contract/src/validation.ts
@@ -1,0 +1,34 @@
+import type { ServerMessage, ClientMessage } from "./messages";
+
+const SERVER_MESSAGE_TYPES: ReadonlySet<string> = new Set([
+  "surface.update",
+  "surface.partial",
+  "approval.request",
+  "status",
+  "error",
+]);
+
+const CLIENT_MESSAGE_TYPES: ReadonlySet<string> = new Set([
+  "user.message",
+  "user.interaction",
+  "user.intent.url",
+  "approval.response",
+]);
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isValidServerMessage(msg: unknown): msg is ServerMessage {
+  if (!isObject(msg)) return false;
+  if (typeof msg.type !== "string") return false;
+  if (!("payload" in msg)) return false;
+  return SERVER_MESSAGE_TYPES.has(msg.type);
+}
+
+export function isValidClientMessage(msg: unknown): msg is ClientMessage {
+  if (!isObject(msg)) return false;
+  if (typeof msg.type !== "string") return false;
+  if (!("payload" in msg)) return false;
+  return CLIENT_MESSAGE_TYPES.has(msg.type);
+}


### PR DESCRIPTION
## Summary
- Define `ServerMessage` and `ClientMessage` discriminated union types for the WebSocket protocol between backend and frontend
- Add `ComposedLayout`, `LayoutDirective`, and `AgentStatus` interfaces for layout composition
- Implement `isValidServerMessage` and `isValidClientMessage` runtime validation guards
- Barrel export all types and utilities from package index

## Test plan
- [x] TypeScript compilation passes (`tsc -b` with project references)
- [ ] Verify types are importable from `@waibspace/ui-renderer-contract`
- [ ] Validate runtime guards correctly narrow message types

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)