### PR TITLE
feat(policy): implement policy engine

### DIFF
--- a/packages/policy/src/default-rules.ts
+++ b/packages/policy/src/default-rules.ts
@@ -1,0 +1,97 @@
+import type { PolicyRule } from "./types";
+
+export const DEFAULT_POLICY_RULES: PolicyRule[] = [
+  // Class A — auto-approve
+  {
+    id: "surface-compose",
+    name: "Surface Composition",
+    actionPattern: "surface.*",
+    riskClass: "A",
+    autoApprove: true,
+    description: "All surface composition actions",
+  },
+  {
+    id: "summarize",
+    name: "Summarization",
+    actionPattern: "summarize.*",
+    riskClass: "A",
+    autoApprove: true,
+    description: "All summarization actions",
+  },
+  {
+    id: "rank",
+    name: "Ranking",
+    actionPattern: "rank.*",
+    riskClass: "A",
+    autoApprove: true,
+    description: "All ranking actions",
+  },
+  {
+    id: "draft",
+    name: "Draft Creation",
+    actionPattern: "draft.*",
+    riskClass: "A",
+    autoApprove: true,
+    description: "Draft creation",
+  },
+  {
+    id: "fetch-data",
+    name: "Data Fetch",
+    actionPattern: "fetch.*",
+    riskClass: "A",
+    autoApprove: true,
+    description: "Data retrieval operations",
+  },
+
+  // Class B — standing approval
+  {
+    id: "archive",
+    name: "Archive",
+    actionPattern: "archive.*",
+    riskClass: "B",
+    autoApprove: true,
+    description: "Archive actions",
+  },
+  {
+    id: "categorize",
+    name: "Categorize",
+    actionPattern: "categorize.*",
+    riskClass: "B",
+    autoApprove: true,
+    description: "Categorization",
+  },
+
+  // Class C — require approval
+  {
+    id: "email-send",
+    name: "Send Email",
+    actionPattern: "email.send",
+    riskClass: "C",
+    autoApprove: false,
+    description: "Sending emails requires approval",
+  },
+  {
+    id: "calendar-create",
+    name: "Create Calendar Event",
+    actionPattern: "calendar.create",
+    riskClass: "C",
+    autoApprove: false,
+    description: "Creating calendar events requires approval",
+  },
+  {
+    id: "calendar-update",
+    name: "Update Calendar Event",
+    actionPattern: "calendar.update",
+    riskClass: "C",
+    autoApprove: false,
+    description: "Updating calendar events requires approval",
+  },
+  {
+    id: "post-public",
+    name: "Public Post",
+    actionPattern: "post.*",
+    riskClass: "C",
+    autoApprove: false,
+    description: "Public posts require approval",
+  },
+];

--- a/packages/policy/src/engine.ts
+++ b/packages/policy/src/engine.ts
@@ -1,0 +1,124 @@
+import type { PolicyDecision } from "@waibspace/types";
+import type { PolicyRule, ProposedAction, PolicyCondition } from "./types";
+
+/**
+ * Match an action type against a simple glob pattern.
+ * Supports `*` as a wildcard for any sequence of characters.
+ * e.g. "surface.*" matches "surface.compose", "email.send" matches exactly.
+ */
+function matchPattern(pattern: string, actionType: string): boolean {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp("^" + escaped.replace(/\*/g, ".*") + "$");
+  return regex.test(actionType);
+}
+
+function evaluateCondition(
+  condition: PolicyCondition,
+  action: ProposedAction,
+): boolean {
+  const value = (action as unknown as Record<string, unknown>)[condition.field];
+
+  switch (condition.operator) {
+    case "eq":
+      return value === condition.value;
+    case "neq":
+      return value !== condition.value;
+    case "gt":
+      return typeof value === "number" && value > (condition.value as number);
+    case "lt":
+      return typeof value === "number" && value < (condition.value as number);
+    case "in":
+      return Array.isArray(condition.value) && condition.value.includes(value);
+    default:
+      return false;
+  }
+}
+
+export class PolicyEngine {
+  private rules: Map<string, PolicyRule>;
+
+  constructor(rules?: PolicyRule[]) {
+    this.rules = new Map();
+    if (rules) {
+      for (const rule of rules) {
+        this.rules.set(rule.id, rule);
+      }
+    }
+  }
+
+  evaluate(action: ProposedAction): PolicyDecision {
+    const matchingRules = Array.from(this.rules.values()).filter((rule) =>
+      matchPattern(rule.actionPattern, action.actionType),
+    );
+
+    // No matching rules — default to Class C for safety
+    if (matchingRules.length === 0) {
+      return {
+        action: action.actionType,
+        riskClass: "C",
+        verdict: "approval_required",
+        reason: "No matching policy rule found; defaulting to approval required",
+        requiredApproval: {
+          prompt: `Approve action "${action.actionType}"?`,
+          context: action.payload,
+        },
+      };
+    }
+
+    // Use the first matching rule (most specific rules should be added first)
+    const rule = matchingRules[0];
+
+    // Evaluate conditions if present
+    if (rule.conditions && rule.conditions.length > 0) {
+      const allConditionsMet = rule.conditions.every((condition) =>
+        evaluateCondition(condition, action),
+      );
+      if (!allConditionsMet) {
+        return {
+          action: action.actionType,
+          riskClass: "C",
+          verdict: "approval_required",
+          reason: `Conditions not met for rule "${rule.name}"`,
+          requiredApproval: {
+            prompt: `Approve action "${action.actionType}"?`,
+            context: action.payload,
+          },
+        };
+      }
+    }
+
+    // Auto-approve or Class A/B
+    if (rule.autoApprove || rule.riskClass === "A" || rule.riskClass === "B") {
+      return {
+        action: action.actionType,
+        riskClass: rule.riskClass,
+        verdict: "approved",
+        reason: rule.description,
+      };
+    }
+
+    // Class C — require approval
+    return {
+      action: action.actionType,
+      riskClass: rule.riskClass,
+      verdict: "approval_required",
+      reason: rule.description,
+      requiredApproval: {
+        prompt: `Approve action "${action.actionType}"?`,
+        context: action.payload,
+      },
+    };
+  }
+
+  addRule(rule: PolicyRule): void {
+    this.rules.set(rule.id, rule);
+  }
+
+  removeRule(ruleId: string): void {
+    this.rules.delete(ruleId);
+  }
+
+  getRules(): PolicyRule[] {
+    return Array.from(this.rules.values());
+  }
+}

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -1,1 +1,3 @@
-// packages/policy
+export { PolicyEngine } from "./engine";
+export { DEFAULT_POLICY_RULES } from "./default-rules";
+export type { PolicyRule, PolicyCondition, ProposedAction } from "./types";

--- a/packages/policy/src/types.ts
+++ b/packages/policy/src/types.ts
@@ -1,0 +1,26 @@
+import type { RiskClass } from "@waibspace/types";
+
+export interface PolicyRule {
+  id: string;
+  name: string;
+  description: string;
+  actionPattern: string;
+  riskClass: RiskClass;
+  autoApprove: boolean;
+  conditions?: PolicyCondition[];
+}
+
+export interface PolicyCondition {
+  field: string;
+  operator: "eq" | "neq" | "gt" | "lt" | "in";
+  value: unknown;
+}
+
+export interface ProposedAction {
+  actionType: string;
+  connector?: string;
+  trustLevel?: string;
+  payload?: unknown;
+  agentId: string;
+  traceId: string;
+}


### PR DESCRIPTION
## Summary
- Implement `PolicyEngine` class with glob-based rule matching for evaluating proposed agent actions
- Add policy rule types (`PolicyRule`, `PolicyCondition`, `ProposedAction`) in `types.ts`
- Include default rules covering Class A (surface, summarize, rank, draft, fetch), Class B (archive, categorize), and Class C (email send, calendar create/update, public post) actions
- Unmatched actions default to Class C (approval required) for safety

## Test plan
- [ ] Verify typecheck passes: `npx tsc --noEmit -p packages/policy/tsconfig.json`
- [ ] Verify Class A actions (e.g. `surface.compose`) return `approved` verdict
- [ ] Verify Class C actions (e.g. `email.send`) return `approval_required` verdict
- [ ] Verify unknown actions default to `approval_required`
- [ ] Verify glob patterns match correctly (e.g. `surface.*` matches `surface.compose`)
- [ ] Verify conditions are evaluated when present on rules

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)