### PR TITLE
feat: wire orchestration kernel into backend server

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,23 +1,91 @@
 import { EventBus } from "@waibspace/event-bus";
 import type { WaibEvent } from "@waibspace/types";
 import type { ServerMessage, ComposedLayout } from "@waibspace/ui-renderer-contract";
+import { Orchestrator, AgentRegistry } from "@waibspace/orchestrator";
+import {
+  InputNormalizerAgent,
+  URLIntentParserAgent,
+  IntentAgent,
+  ConfidenceScorerAgent,
+} from "@waibspace/agents";
+import {
+  ModelProviderRegistry,
+  AnthropicProvider,
+} from "@waibspace/model-provider";
 import { startServer } from "./server";
 import { broadcast } from "./ws";
 
-// Initialize event bus
+// ---------- 1. Event Bus ----------
 const bus = new EventBus();
 
-// Subscribe to surface.composed events and broadcast to all WebSocket clients
+// ---------- 2. Model Provider ----------
+const modelRegistry = new ModelProviderRegistry();
+modelRegistry.register(new AnthropicProvider());
+
+// ---------- 3. Agent Registry ----------
+const agentRegistry = new AgentRegistry();
+agentRegistry.register(new InputNormalizerAgent());
+agentRegistry.register(new URLIntentParserAgent());
+agentRegistry.register(new IntentAgent());
+agentRegistry.register(new ConfidenceScorerAgent());
+
+console.log(
+  `[backend] Registered ${agentRegistry.getAll().length} agents: ${agentRegistry.getAll().map((a) => a.id).join(", ")}`,
+);
+
+// ---------- 4. Orchestrator ----------
+const orchestrator = new Orchestrator(bus, agentRegistry, {
+  modelProvider: modelRegistry,
+});
+
+// ---------- 5. Route user events to orchestrator ----------
+const USER_EVENT_PATTERNS = [
+  "user.*",
+  "policy.approval.*",
+];
+
+for (const pattern of USER_EVENT_PATTERNS) {
+  bus.on(pattern, async (event: WaibEvent) => {
+    const traceId = event.traceId;
+    console.log(
+      `[backend] [trace:${traceId}] Routing event "${event.type}" to orchestrator`,
+    );
+    try {
+      await orchestrator.processEvent(event);
+    } catch (err) {
+      console.error(
+        `[backend] [trace:${traceId}] Orchestrator error for "${event.type}":`,
+        err,
+      );
+      // Send error to all clients with partial status
+      const errorMessage =
+        err instanceof Error ? err.message : "Unknown orchestrator error";
+      const errorMsg: ServerMessage = {
+        type: "error",
+        payload: {
+          message: errorMessage,
+          code: "ORCHESTRATOR_ERROR",
+        },
+      };
+      broadcast(errorMsg);
+    }
+  });
+}
+
+// ---------- 6. Broadcast composed surfaces to WebSocket clients ----------
 bus.on("surface.composed", (event: WaibEvent) => {
   const message: ServerMessage = {
     type: "surface.update",
     payload: event.payload as ComposedLayout,
   };
+  console.log(
+    `[backend] [trace:${event.traceId}] Broadcasting surface.composed to WebSocket clients`,
+  );
   broadcast(message);
 });
 
-// Start HTTP/WebSocket server
-const server = startServer(bus);
+// ---------- 7. Start HTTP/WebSocket server ----------
+const server = startServer({ eventBus: bus, orchestrator });
 
 const PORT = Number(process.env.PORT) || 3001;
 console.log(`[backend] WaibSpace backend started`);

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1,4 +1,5 @@
 import type { EventBus } from "@waibspace/event-bus";
+import type { Orchestrator } from "@waibspace/orchestrator";
 import {
   createWebSocketHandlers,
   type WebSocketData,
@@ -19,10 +20,15 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
+export interface ServerDeps {
+  eventBus: EventBus;
+  orchestrator: Orchestrator;
+}
+
 const startTime = Date.now();
 
-export function startServer(bus: EventBus) {
-  const wsHandlers = createWebSocketHandlers(bus);
+export function startServer(deps: ServerDeps) {
+  const wsHandlers = createWebSocketHandlers(deps.eventBus);
 
   const server = Bun.serve<WebSocketData>({
     port: PORT,

--- a/apps/backend/src/ws.ts
+++ b/apps/backend/src/ws.ts
@@ -25,6 +25,24 @@ export function broadcast(message: ServerMessage): void {
 }
 
 /**
+ * Map ClientMessage types to WaibEvent types for the event bus.
+ */
+function mapClientMessageToEventType(msg: ClientMessage): string {
+  switch (msg.type) {
+    case "user.message":
+      return "user.message.received";
+    case "user.interaction": {
+      const interaction = msg.payload.interaction || "clicked";
+      return `user.interaction.${interaction}`;
+    }
+    case "user.intent.url":
+      return "user.intent.url_received";
+    case "approval.response":
+      return "policy.approval.response";
+  }
+}
+
+/**
  * Create Bun WebSocket handlers wired to the given EventBus.
  */
 export function createWebSocketHandlers(bus: EventBus) {
@@ -38,11 +56,13 @@ export function createWebSocketHandlers(bus: EventBus) {
 
     message(ws: ServerWebSocket<WebSocketData>, message: string | Buffer) {
       const raw = typeof message === "string" ? message : message.toString();
+      const traceId = createTraceId();
 
       let parsed: unknown;
       try {
         parsed = JSON.parse(raw);
       } catch {
+        console.error(`[ws] [trace:${traceId}] Invalid JSON from ${ws.data.connectionId}`);
         const errorMsg: ServerMessage = {
           type: "error",
           payload: { message: "Invalid JSON", code: "INVALID_JSON" },
@@ -52,6 +72,7 @@ export function createWebSocketHandlers(bus: EventBus) {
       }
 
       if (!isValidClientMessage(parsed)) {
+        console.error(`[ws] [trace:${traceId}] Invalid message format from ${ws.data.connectionId}`);
         const errorMsg: ServerMessage = {
           type: "error",
           payload: {
@@ -64,16 +85,18 @@ export function createWebSocketHandlers(bus: EventBus) {
       }
 
       const clientMsg = parsed as ClientMessage;
+      const eventType = mapClientMessageToEventType(clientMsg);
+
       console.log(
-        `[ws] message from ${ws.data.connectionId}: ${clientMsg.type}`,
+        `[ws] [trace:${traceId}] message from ${ws.data.connectionId}: ${clientMsg.type} -> ${eventType}`,
       );
 
-      // Map client message type to WaibEvent type and emit
+      // Create a WaibEvent and emit to the event bus
       const event = createEvent(
-        clientMsg.type,
+        eventType,
         clientMsg.payload,
         `ws:${ws.data.connectionId}`,
-        createTraceId(),
+        traceId,
       );
       bus.emit(event);
     },

--- a/bun.lock
+++ b/bun.lock
@@ -83,6 +83,7 @@
       "name": "@waibspace/orchestrator",
       "version": "0.0.1",
       "dependencies": {
+        "@waibspace/agents": "workspace:*",
         "@waibspace/event-bus": "workspace:*",
         "@waibspace/policy": "workspace:*",
         "@waibspace/types": "workspace:*",

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1,12 +1,14 @@
 import type { WaibEvent, AgentOutput, AgentCategory } from "@waibspace/types";
 import { EventBus, createEvent } from "@waibspace/event-bus";
 import { executeAgent } from "@waibspace/agents";
+import type { ModelProviderRegistry } from "@waibspace/model-provider";
 import { AgentRegistry } from "./agent-registry";
 import { buildExecutionPlan } from "./execution-planner";
 import { createPipelineTrace, logTrace } from "./trace";
 
 export interface OrchestratorOptions {
   timeoutMs?: number;
+  modelProvider?: ModelProviderRegistry;
 }
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -31,7 +33,10 @@ export class Orchestrator {
 
     for (const phase of plan.phases) {
       const input = { event, priorOutputs };
-      const context = { traceId: event.traceId };
+      const context = {
+        traceId: event.traceId,
+        modelProvider: this.options?.modelProvider,
+      };
 
       // Execute all agents in this phase in parallel
       const results = await Promise.allSettled(


### PR DESCRIPTION
## Summary
- Initialize `ModelProviderRegistry` (with `AnthropicProvider`), `AgentRegistry` (with all 4 agents), and `Orchestrator` at backend startup in `index.ts`
- Map `ClientMessage` types to `WaibEvent` types in `ws.ts` (`user.message` -> `user.message.received`, `user.interaction` -> `user.interaction.<type>`, `user.intent.url` -> `user.intent.url_received`, `approval.response` -> `policy.approval.response`)
- Subscribe event bus to route `user.*` and `policy.approval.*` events to `Orchestrator.processEvent()`, and broadcast `surface.composed` events back to WebSocket clients
- Update `server.ts` to accept a `ServerDeps` object (eventBus + orchestrator) instead of a bare `EventBus`
- Extend `OrchestratorOptions` with optional `modelProvider` so agents that need LLM access receive the registry in their context
- Add traceId-based logging for all event routing and error paths

## Test plan
- [ ] Verify `bun run typecheck` passes for the backend package
- [ ] Start the backend and confirm all 4 agents are logged as registered
- [ ] Connect a WebSocket client and send a `user.message` — confirm it flows through the orchestrator pipeline
- [ ] Send malformed JSON and invalid message formats — confirm error responses are returned
- [ ] Verify `surface.composed` events are broadcast to connected clients

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)