### PR TITLE
Implement agent base framework

### DIFF
--- a/packages/agents/src/base-agent.ts
+++ b/packages/agents/src/base-agent.ts
@@ -1,0 +1,58 @@
+import type {
+  AgentCategory,
+  AgentOutput,
+  ProvenanceMetadata,
+} from "@waibspace/types";
+import type { Agent, AgentInput, AgentContext } from "./types";
+
+export abstract class BaseAgent implements Agent {
+  readonly id: string;
+  readonly name: string;
+  readonly type: string;
+  readonly category: AgentCategory;
+
+  constructor(config: {
+    id: string;
+    name: string;
+    type: string;
+    category: AgentCategory;
+  }) {
+    this.id = config.id;
+    this.name = config.name;
+    this.type = config.type;
+    this.category = config.category;
+  }
+
+  abstract execute(
+    input: AgentInput,
+    context: AgentContext,
+  ): Promise<AgentOutput>;
+
+  protected createOutput(
+    output: unknown,
+    confidence: number,
+    provenance?: Partial<ProvenanceMetadata>,
+  ): AgentOutput {
+    return {
+      agentId: this.id,
+      agentType: this.type,
+      category: this.category,
+      output,
+      confidence,
+      provenance: {
+        sourceType: "agent",
+        sourceId: this.id,
+        trustLevel: "trusted",
+        timestamp: Date.now(),
+        freshness: "realtime",
+        dataState: "transformed",
+        ...provenance,
+      },
+      timing: { startMs: 0, endMs: 0, durationMs: 0 },
+    };
+  }
+
+  protected log(message: string, data?: unknown): void {
+    console.log(`[${this.category}:${this.name}] ${message}`, data ?? "");
+  }
+}

--- a/packages/agents/src/categories.ts
+++ b/packages/agents/src/categories.ts
@@ -1,0 +1,8 @@
+export const AGENT_CATEGORIES = {
+  perception: "Normalize input signals into structured events",
+  reasoning: "Interpret what the user is trying to do",
+  context: "Determine what data is needed and retrieve it",
+  ui: "Propose surface specifications",
+  safety: "Evaluate policy and trust",
+  execution: "Carry out approved actions",
+} as const;

--- a/packages/agents/src/execution-harness.ts
+++ b/packages/agents/src/execution-harness.ts
@@ -1,0 +1,72 @@
+import type { AgentOutput } from "@waibspace/types";
+import type { Agent, AgentInput, AgentContext } from "./types";
+
+export interface ExecutionOptions {
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export async function executeAgent(
+  agent: Agent,
+  input: AgentInput,
+  context: AgentContext,
+  options?: ExecutionOptions,
+): Promise<AgentOutput> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const startMs = Date.now();
+
+  try {
+    const result = await Promise.race<AgentOutput>([
+      agent.execute(input, context),
+      new Promise<AgentOutput>((_, reject) =>
+        setTimeout(() => reject(new Error("Agent execution timed out")), timeoutMs),
+      ),
+    ]);
+
+    const endMs = Date.now();
+
+    return {
+      ...result,
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+      provenance: {
+        ...result.provenance,
+        sourceType: "agent",
+        sourceId: agent.id,
+      },
+    };
+  } catch (error) {
+    const endMs = Date.now();
+    const message =
+      error instanceof Error ? error.message : "Unknown error during agent execution";
+
+    console.error(
+      `[executeAgent] Agent ${agent.id} (${agent.category}:${agent.name}) failed: ${message}`,
+    );
+
+    return {
+      agentId: agent.id,
+      agentType: agent.type,
+      category: agent.category,
+      output: { error: message },
+      confidence: 0,
+      provenance: {
+        sourceType: "agent",
+        sourceId: agent.id,
+        trustLevel: "untrusted",
+        timestamp: startMs,
+        freshness: "realtime",
+        dataState: "raw",
+      },
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1,1 +1,4 @@
-// packages/agents
+export { type Agent, type AgentInput, type AgentContext } from "./types";
+export { BaseAgent } from "./base-agent";
+export { executeAgent, type ExecutionOptions } from "./execution-harness";
+export { AGENT_CATEGORIES } from "./categories";

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -1,0 +1,25 @@
+import type {
+  WaibEvent,
+  AgentOutput,
+  AgentCategory,
+  MemoryEntry,
+} from "@waibspace/types";
+
+export interface Agent {
+  id: string;
+  name: string;
+  type: string;
+  category: AgentCategory;
+  execute(input: AgentInput, context: AgentContext): Promise<AgentOutput>;
+}
+
+export interface AgentInput {
+  event: WaibEvent;
+  priorOutputs: AgentOutput[];
+}
+
+export interface AgentContext {
+  traceId: string;
+  memory?: MemoryEntry[];
+  config?: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- Add `Agent`, `AgentInput`, and `AgentContext` interfaces in `types.ts`
- Implement `BaseAgent` abstract class with `createOutput` helper and structured logging
- Implement `executeAgent` harness with configurable timeout (default 10s), error handling, and timing/provenance attachment
- Export `AGENT_CATEGORIES` constant mapping each category to its role description
- Barrel export all public API from `index.ts`

Closes #9

## Test plan
- [ ] Verify `bun run typecheck` passes in `packages/agents`
- [ ] Subclass `BaseAgent`, call `executeAgent`, and confirm timing fields are populated
- [ ] Trigger timeout by creating a slow agent and setting `timeoutMs: 50`; verify error output with confidence 0
- [ ] Throw inside `execute()` and verify error is caught and returned as an `AgentOutput`

🤖 Generated with [Claude Code](https://claude.com/claude-code)