### PR TITLE
feat: model role config enhancement + agent framework integration

### DIFF
--- a/packages/agents/src/base-agent.ts
+++ b/packages/agents/src/base-agent.ts
@@ -3,6 +3,11 @@ import type {
   AgentOutput,
   ProvenanceMetadata,
 } from "@waibspace/types";
+import type {
+  Message,
+  CompletionResponse,
+  ModelRoleConfig,
+} from "@waibspace/model-provider";
 import type { Agent, AgentInput, AgentContext } from "./types";
 
 export abstract class BaseAgent implements Agent {
@@ -50,6 +55,44 @@ export abstract class BaseAgent implements Agent {
       },
       timing: { startMs: 0, endMs: 0, durationMs: 0 },
     };
+  }
+
+  /**
+   * Send a completion request using the model provider configured for a given role.
+   * Requires `context.modelProvider` to be set.
+   */
+  protected async complete(
+    context: AgentContext,
+    role: keyof ModelRoleConfig,
+    messages: Message[],
+    system?: string,
+  ): Promise<CompletionResponse> {
+    if (!context.modelProvider)
+      throw new Error("No model provider in context");
+    const { provider, model } = context.modelProvider.getForRole(role);
+    return provider.complete({ model, messages, system });
+  }
+
+  /**
+   * Send a structured completion request that returns a typed response.
+   * Requires `context.modelProvider` to be set.
+   */
+  protected async completeStructured<T>(
+    context: AgentContext,
+    role: keyof ModelRoleConfig,
+    messages: Message[],
+    responseSchema: Record<string, unknown>,
+    system?: string,
+  ): Promise<T> {
+    if (!context.modelProvider)
+      throw new Error("No model provider in context");
+    const { provider, model } = context.modelProvider.getForRole(role);
+    return provider.completeStructured<T>({
+      model,
+      messages,
+      responseSchema,
+      system,
+    });
   }
 
   protected log(message: string, data?: unknown): void {

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -4,6 +4,7 @@ import type {
   AgentCategory,
   MemoryEntry,
 } from "@waibspace/types";
+import type { ModelProviderRegistry } from "@waibspace/model-provider";
 
 export interface Agent {
   id: string;
@@ -22,4 +23,6 @@ export interface AgentContext {
   traceId: string;
   memory?: MemoryEntry[];
   config?: Record<string, unknown>;
+  /** Optional model provider registry for agents that need LLM access */
+  modelProvider?: ModelProviderRegistry;
 }

--- a/packages/model-provider/src/config.ts
+++ b/packages/model-provider/src/config.ts
@@ -1,7 +1,11 @@
 export interface ModelRoleConfig {
+  /** Used by reasoning/planning agents (e.g., PlannerAgent, ReasoningAgent) */
   reasoning: { provider: string; model: string };
+  /** Used by classification/routing agents (e.g., IntentClassifier, CategoryAgent) */
   classification: { provider: string; model: string };
+  /** Used by summarization agents (e.g., SummaryAgent, DigestAgent) */
   summarization: { provider: string; model: string };
+  /** Used by UI generation agents (e.g., UIComposerAgent, LayoutAgent) */
   uiGeneration: { provider: string; model: string };
 }
 
@@ -17,3 +21,64 @@ export const DEFAULT_MODEL_CONFIG: ModelRoleConfig = {
   },
   uiGeneration: { provider: "anthropic", model: "claude-sonnet-4-6" },
 };
+
+/**
+ * Environment variable names for overriding model config.
+ * Format: WAIBSPACE_MODEL_{ROLE} for model, WAIBSPACE_PROVIDER_{ROLE} for provider.
+ *
+ * Examples:
+ *   WAIBSPACE_MODEL_REASONING=claude-sonnet-4-6
+ *   WAIBSPACE_PROVIDER_REASONING=anthropic
+ *   WAIBSPACE_MODEL_CLASSIFICATION=claude-haiku-4-5-20251001
+ *   WAIBSPACE_MODEL_UI_GENERATION=claude-sonnet-4-6
+ */
+const ENV_ROLE_MAP: Record<keyof ModelRoleConfig, string> = {
+  reasoning: "REASONING",
+  classification: "CLASSIFICATION",
+  summarization: "SUMMARIZATION",
+  uiGeneration: "UI_GENERATION",
+};
+
+/**
+ * Creates a ModelRoleConfig by merging defaults with environment variable
+ * overrides and any explicit overrides passed in.
+ *
+ * Environment variables checked (per role):
+ *   - WAIBSPACE_MODEL_{ROLE} — overrides the model name
+ *   - WAIBSPACE_PROVIDER_{ROLE} — overrides the provider id
+ *
+ * @param overrides - Explicit overrides that take precedence over env vars
+ * @returns A fully resolved ModelRoleConfig
+ */
+export function createModelConfig(
+  overrides?: Partial<ModelRoleConfig>,
+): ModelRoleConfig {
+  const config = { ...DEFAULT_MODEL_CONFIG };
+
+  for (const [role, envSuffix] of Object.entries(ENV_ROLE_MAP) as Array<
+    [keyof ModelRoleConfig, string]
+  >) {
+    const envModel = process.env[`WAIBSPACE_MODEL_${envSuffix}`];
+    const envProvider = process.env[`WAIBSPACE_PROVIDER_${envSuffix}`];
+
+    if (envModel || envProvider) {
+      config[role] = {
+        provider: envProvider ?? config[role].provider,
+        model: envModel ?? config[role].model,
+      };
+    }
+  }
+
+  // Explicit overrides take highest precedence
+  if (overrides) {
+    for (const [role, value] of Object.entries(overrides) as Array<
+      [keyof ModelRoleConfig, { provider: string; model: string }]
+    >) {
+      if (value) {
+        config[role] = { ...config[role], ...value };
+      }
+    }
+  }
+
+  return config;
+}

--- a/packages/model-provider/src/index.ts
+++ b/packages/model-provider/src/index.ts
@@ -8,5 +8,5 @@ export type {
 export { AnthropicProvider } from "./anthropic-provider";
 export { OpenAIProvider } from "./openai-provider";
 export type { ModelRoleConfig } from "./config";
-export { DEFAULT_MODEL_CONFIG } from "./config";
+export { DEFAULT_MODEL_CONFIG, createModelConfig } from "./config";
 export { ModelProviderRegistry } from "./registry";


### PR DESCRIPTION
## Summary
- **P2-2**: Enhanced `DEFAULT_MODEL_CONFIG` with `createModelConfig()` function that merges defaults with `WAIBSPACE_MODEL_*` / `WAIBSPACE_PROVIDER_*` environment variable overrides. Added doc comments mapping roles to agent types.
- **P2-3**: Added optional `modelProvider` field to `AgentContext` and `complete()` / `completeStructured()` helper methods to `BaseAgent` for convenient role-based LLM access. Model provider remains optional so perception agents still work without it.

## Test plan
- [ ] Verify `createModelConfig()` returns defaults when no env vars are set
- [ ] Verify `createModelConfig()` picks up `WAIBSPACE_MODEL_REASONING` env override
- [ ] Verify `BaseAgent.complete()` throws when `modelProvider` is not in context
- [ ] Verify `BaseAgent.complete()` delegates to correct provider/model for a given role
- [ ] Verify agents without `modelProvider` in context still instantiate and run

Closes #15, Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)