### PR TITLE
Implement connector framework

### DIFF
--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
+    "@waibspace/policy": "workspace:*",
     "@waibspace/types": "workspace:*"
   },
   "scripts": {

--- a/packages/connectors/src/base-connector.ts
+++ b/packages/connectors/src/base-connector.ts
@@ -1,0 +1,114 @@
+import type {
+  ProvenanceMetadata,
+  TrustLevel,
+  ConnectorCapability,
+} from "@waibspace/types";
+import type {
+  Connector,
+  ConnectorRequest,
+  ConnectorResponse,
+  ConnectorAction,
+  ConnectorResult,
+} from "./types";
+
+export interface BaseConnectorConfig {
+  id: string;
+  name: string;
+  type: string;
+  trustLevel: TrustLevel;
+  capabilities: ConnectorCapability;
+}
+
+export abstract class BaseConnector implements Connector {
+  readonly id: string;
+  readonly name: string;
+  readonly type: string;
+  readonly trustLevel: TrustLevel;
+  readonly capabilities: ConnectorCapability;
+  protected connected = false;
+
+  constructor(config: BaseConnectorConfig) {
+    this.id = config.id;
+    this.name = config.name;
+    this.type = config.type;
+    this.trustLevel = config.trustLevel;
+    this.capabilities = config.capabilities;
+  }
+
+  abstract connect(): Promise<void>;
+  abstract disconnect(): Promise<void>;
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  async fetch(request: ConnectorRequest): Promise<ConnectorResponse> {
+    if (!this.connected) {
+      throw new Error(`Connector "${this.name}" (${this.id}) is not connected`);
+    }
+
+    this.log(`fetch: ${request.operation}`, {
+      traceId: request.traceId,
+      params: request.params,
+    });
+
+    const response = await this.doFetch(request);
+
+    // Attach provenance metadata if not already set
+    if (!response.provenance) {
+      response.provenance = this.createProvenance(this.id);
+    }
+
+    return response;
+  }
+
+  async execute(action: ConnectorAction): Promise<ConnectorResult> {
+    // Verify policy decision is approved
+    if (action.policyDecision.verdict !== "approved") {
+      return {
+        success: false,
+        error: `Action "${action.operation}" rejected by policy: ${action.policyDecision.reason} (verdict: ${action.policyDecision.verdict})`,
+      };
+    }
+
+    if (!this.connected) {
+      throw new Error(`Connector "${this.name}" (${this.id}) is not connected`);
+    }
+
+    this.log(`execute: ${action.operation}`, {
+      traceId: action.traceId,
+      params: action.params,
+      riskClass: action.policyDecision.riskClass,
+    });
+
+    return this.doExecute(action);
+  }
+
+  protected abstract doFetch(
+    request: ConnectorRequest,
+  ): Promise<ConnectorResponse>;
+
+  protected abstract doExecute(
+    action: ConnectorAction,
+  ): Promise<ConnectorResult>;
+
+  protected createProvenance(sourceId?: string): ProvenanceMetadata {
+    return {
+      sourceType: this.type,
+      sourceId: sourceId ?? this.id,
+      trustLevel: this.trustLevel,
+      timestamp: Date.now(),
+      freshness: "realtime",
+      dataState: "raw",
+    };
+  }
+
+  protected log(message: string, data?: unknown): void {
+    const prefix = `[${this.type}:${this.name}]`;
+    if (data !== undefined) {
+      console.log(prefix, message, data);
+    } else {
+      console.log(prefix, message);
+    }
+  }
+}

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -1,1 +1,10 @@
-// packages/connectors
+export type {
+  Connector,
+  ConnectorRequest,
+  ConnectorResponse,
+  ConnectorAction,
+  ConnectorResult,
+} from "./types";
+export { BaseConnector } from "./base-connector";
+export type { BaseConnectorConfig } from "./base-connector";
+export { ConnectorRegistry } from "./registry";

--- a/packages/connectors/src/registry.ts
+++ b/packages/connectors/src/registry.ts
@@ -1,0 +1,39 @@
+import type { TrustLevel, ConnectorCapability } from "@waibspace/types";
+import type { Connector } from "./types";
+
+export class ConnectorRegistry {
+  private connectors = new Map<string, Connector>();
+
+  register(connector: Connector): void {
+    if (this.connectors.has(connector.id)) {
+      throw new Error(
+        `Connector with id "${connector.id}" is already registered`,
+      );
+    }
+    this.connectors.set(connector.id, connector);
+  }
+
+  get(id: string): Connector | undefined {
+    return this.connectors.get(id);
+  }
+
+  getByType(type: string): Connector[] {
+    return Array.from(this.connectors.values()).filter(
+      (c) => c.type === type,
+    );
+  }
+
+  getByTrustLevel(level: TrustLevel): Connector[] {
+    return Array.from(this.connectors.values()).filter(
+      (c) => c.trustLevel === level,
+    );
+  }
+
+  getAll(): Connector[] {
+    return Array.from(this.connectors.values());
+  }
+
+  listCapabilities(): ConnectorCapability[] {
+    return Array.from(this.connectors.values()).map((c) => c.capabilities);
+  }
+}

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -1,0 +1,46 @@
+import type {
+  ProvenanceMetadata,
+  TrustLevel,
+  ConnectorCapability,
+  PolicyDecision,
+} from "@waibspace/types";
+
+export interface Connector {
+  id: string;
+  name: string;
+  type: string; // "api", "mcp", "web-fetch"
+  trustLevel: TrustLevel;
+  capabilities: ConnectorCapability;
+
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  isConnected(): boolean;
+
+  fetch(request: ConnectorRequest): Promise<ConnectorResponse>;
+  execute(action: ConnectorAction): Promise<ConnectorResult>;
+}
+
+export interface ConnectorRequest {
+  operation: string;
+  params: Record<string, unknown>;
+  traceId: string;
+}
+
+export interface ConnectorResponse {
+  data: unknown;
+  provenance: ProvenanceMetadata;
+  raw?: unknown;
+}
+
+export interface ConnectorAction {
+  operation: string;
+  params: Record<string, unknown>;
+  policyDecision: PolicyDecision;
+  traceId: string;
+}
+
+export interface ConnectorResult {
+  success: boolean;
+  result?: unknown;
+  error?: string;
+}

--- a/packages/connectors/tsconfig.json
+++ b/packages/connectors/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": ["src"],
   "references": [
-    { "path": "../types" }
+    { "path": "../types" },
+    { "path": "../policy" }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `Connector` interface and supporting request/response/action/result types in `types.ts`
- Implement `BaseConnector` abstract class with built-in policy enforcement (rejects non-approved actions), automatic provenance metadata attachment, connection state checks, and structured logging
- Add `ConnectorRegistry` for managing connector instances with lookup by id, type, and trust level
- Add `@waibspace/policy` as a dependency and project reference

Closes #20

## Test plan
- [ ] Verify `tsc -b packages/connectors/tsconfig.json` builds cleanly
- [ ] Verify a concrete subclass can extend `BaseConnector` and implement `doFetch`/`doExecute`
- [ ] Verify `ConnectorRegistry` correctly filters by type and trust level
- [ ] Verify `execute()` rejects actions with non-approved policy decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)