### PR TITLE
feat(connectors): scaffold MCP connector

### DIFF
--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -29,3 +29,4 @@ export {
   RateLimiter,
 } from "./web-fetch";
 export type { ExtractedContent } from "./web-fetch";
+export { MCPConnector } from "./mcp";

--- a/packages/connectors/src/mcp/index.ts
+++ b/packages/connectors/src/mcp/index.ts
@@ -1,0 +1,1 @@
+export { MCPConnector } from "./mcp-connector";

--- a/packages/connectors/src/mcp/mcp-connector.ts
+++ b/packages/connectors/src/mcp/mcp-connector.ts
@@ -1,0 +1,60 @@
+import { BaseConnector } from "../base-connector";
+import type {
+  ConnectorRequest,
+  ConnectorResponse,
+  ConnectorAction,
+  ConnectorResult,
+} from "../types";
+
+export class MCPConnector extends BaseConnector {
+  constructor(config: { serverCommand: string; serverArgs?: string[] }) {
+    super({
+      id: "mcp",
+      name: "MCP Server",
+      type: "mcp",
+      trustLevel: "semi-trusted",
+      capabilities: {
+        connectorId: "mcp",
+        connectorType: "mcp",
+        actions: [], // dynamically discovered
+        dataTypes: ["mcp-tool-result"],
+        trustLevel: "semi-trusted",
+      },
+    });
+  }
+
+  async connect(): Promise<void> {
+    // For MVP: just log that MCP connector is ready
+    // Full implementation would spawn the MCP server process via stdio
+    this.connected = true;
+    this.log("MCP connector scaffold initialized (stub mode)");
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+  }
+
+  protected async doFetch(
+    request: ConnectorRequest,
+  ): Promise<ConnectorResponse> {
+    // Stub: return a placeholder response indicating MCP is not fully implemented
+    return {
+      data: {
+        message:
+          "MCP connector is in scaffold mode. Tool invocation not yet implemented.",
+        operation: request.operation,
+      },
+      provenance: this.createProvenance("mcp-stub"),
+    };
+  }
+
+  protected async doExecute(
+    action: ConnectorAction,
+  ): Promise<ConnectorResult> {
+    return {
+      success: false,
+      error:
+        "MCP connector is in scaffold mode. Execution not yet implemented.",
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add `MCPConnector` class extending `BaseConnector` with type `"mcp"` and trust level `"semi-trusted"`
- Stub implementations for `connect`, `disconnect`, `doFetch`, and `doExecute` — ready for future MCP server integration
- Export `MCPConnector` from `@waibspace/connectors` package barrel

## Test plan
- [x] Verify no new type errors introduced (all pre-existing errors unrelated to MCP)
- [ ] Instantiate `MCPConnector` and call `connect()` / `fetch()` to confirm stub responses

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)