### PR TITLE
Scaffold apps/backend with Bun HTTP + WebSocket

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -18,6 +18,7 @@
     "@waibspace/policy": "workspace:*",
     "@waibspace/memory": "workspace:*",
     "@waibspace/surfaces": "workspace:*",
-    "@waibspace/model-provider": "workspace:*"
+    "@waibspace/model-provider": "workspace:*",
+    "@waibspace/ui-renderer-contract": "workspace:*"
   }
 }

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,1 +1,25 @@
-// apps/backend
+import { EventBus } from "@waibspace/event-bus";
+import type { WaibEvent } from "@waibspace/types";
+import type { ServerMessage, ComposedLayout } from "@waibspace/ui-renderer-contract";
+import { startServer } from "./server";
+import { broadcast } from "./ws";
+
+// Initialize event bus
+const bus = new EventBus();
+
+// Subscribe to surface.composed events and broadcast to all WebSocket clients
+bus.on("surface.composed", (event: WaibEvent) => {
+  const message: ServerMessage = {
+    type: "surface.update",
+    payload: event.payload as ComposedLayout,
+  };
+  broadcast(message);
+});
+
+// Start HTTP/WebSocket server
+const server = startServer(bus);
+
+const PORT = Number(process.env.PORT) || 3001;
+console.log(`[backend] WaibSpace backend started`);
+console.log(`[backend] HTTP & WebSocket listening on port ${PORT}`);
+console.log(`[backend] Started at ${new Date().toISOString()}`);

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1,0 +1,65 @@
+import type { EventBus } from "@waibspace/event-bus";
+import {
+  createWebSocketHandlers,
+  type WebSocketData,
+} from "./ws";
+
+const PORT = Number(process.env.PORT) || 3001;
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "http://localhost:5173",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+  });
+}
+
+const startTime = Date.now();
+
+export function startServer(bus: EventBus) {
+  const wsHandlers = createWebSocketHandlers(bus);
+
+  const server = Bun.serve<WebSocketData>({
+    port: PORT,
+
+    fetch(req, server) {
+      const url = new URL(req.url);
+
+      // CORS preflight
+      if (req.method === "OPTIONS") {
+        return new Response(null, { status: 204, headers: CORS_HEADERS });
+      }
+
+      // WebSocket upgrade
+      if (url.pathname === "/ws") {
+        const upgraded = server.upgrade(req, {
+          data: {
+            connectionId: crypto.randomUUID(),
+            connectedAt: Date.now(),
+          },
+        });
+        if (upgraded) return undefined;
+        return jsonResponse({ error: "WebSocket upgrade failed" }, 400);
+      }
+
+      // Health check
+      if (url.pathname === "/health" && req.method === "GET") {
+        return jsonResponse({
+          status: "ok",
+          uptime: Date.now() - startTime,
+        });
+      }
+
+      return jsonResponse({ error: "Not found" }, 404);
+    },
+
+    websocket: wsHandlers,
+  });
+
+  return server;
+}

--- a/apps/backend/src/ws.ts
+++ b/apps/backend/src/ws.ts
@@ -1,0 +1,93 @@
+import type { ServerWebSocket } from "bun";
+import type { ServerMessage, ClientMessage } from "@waibspace/ui-renderer-contract";
+import { isValidClientMessage } from "@waibspace/ui-renderer-contract";
+import { EventBus, createEvent, createTraceId } from "@waibspace/event-bus";
+
+export interface WebSocketData {
+  connectionId: string;
+  connectedAt: number;
+}
+
+const clients = new Set<ServerWebSocket<WebSocketData>>();
+
+export function getClients(): Set<ServerWebSocket<WebSocketData>> {
+  return clients;
+}
+
+/**
+ * Broadcast a ServerMessage to all connected WebSocket clients.
+ */
+export function broadcast(message: ServerMessage): void {
+  const raw = JSON.stringify(message);
+  for (const ws of clients) {
+    ws.send(raw);
+  }
+}
+
+/**
+ * Create Bun WebSocket handlers wired to the given EventBus.
+ */
+export function createWebSocketHandlers(bus: EventBus) {
+  return {
+    open(ws: ServerWebSocket<WebSocketData>) {
+      clients.add(ws);
+      console.log(
+        `[ws] client connected: ${ws.data.connectionId} (total: ${clients.size})`,
+      );
+    },
+
+    message(ws: ServerWebSocket<WebSocketData>, message: string | Buffer) {
+      const raw = typeof message === "string" ? message : message.toString();
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        const errorMsg: ServerMessage = {
+          type: "error",
+          payload: { message: "Invalid JSON", code: "INVALID_JSON" },
+        };
+        ws.send(JSON.stringify(errorMsg));
+        return;
+      }
+
+      if (!isValidClientMessage(parsed)) {
+        const errorMsg: ServerMessage = {
+          type: "error",
+          payload: {
+            message: "Invalid client message format",
+            code: "INVALID_MESSAGE",
+          },
+        };
+        ws.send(JSON.stringify(errorMsg));
+        return;
+      }
+
+      const clientMsg = parsed as ClientMessage;
+      console.log(
+        `[ws] message from ${ws.data.connectionId}: ${clientMsg.type}`,
+      );
+
+      // Map client message type to WaibEvent type and emit
+      const event = createEvent(
+        clientMsg.type,
+        clientMsg.payload,
+        `ws:${ws.data.connectionId}`,
+        createTraceId(),
+      );
+      bus.emit(event);
+    },
+
+    close(ws: ServerWebSocket<WebSocketData>) {
+      clients.delete(ws);
+      console.log(
+        `[ws] client disconnected: ${ws.data.connectionId} (total: ${clients.size})`,
+      );
+    },
+
+    error(ws: ServerWebSocket<WebSocketData>, error: Error) {
+      console.error(`[ws] error for ${ws.data.connectionId}:`, error);
+      clients.delete(ws);
+    },
+  };
+}

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "../../packages/policy" },
     { "path": "../../packages/memory" },
     { "path": "../../packages/surfaces" },
-    { "path": "../../packages/model-provider" }
+    { "path": "../../packages/model-provider" },
+    { "path": "../../packages/ui-renderer-contract" }
   ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "@waibspace/policy": "workspace:*",
         "@waibspace/surfaces": "workspace:*",
         "@waibspace/types": "workspace:*",
+        "@waibspace/ui-renderer-contract": "workspace:*",
       },
     },
     "apps/frontend": {


### PR DESCRIPTION
## Summary
- Implement `server.ts` with Bun.serve() HTTP server: CORS headers for localhost:5173, `GET /health` endpoint, WebSocket upgrade on `/ws`
- Implement `ws.ts` with WebSocket connection lifecycle handlers, JSON message parsing/validation via `isValidClientMessage`, per-connection state tracking (connectionId via crypto.randomUUID()), broadcast capability, and event bus integration
- Wire up `index.ts` entry point: initializes EventBus, starts server, subscribes `surface.composed` events to broadcast to all connected clients
- Add `@waibspace/ui-renderer-contract` as a backend dependency

## Test plan
- [ ] `bun run typecheck` passes in `apps/backend`
- [ ] `bun run dev` starts the server on port 3001
- [ ] `GET /health` returns `{ status: "ok", uptime: <number> }`
- [ ] WebSocket connects on `ws://localhost:3001/ws`
- [ ] Invalid JSON sent over WebSocket returns error message
- [ ] Invalid message format returns error with code `INVALID_MESSAGE`
- [ ] Valid client messages are emitted to event bus

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)