### PR TITLE
Implement MVP reasoning agents

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -8,3 +8,9 @@ export {
   URLIntentParserAgent,
   type URLIntentParsed,
 } from "./perception";
+export {
+  IntentAgent,
+  type IntentClassification,
+  ConfidenceScorerAgent,
+  type ConfidenceAdjustment,
+} from "./reasoning";

--- a/packages/agents/src/reasoning/confidence-scorer.ts
+++ b/packages/agents/src/reasoning/confidence-scorer.ts
@@ -1,0 +1,166 @@
+import type { AgentOutput } from "@waibspace/types";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+import type { IntentClassification } from "./intent-agent";
+
+export interface ConfidenceAdjustment {
+  originalConfidence: number;
+  adjustedConfidence: number;
+  adjustmentReason: string;
+}
+
+const KNOWN_CATEGORIES = new Set([
+  "email",
+  "calendar",
+  "discovery",
+  "task",
+  "general",
+]);
+
+export class ConfidenceScorerAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "reasoning.confidence-scorer",
+      name: "ConfidenceScorer",
+      type: "confidence-scorer",
+      category: "reasoning",
+    });
+  }
+
+  async execute(
+    input: AgentInput,
+    _context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+
+    const intentOutput = this.findIntentClassification(input);
+
+    if (!intentOutput) {
+      this.log("No intent classification found in prior outputs");
+      const adjustment: ConfidenceAdjustment = {
+        originalConfidence: 0,
+        adjustedConfidence: 0,
+        adjustmentReason: "No intent classification available",
+      };
+      return this.createOutput(adjustment, 0, {
+        dataState: "transformed",
+        transformations: ["confidence-adjustment"],
+        timestamp: startMs,
+      });
+    }
+
+    const { classification, normalizedContent } = intentOutput;
+    const adjustment = this.adjustConfidence(classification, normalizedContent);
+
+    this.log("Adjusted confidence", adjustment);
+
+    const endMs = Date.now();
+
+    return {
+      ...this.createOutput(adjustment, adjustment.adjustedConfidence, {
+        dataState: "transformed",
+        transformations: ["confidence-adjustment"],
+        timestamp: startMs,
+      }),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+
+  private findIntentClassification(input: AgentInput): {
+    classification: IntentClassification;
+    normalizedContent: string;
+  } | undefined {
+    let classification: IntentClassification | undefined;
+    let normalizedContent = "";
+
+    for (const prior of input.priorOutputs) {
+      // Find intent classification
+      if (
+        prior.category === "reasoning" &&
+        prior.agentType === "intent-classifier" &&
+        prior.output
+      ) {
+        classification = prior.output as IntentClassification;
+      }
+
+      // Find normalized content for word count
+      if (prior.category === "perception" && prior.output) {
+        const output = prior.output as Record<string, unknown>;
+        if ("normalizedContent" in output) {
+          normalizedContent = output["normalizedContent"] as string;
+        }
+      }
+    }
+
+    if (!classification) return undefined;
+    return { classification, normalizedContent };
+  }
+
+  private adjustConfidence(
+    classification: IntentClassification,
+    normalizedContent: string,
+  ): ConfidenceAdjustment {
+    let adjusted = classification.confidence;
+    const reasons: string[] = [];
+
+    // Has specific entities extracted? +0.1
+    const entityCount = Object.keys(classification.entities).length;
+    if (entityCount > 0) {
+      adjusted += 0.1;
+      reasons.push(`+0.1: ${entityCount} entities extracted`);
+    }
+
+    // Intent category is one of known categories? +0.1
+    if (KNOWN_CATEGORIES.has(classification.intentCategory)) {
+      adjusted += 0.1;
+      reasons.push(
+        `+0.1: known category "${classification.intentCategory}"`,
+      );
+    }
+
+    // Input was very short (< 3 words)? -0.1
+    const wordCount = normalizedContent.trim().split(/\s+/).filter(Boolean).length;
+    if (wordCount < 3) {
+      adjusted -= 0.1;
+      reasons.push(`-0.1: short input (${wordCount} words)`);
+    }
+
+    // Multiple possible interpretations mentioned in reasoning? -0.15
+    const reasoningLower = classification.reasoning.toLowerCase();
+    if (
+      reasoningLower.includes("could also") ||
+      reasoningLower.includes("might also") ||
+      reasoningLower.includes("ambiguous") ||
+      reasoningLower.includes("multiple") ||
+      reasoningLower.includes("unclear")
+    ) {
+      adjusted -= 0.15;
+      reasons.push("-0.15: reasoning indicates ambiguity");
+    }
+
+    // Cap high confidence at 0.95
+    if (adjusted > 0.95) {
+      adjusted = 0.95;
+      reasons.push("capped at 0.95");
+    }
+
+    // Floor at 0
+    if (adjusted < 0) {
+      adjusted = 0;
+      reasons.push("floored at 0");
+    }
+
+    // Round to avoid floating point issues
+    adjusted = Math.round(adjusted * 100) / 100;
+
+    return {
+      originalConfidence: classification.confidence,
+      adjustedConfidence: adjusted,
+      adjustmentReason: reasons.join("; "),
+    };
+  }
+}

--- a/packages/agents/src/reasoning/index.ts
+++ b/packages/agents/src/reasoning/index.ts
@@ -1,0 +1,5 @@
+export { IntentAgent, type IntentClassification } from "./intent-agent";
+export {
+  ConfidenceScorerAgent,
+  type ConfidenceAdjustment,
+} from "./confidence-scorer";

--- a/packages/agents/src/reasoning/intent-agent.ts
+++ b/packages/agents/src/reasoning/intent-agent.ts
@@ -1,0 +1,126 @@
+import type { AgentOutput } from "@waibspace/types";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+import type { NormalizedInput } from "../perception/input-normalizer";
+
+export interface IntentClassification {
+  primaryIntent: string;
+  intentCategory: string;
+  entities: Record<string, string>;
+  suggestedAgents: string[];
+  confidence: number;
+  reasoning: string;
+}
+
+const SYSTEM_PROMPT = `You are an intent classifier for WaibSpace, an AI-powered personal assistant.
+
+Analyze the user's input and classify their intent. WaibSpace supports the following capabilities:
+
+- **Email management**: check inbox, summarize emails, reply to emails, search emails
+- **Calendar management**: view upcoming events, check availability, schedule meetings
+- **Discovery**: find information, movies, restaurants, services, recommendations
+- **Task management**: create tasks, list tasks, complete/update tasks
+
+For each input, determine:
+1. The primary intent (e.g., "check_email", "find_movie", "schedule_meeting", "create_task")
+2. The intent category (one of: "email", "calendar", "discovery", "task", "general")
+3. Any entities mentioned (e.g., genre, date, time, person, subject)
+4. Which downstream agents should handle this (e.g., "context.email", "context.calendar", "ui.discovery")
+5. Your confidence level (0-1)
+6. A brief reasoning explanation
+
+Respond with a JSON object matching the IntentClassification schema.`;
+
+const INTENT_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    primaryIntent: { type: "string" },
+    intentCategory: { type: "string" },
+    entities: {
+      type: "object",
+      additionalProperties: { type: "string" },
+    },
+    suggestedAgents: {
+      type: "array",
+      items: { type: "string" },
+    },
+    confidence: { type: "number", minimum: 0, maximum: 1 },
+    reasoning: { type: "string" },
+  },
+  required: [
+    "primaryIntent",
+    "intentCategory",
+    "entities",
+    "suggestedAgents",
+    "confidence",
+    "reasoning",
+  ],
+};
+
+export class IntentAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "reasoning.intent",
+      name: "IntentAgent",
+      type: "intent-classifier",
+      category: "reasoning",
+    });
+  }
+
+  async execute(
+    input: AgentInput,
+    context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+
+    const normalizedInput = this.findNormalizedInput(input);
+    const userContent = normalizedInput
+      ? normalizedInput.normalizedContent
+      : this.fallbackContent(input);
+
+    this.log("Classifying intent", { content: userContent });
+
+    const classification = await this.completeStructured<IntentClassification>(
+      context,
+      "classification",
+      [{ role: "user", content: userContent }],
+      INTENT_SCHEMA,
+      SYSTEM_PROMPT,
+    );
+
+    const endMs = Date.now();
+
+    return {
+      ...this.createOutput(classification, classification.confidence, {
+        dataState: "transformed",
+        transformations: ["intent-classification"],
+        timestamp: startMs,
+      }),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+
+  private findNormalizedInput(input: AgentInput): NormalizedInput | undefined {
+    for (const prior of input.priorOutputs) {
+      if (prior.category === "perception" && prior.output) {
+        const output = prior.output as Record<string, unknown>;
+        if ("normalizedContent" in output && "inputType" in output) {
+          return output as unknown as NormalizedInput;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private fallbackContent(input: AgentInput): string {
+    const payload = input.event.payload as Record<string, unknown> | undefined;
+    if (payload && typeof payload["text"] === "string") {
+      return payload["text"];
+    }
+    return JSON.stringify(input.event.payload ?? "");
+  }
+}


### PR DESCRIPTION
## Summary
- Add `IntentAgent` that uses LLM (`completeStructured()` with "classification" role) to classify user intent into categories (email, calendar, discovery, task, general), extract entities, and suggest downstream agents
- Add `ConfidenceScorerAgent` that applies rule-based adjustments to intent confidence scores (entity presence, category clarity, input length, reasoning ambiguity)
- Export both agents and their types from `@waibspace/agents`

Closes #12

## Test plan
- [ ] Verify TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Integration test: feed a `user.message.received` event through InputNormalizerAgent -> IntentAgent -> ConfidenceScorerAgent pipeline
- [ ] Verify IntentAgent produces valid IntentClassification with all required fields
- [ ] Verify ConfidenceScorerAgent adjusts confidence correctly for edge cases (short input, ambiguous reasoning, high confidence capping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)