### PR TITLE
Implement model provider abstraction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
       "name": "@waibspace/model-provider",
       "version": "0.0.1",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.78.0",
         "@waibspace/types": "workspace:*",
       },
     },
@@ -115,6 +116,8 @@
     },
   },
   "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
@@ -146,6 +149,8 @@
     "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
 
     "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
@@ -361,6 +366,8 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -406,6 +413,8 @@
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/packages/model-provider/package.json
+++ b/packages/model-provider/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
     "@waibspace/types": "workspace:*"
   },
   "scripts": {

--- a/packages/model-provider/src/anthropic-provider.ts
+++ b/packages/model-provider/src/anthropic-provider.ts
@@ -1,0 +1,62 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type {
+  ModelProvider,
+  CompletionRequest,
+  CompletionResponse,
+  StructuredCompletionRequest,
+} from "./types";
+
+export class AnthropicProvider implements ModelProvider {
+  id = "anthropic";
+  name = "Anthropic";
+  private client: Anthropic;
+
+  constructor(apiKey?: string) {
+    this.client = new Anthropic({
+      apiKey: apiKey || process.env.ANTHROPIC_API_KEY,
+    });
+  }
+
+  async complete(request: CompletionRequest): Promise<CompletionResponse> {
+    const response = await this.client.messages.create({
+      model: request.model,
+      max_tokens: request.maxTokens ?? 1024,
+      ...(request.system ? { system: request.system } : {}),
+      ...(request.temperature !== undefined
+        ? { temperature: request.temperature }
+        : {}),
+      messages: request.messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+      })),
+    });
+
+    const textContent = response.content.find((block) => block.type === "text");
+    const content = textContent?.type === "text" ? textContent.text : "";
+
+    return {
+      content,
+      model: response.model,
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+      },
+      stopReason: response.stop_reason ?? "unknown",
+    };
+  }
+
+  async completeStructured<T>(
+    request: StructuredCompletionRequest,
+  ): Promise<T> {
+    const schemaInstruction = `\n\nRespond ONLY with valid JSON matching this schema:\n${JSON.stringify(request.responseSchema, null, 2)}`;
+
+    const systemPrompt = (request.system ?? "") + schemaInstruction;
+
+    const response = await this.complete({
+      ...request,
+      system: systemPrompt,
+    });
+
+    return JSON.parse(response.content) as T;
+  }
+}

--- a/packages/model-provider/src/config.ts
+++ b/packages/model-provider/src/config.ts
@@ -1,0 +1,19 @@
+export interface ModelRoleConfig {
+  reasoning: { provider: string; model: string };
+  classification: { provider: string; model: string };
+  summarization: { provider: string; model: string };
+  uiGeneration: { provider: string; model: string };
+}
+
+export const DEFAULT_MODEL_CONFIG: ModelRoleConfig = {
+  reasoning: { provider: "anthropic", model: "claude-sonnet-4-6" },
+  classification: {
+    provider: "anthropic",
+    model: "claude-haiku-4-5-20251001",
+  },
+  summarization: {
+    provider: "anthropic",
+    model: "claude-haiku-4-5-20251001",
+  },
+  uiGeneration: { provider: "anthropic", model: "claude-sonnet-4-6" },
+};

--- a/packages/model-provider/src/index.ts
+++ b/packages/model-provider/src/index.ts
@@ -1,1 +1,12 @@
-// packages/model-provider
+export type {
+  ModelProvider,
+  CompletionRequest,
+  CompletionResponse,
+  StructuredCompletionRequest,
+  Message,
+} from "./types";
+export { AnthropicProvider } from "./anthropic-provider";
+export { OpenAIProvider } from "./openai-provider";
+export type { ModelRoleConfig } from "./config";
+export { DEFAULT_MODEL_CONFIG } from "./config";
+export { ModelProviderRegistry } from "./registry";

--- a/packages/model-provider/src/openai-provider.ts
+++ b/packages/model-provider/src/openai-provider.ts
@@ -1,0 +1,21 @@
+import type {
+  ModelProvider,
+  CompletionRequest,
+  CompletionResponse,
+  StructuredCompletionRequest,
+} from "./types";
+
+export class OpenAIProvider implements ModelProvider {
+  id = "openai";
+  name = "OpenAI";
+
+  async complete(_request: CompletionRequest): Promise<CompletionResponse> {
+    throw new Error("OpenAI provider not yet implemented");
+  }
+
+  async completeStructured<T>(
+    _request: StructuredCompletionRequest,
+  ): Promise<T> {
+    throw new Error("OpenAI provider not yet implemented");
+  }
+}

--- a/packages/model-provider/src/registry.ts
+++ b/packages/model-provider/src/registry.ts
@@ -1,0 +1,32 @@
+import type { ModelProvider } from "./types";
+import type { ModelRoleConfig } from "./config";
+import { DEFAULT_MODEL_CONFIG } from "./config";
+
+export class ModelProviderRegistry {
+  private providers = new Map<string, ModelProvider>();
+  private config: ModelRoleConfig;
+
+  constructor(config?: Partial<ModelRoleConfig>) {
+    this.config = { ...DEFAULT_MODEL_CONFIG, ...config };
+  }
+
+  register(provider: ModelProvider): void {
+    this.providers.set(provider.id, provider);
+  }
+
+  getProvider(id: string): ModelProvider {
+    const p = this.providers.get(id);
+    if (!p) throw new Error(`Provider '${id}' not registered`);
+    return p;
+  }
+
+  getForRole(
+    role: keyof ModelRoleConfig,
+  ): { provider: ModelProvider; model: string } {
+    const roleConfig = this.config[role];
+    return {
+      provider: this.getProvider(roleConfig.provider),
+      model: roleConfig.model,
+    };
+  }
+}

--- a/packages/model-provider/src/types.ts
+++ b/packages/model-provider/src/types.ts
@@ -1,0 +1,30 @@
+export interface ModelProvider {
+  id: string;
+  name: string;
+  complete(request: CompletionRequest): Promise<CompletionResponse>;
+  completeStructured<T>(request: StructuredCompletionRequest): Promise<T>;
+}
+
+export interface CompletionRequest {
+  model: string;
+  messages: Message[];
+  maxTokens?: number;
+  temperature?: number;
+  system?: string;
+}
+
+export interface StructuredCompletionRequest extends CompletionRequest {
+  responseSchema: Record<string, unknown>;
+}
+
+export interface CompletionResponse {
+  content: string;
+  model: string;
+  usage: { inputTokens: number; outputTokens: number };
+  stopReason: string;
+}
+
+export interface Message {
+  role: "user" | "assistant";
+  content: string;
+}


### PR DESCRIPTION
## Summary
- Add `ModelProvider` interface and related types (`CompletionRequest`, `CompletionResponse`, `StructuredCompletionRequest`, `Message`)
- Implement `AnthropicProvider` using `@anthropic-ai/sdk` with `complete()` and `completeStructured()` methods
- Add `OpenAIProvider` stub that throws "not yet implemented"
- Define `ModelRoleConfig` with defaults mapping roles (reasoning, classification, summarization, uiGeneration) to Anthropic models
- Implement `ModelProviderRegistry` for registering providers and resolving them by role

Closes #14

## Test plan
- [x] TypeScript typecheck passes (`bun run typecheck`)
- [ ] Integration test with live Anthropic API key
- [ ] Verify registry role resolution returns correct provider/model pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)