### PR TITLE
feat: implement MVP perception agents

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -2,3 +2,9 @@ export { type Agent, type AgentInput, type AgentContext } from "./types";
 export { BaseAgent } from "./base-agent";
 export { executeAgent, type ExecutionOptions } from "./execution-harness";
 export { AGENT_CATEGORIES } from "./categories";
+export {
+  InputNormalizerAgent,
+  type NormalizedInput,
+  URLIntentParserAgent,
+  type URLIntentParsed,
+} from "./perception";

--- a/packages/agents/src/perception/index.ts
+++ b/packages/agents/src/perception/index.ts
@@ -1,0 +1,2 @@
+export { InputNormalizerAgent, type NormalizedInput } from "./input-normalizer";
+export { URLIntentParserAgent, type URLIntentParsed } from "./url-intent-parser";

--- a/packages/agents/src/perception/input-normalizer.ts
+++ b/packages/agents/src/perception/input-normalizer.ts
@@ -1,0 +1,111 @@
+import type { AgentOutput } from "@waibspace/types";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+
+export interface NormalizedInput {
+  inputType: "text" | "interaction" | "url_intent" | "voice";
+  normalizedContent: string;
+  rawInput: unknown;
+  inputMetadata: Record<string, unknown>;
+}
+
+export class InputNormalizerAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "perception.input-normalizer",
+      name: "InputNormalizer",
+      type: "input-normalizer",
+      category: "perception",
+    });
+  }
+
+  async execute(input: AgentInput, _context: AgentContext): Promise<AgentOutput> {
+    const { event } = input;
+    const payload = event.payload as Record<string, unknown> | undefined;
+    const startMs = Date.now();
+
+    const normalized = this.normalize(event.type, payload);
+
+    this.log("Normalized input", { inputType: normalized.inputType });
+
+    return this.createOutput(normalized, 1.0, {
+      relatedEventId: event.id,
+      dataState: "transformed",
+      transformations: ["input-normalization"],
+      timestamp: startMs,
+    });
+  }
+
+  private normalize(
+    eventType: string,
+    payload: Record<string, unknown> | undefined,
+  ): NormalizedInput {
+    if (eventType === "user.message.received") {
+      const text = typeof payload?.text === "string" ? payload.text : "";
+      return {
+        inputType: "text",
+        normalizedContent: text,
+        rawInput: payload,
+        inputMetadata: { originalEventType: eventType },
+      };
+    }
+
+    if (eventType.startsWith("user.interaction.")) {
+      const action = eventType.replace("user.interaction.", "");
+      const target = typeof payload?.target === "string" ? payload.target : "unknown";
+      return {
+        inputType: "interaction",
+        normalizedContent: `${action} on ${target}`,
+        rawInput: payload,
+        inputMetadata: { action, target, originalEventType: eventType },
+      };
+    }
+
+    if (eventType === "user.intent.url_received") {
+      const path = typeof payload?.path === "string" ? payload.path : "";
+      return {
+        inputType: "url_intent",
+        normalizedContent: path,
+        rawInput: payload,
+        inputMetadata: { originalEventType: eventType },
+      };
+    }
+
+    if (eventType === "user.voice.transcribed") {
+      const transcript = typeof payload?.text === "string" ? payload.text : "";
+      return {
+        inputType: "voice",
+        normalizedContent: transcript,
+        rawInput: payload,
+        inputMetadata: { originalEventType: eventType },
+      };
+    }
+
+    // Default: best-effort text extraction
+    const content = this.extractBestEffort(payload);
+    return {
+      inputType: "text",
+      normalizedContent: content,
+      rawInput: payload,
+      inputMetadata: { originalEventType: eventType, fallback: true },
+    };
+  }
+
+  private extractBestEffort(payload: Record<string, unknown> | undefined): string {
+    if (!payload) return "";
+
+    // Try common field names
+    for (const key of ["text", "message", "content", "body", "query", "input"]) {
+      if (typeof payload[key] === "string") {
+        return payload[key] as string;
+      }
+    }
+
+    // Last resort: stringify
+    try {
+      return JSON.stringify(payload);
+    } catch {
+      return "";
+    }
+  }
+}

--- a/packages/agents/src/perception/url-intent-parser.ts
+++ b/packages/agents/src/perception/url-intent-parser.ts
@@ -1,0 +1,122 @@
+import type { AgentOutput } from "@waibspace/types";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+
+export interface URLIntentParsed {
+  host: string | null;
+  pathSegments: string[];
+  intentQuery: string;
+  hasExternalTarget: boolean;
+}
+
+export class URLIntentParserAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "perception.url-intent-parser",
+      name: "URLIntentParser",
+      type: "url-intent-parser",
+      category: "perception",
+    });
+  }
+
+  async execute(input: AgentInput, _context: AgentContext): Promise<AgentOutput> {
+    const { event } = input;
+    const payload = event.payload as Record<string, unknown> | undefined;
+    const startMs = Date.now();
+
+    const rawContent = this.extractContent(input);
+    const parsed = this.parse(rawContent);
+
+    this.log("Parsed URL intent", {
+      host: parsed.host,
+      hasExternalTarget: parsed.hasExternalTarget,
+      segments: parsed.pathSegments.length,
+    });
+
+    return this.createOutput(parsed, parsed.host ? 0.9 : 0.7, {
+      relatedEventId: event.id,
+      dataState: "transformed",
+      transformations: ["url-intent-parsing"],
+      timestamp: startMs,
+    });
+  }
+
+  private extractContent(input: AgentInput): string {
+    const payload = input.event.payload as Record<string, unknown> | undefined;
+
+    // Try to use normalized content from a prior InputNormalizerAgent output
+    for (const prior of input.priorOutputs) {
+      const out = prior.output as Record<string, unknown> | undefined;
+      if (out && typeof out.normalizedContent === "string") {
+        return out.normalizedContent;
+      }
+    }
+
+    // Fall back to payload fields
+    if (payload) {
+      if (typeof payload.path === "string") return payload.path;
+      if (typeof payload.url === "string") return payload.url;
+      if (typeof payload.text === "string") return payload.text;
+    }
+
+    return "";
+  }
+
+  private parse(raw: string): URLIntentParsed {
+    if (!raw || !raw.trim()) {
+      return { host: null, pathSegments: [], intentQuery: "", hasExternalTarget: false };
+    }
+
+    const trimmed = raw.trim();
+
+    // Strip protocol if present
+    let withoutProtocol = trimmed;
+    const protocolMatch = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.exec(trimmed);
+    if (protocolMatch) {
+      withoutProtocol = trimmed.slice(protocolMatch[0].length);
+    }
+
+    // Try to detect host vs bare path
+    let host: string | null = null;
+    let pathPart = withoutProtocol;
+
+    // A hostname has dots and the first segment looks like a domain (no spaces, has a dot)
+    const slashIndex = withoutProtocol.indexOf("/");
+    const possibleHost = slashIndex >= 0 ? withoutProtocol.slice(0, slashIndex) : withoutProtocol;
+
+    if (this.looksLikeHostname(possibleHost)) {
+      host = possibleHost.toLowerCase();
+      pathPart = slashIndex >= 0 ? withoutProtocol.slice(slashIndex) : "";
+    }
+
+    // Strip query string and fragment
+    pathPart = pathPart.split("?")[0].split("#")[0];
+
+    // Split path into segments, splitting on / and -
+    const pathSegments = pathPart
+      .split(/[/\-]/)
+      .map((s) => decodeURIComponent(s).trim())
+      .filter(Boolean);
+
+    // Build human-readable intent query from segments
+    const intentQuery = pathSegments.join(" ");
+
+    return {
+      host,
+      pathSegments,
+      intentQuery,
+      hasExternalTarget: host !== null,
+    };
+  }
+
+  private looksLikeHostname(value: string): boolean {
+    if (!value || value.includes(" ")) return false;
+    // Must contain at least one dot and no spaces
+    if (!value.includes(".")) return false;
+    // Basic domain-like pattern: segments separated by dots, optional port
+    const withoutPort = value.split(":")[0];
+    return /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)+$/.test(
+      withoutPort,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- **InputNormalizerAgent**: Classifies raw `WaibEvent`s by type (`text`, `interaction`, `url_intent`, `voice`) and produces a unified `NormalizedInput` shape. Pure structural logic, no LLM call.
- **URLIntentParserAgent**: Parses URL-like strings into `host`, `pathSegments`, `intentQuery`, and `hasExternalTarget` via regex/string parsing. Handles full URLs, bare paths, empty input, and special characters.
- Barrel export from `packages/agents/src/perception/index.ts` and re-exported from the package root.

Closes #11

## Test plan
- [ ] Verify typecheck passes (`tsc --build packages/agents/tsconfig.json`)
- [ ] Unit test InputNormalizerAgent with each event type and fallback case
- [ ] Unit test URLIntentParserAgent with full URLs, bare paths, empty strings, and special characters
- [ ] Integration test: chain InputNormalizer output into URLIntentParser via `priorOutputs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)