### PR TITLE
Implement context planning agents

### DIFF
--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "@waibspace/types": "workspace:*",
     "@waibspace/event-bus": "workspace:*",
-    "@waibspace/model-provider": "workspace:*"
+    "@waibspace/model-provider": "workspace:*",
+    "@waibspace/connectors": "workspace:*"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/agents/src/context/connector-selection.ts
+++ b/packages/agents/src/context/connector-selection.ts
@@ -1,0 +1,124 @@
+import type { AgentOutput } from "@waibspace/types";
+import type { ConnectorRegistry } from "@waibspace/connectors";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+import type { DataSourcePlan } from "./context-planner";
+
+export interface FinalizedPlan {
+  retrievals: Array<{
+    connectorId: string;
+    operation: string;
+    params: Record<string, unknown>;
+    available: boolean;
+    trustLevel: string;
+  }>;
+  unavailableConnectors: string[];
+}
+
+export class ConnectorSelectionAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "context.connector-selection",
+      name: "ConnectorSelectionAgent",
+      type: "connector-selector",
+      category: "context",
+    });
+  }
+
+  async execute(
+    input: AgentInput,
+    context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+
+    const dataSourcePlan = this.findDataSourcePlan(input);
+    if (!dataSourcePlan) {
+      throw new Error(
+        "ConnectorSelectionAgent requires DataSourcePlan from prior outputs",
+      );
+    }
+
+    const registry = context.config?.["connectorRegistry"] as
+      | ConnectorRegistry
+      | undefined;
+    if (!registry) {
+      throw new Error(
+        "ConnectorSelectionAgent requires connectorRegistry in context.config",
+      );
+    }
+
+    this.log("Validating retrieval plan", {
+      plannedSources: dataSourcePlan.dataSources.length,
+    });
+
+    const unavailableConnectors: string[] = [];
+    const retrievals: FinalizedPlan["retrievals"] = [];
+
+    for (const source of dataSourcePlan.dataSources) {
+      const connector = registry.get(source.connectorId);
+      const available = connector !== undefined && connector.isConnected();
+      const trustLevel = connector?.trustLevel ?? "untrusted";
+
+      if (!available) {
+        unavailableConnectors.push(source.connectorId);
+        if (source.required) {
+          this.log("Required connector unavailable", {
+            connectorId: source.connectorId,
+            operation: source.operation,
+          });
+        }
+      }
+
+      retrievals.push({
+        connectorId: source.connectorId,
+        operation: source.operation,
+        params: source.params,
+        available,
+        trustLevel,
+      });
+    }
+
+    const finalizedPlan: FinalizedPlan = {
+      retrievals,
+      unavailableConnectors,
+    };
+
+    const endMs = Date.now();
+
+    // Confidence is lower if there are unavailable required connectors
+    const hasUnavailableRequired = dataSourcePlan.dataSources.some(
+      (s) =>
+        s.required && !retrievals.find(
+          (r) => r.connectorId === s.connectorId && r.available,
+        ),
+    );
+    const confidence = hasUnavailableRequired ? 0.5 : 1.0;
+
+    return {
+      ...this.createOutput(finalizedPlan, confidence, {
+        dataState: "transformed",
+        transformations: ["connector-selection"],
+        timestamp: startMs,
+      }),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+
+  private findDataSourcePlan(
+    input: AgentInput,
+  ): DataSourcePlan | undefined {
+    for (const prior of input.priorOutputs) {
+      if (prior.category === "context" && prior.output) {
+        const output = prior.output as Record<string, unknown>;
+        if ("dataSources" in output && "reasoning" in output) {
+          return output as unknown as DataSourcePlan;
+        }
+      }
+    }
+    return undefined;
+  }
+}

--- a/packages/agents/src/context/context-planner.ts
+++ b/packages/agents/src/context/context-planner.ts
@@ -1,0 +1,141 @@
+import type { AgentOutput } from "@waibspace/types";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+import type { IntentClassification } from "../reasoning/intent-agent";
+
+export interface DataSourcePlan {
+  dataSources: Array<{
+    connectorId: string;
+    operation: string;
+    params: Record<string, unknown>;
+    priority: number;
+    required: boolean;
+  }>;
+  reasoning: string;
+}
+
+const SYSTEM_PROMPT = `You are a context planning agent for WaibSpace, an AI-powered personal assistant.
+
+Given an intent classification, determine which data sources need to be queried to fulfill the user's request.
+
+Available connectors and their operations:
+
+- **gmail**:
+  - list-emails: List recent emails. Params: maxResults (number), labelIds (string[])
+  - get-email: Get a specific email. Params: emailId (string)
+  - search-emails: Search emails by query. Params: query (string), maxResults (number)
+
+- **google-calendar**:
+  - list-events: List upcoming calendar events. Params: timeMin (string), timeMax (string), maxResults (number)
+  - check-availability: Check free/busy status. Params: timeMin (string), timeMax (string)
+  - get-event: Get a specific event. Params: eventId (string)
+
+- **web-fetch**:
+  - fetch-url: Fetch content from a URL. Params: url (string)
+  - search-site: Search a website. Params: query (string), site (string)
+
+For each data source needed, specify:
+- connectorId: which connector to use
+- operation: which operation to call
+- params: parameters for the operation
+- priority: 1 = highest priority, higher numbers = lower priority
+- required: true if the data is essential, false if supplementary
+
+Respond with a JSON object matching the DataSourcePlan schema.`;
+
+const DATA_SOURCE_PLAN_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    dataSources: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          connectorId: { type: "string" },
+          operation: { type: "string" },
+          params: { type: "object", additionalProperties: true },
+          priority: { type: "number", minimum: 1 },
+          required: { type: "boolean" },
+        },
+        required: ["connectorId", "operation", "params", "priority", "required"],
+      },
+    },
+    reasoning: { type: "string" },
+  },
+  required: ["dataSources", "reasoning"],
+};
+
+export class ContextPlannerAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "context.planner",
+      name: "ContextPlannerAgent",
+      type: "context-planner",
+      category: "context",
+    });
+  }
+
+  async execute(
+    input: AgentInput,
+    context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+
+    const intentClassification = this.findIntentClassification(input);
+    if (!intentClassification) {
+      throw new Error(
+        "ContextPlannerAgent requires IntentClassification from prior outputs",
+      );
+    }
+
+    this.log("Planning data sources for intent", {
+      intent: intentClassification.primaryIntent,
+      category: intentClassification.intentCategory,
+    });
+
+    const userMessage = [
+      `Intent: ${intentClassification.primaryIntent}`,
+      `Category: ${intentClassification.intentCategory}`,
+      `Entities: ${JSON.stringify(intentClassification.entities)}`,
+      `Suggested agents: ${intentClassification.suggestedAgents.join(", ")}`,
+      `Reasoning: ${intentClassification.reasoning}`,
+    ].join("\n");
+
+    const plan = await this.completeStructured<DataSourcePlan>(
+      context,
+      "reasoning",
+      [{ role: "user", content: userMessage }],
+      DATA_SOURCE_PLAN_SCHEMA,
+      SYSTEM_PROMPT,
+    );
+
+    const endMs = Date.now();
+
+    return {
+      ...this.createOutput(plan, 0.85, {
+        dataState: "transformed",
+        transformations: ["context-planning"],
+        timestamp: startMs,
+      }),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+
+  private findIntentClassification(
+    input: AgentInput,
+  ): IntentClassification | undefined {
+    for (const prior of input.priorOutputs) {
+      if (prior.category === "reasoning" && prior.output) {
+        const output = prior.output as Record<string, unknown>;
+        if ("primaryIntent" in output && "intentCategory" in output) {
+          return output as unknown as IntentClassification;
+        }
+      }
+    }
+    return undefined;
+  }
+}

--- a/packages/agents/src/context/data-retrieval.ts
+++ b/packages/agents/src/context/data-retrieval.ts
@@ -1,0 +1,170 @@
+import type { AgentOutput, ProvenanceMetadata } from "@waibspace/types";
+import type {
+  ConnectorRegistry,
+  ConnectorResponse,
+} from "@waibspace/connectors";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+import type { FinalizedPlan } from "./connector-selection";
+
+interface RetrievalResult {
+  connectorId: string;
+  operation: string;
+  status: "fulfilled" | "rejected";
+  data?: unknown;
+  provenance?: ProvenanceMetadata;
+  error?: string;
+}
+
+export interface DataRetrievalOutput {
+  results: RetrievalResult[];
+  totalAttempted: number;
+  totalSucceeded: number;
+  totalFailed: number;
+}
+
+export class DataRetrievalAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "context.data-retrieval",
+      name: "DataRetrievalAgent",
+      type: "data-retriever",
+      category: "context",
+    });
+  }
+
+  async execute(
+    input: AgentInput,
+    context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+
+    const finalizedPlan = this.findFinalizedPlan(input);
+    if (!finalizedPlan) {
+      throw new Error(
+        "DataRetrievalAgent requires FinalizedPlan from prior outputs",
+      );
+    }
+
+    const registry = context.config?.["connectorRegistry"] as
+      | ConnectorRegistry
+      | undefined;
+    if (!registry) {
+      throw new Error(
+        "DataRetrievalAgent requires connectorRegistry in context.config",
+      );
+    }
+
+    const availableRetrievals = finalizedPlan.retrievals.filter(
+      (r) => r.available,
+    );
+
+    this.log("Executing retrievals", {
+      total: finalizedPlan.retrievals.length,
+      available: availableRetrievals.length,
+    });
+
+    const settlementResults = await Promise.allSettled(
+      availableRetrievals.map(async (retrieval) => {
+        const connector = registry.get(retrieval.connectorId);
+        if (!connector) {
+          throw new Error(
+            `Connector "${retrieval.connectorId}" not found in registry`,
+          );
+        }
+
+        const response: ConnectorResponse = await connector.fetch({
+          operation: retrieval.operation,
+          params: retrieval.params,
+          traceId: context.traceId,
+        });
+
+        return {
+          connectorId: retrieval.connectorId,
+          operation: retrieval.operation,
+          data: response.data,
+          provenance: response.provenance,
+        };
+      }),
+    );
+
+    const results: RetrievalResult[] = settlementResults.map(
+      (result, index) => {
+        const retrieval = availableRetrievals[index];
+        if (result.status === "fulfilled") {
+          return {
+            connectorId: retrieval.connectorId,
+            operation: retrieval.operation,
+            status: "fulfilled" as const,
+            data: result.value.data,
+            provenance: result.value.provenance,
+          };
+        } else {
+          this.log("Retrieval failed", {
+            connectorId: retrieval.connectorId,
+            operation: retrieval.operation,
+            error:
+              result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason),
+          });
+          return {
+            connectorId: retrieval.connectorId,
+            operation: retrieval.operation,
+            status: "rejected" as const,
+            error:
+              result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason),
+          };
+        }
+      },
+    );
+
+    const totalSucceeded = results.filter(
+      (r) => r.status === "fulfilled",
+    ).length;
+
+    const output: DataRetrievalOutput = {
+      results,
+      totalAttempted: availableRetrievals.length,
+      totalSucceeded,
+      totalFailed: availableRetrievals.length - totalSucceeded,
+    };
+
+    const endMs = Date.now();
+
+    const confidence =
+      availableRetrievals.length > 0
+        ? totalSucceeded / availableRetrievals.length
+        : 0;
+
+    return {
+      ...this.createOutput(output, confidence, {
+        sourceType: "connector",
+        dataState: "raw",
+        freshness: "realtime",
+        timestamp: startMs,
+      }),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+
+  private findFinalizedPlan(
+    input: AgentInput,
+  ): FinalizedPlan | undefined {
+    for (const prior of input.priorOutputs) {
+      if (prior.category === "context" && prior.output) {
+        const output = prior.output as Record<string, unknown>;
+        if ("retrievals" in output && "unavailableConnectors" in output) {
+          return output as unknown as FinalizedPlan;
+        }
+      }
+    }
+    return undefined;
+  }
+}

--- a/packages/agents/src/context/index.ts
+++ b/packages/agents/src/context/index.ts
@@ -1,0 +1,12 @@
+export {
+  ContextPlannerAgent,
+  type DataSourcePlan,
+} from "./context-planner";
+export {
+  ConnectorSelectionAgent,
+  type FinalizedPlan,
+} from "./connector-selection";
+export {
+  DataRetrievalAgent,
+  type DataRetrievalOutput,
+} from "./data-retrieval";

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -20,3 +20,11 @@ export {
   type ProvenanceAnnotation,
   type ProvenanceAnnotationResult,
 } from "./safety";
+export {
+  ContextPlannerAgent,
+  type DataSourcePlan,
+  ConnectorSelectionAgent,
+  type FinalizedPlan,
+  DataRetrievalAgent,
+  type DataRetrievalOutput,
+} from "./context";

--- a/packages/agents/tsconfig.json
+++ b/packages/agents/tsconfig.json
@@ -8,6 +8,7 @@
   "references": [
     { "path": "../types" },
     { "path": "../event-bus" },
-    { "path": "../model-provider" }
+    { "path": "../model-provider" },
+    { "path": "../connectors" }
   ]
 }


### PR DESCRIPTION
## Summary
- **ContextPlannerAgent**: LLM-based agent that takes IntentClassification from reasoning phase and produces a DataSourcePlan specifying which connectors/operations to query (gmail, google-calendar, web-fetch)
- **ConnectorSelectionAgent**: Deterministic agent that validates the plan against ConnectorRegistry, marking connector availability and attaching trust levels
- **DataRetrievalAgent**: Deterministic agent that executes all available retrievals in parallel via `Promise.allSettled`, collecting responses with provenance and handling partial failures gracefully

Adds `@waibspace/connectors` as a dependency of `@waibspace/agents`.

Closes #25

## Test plan
- [ ] Verify typecheck passes for agents package
- [ ] Unit test ContextPlannerAgent with mocked LLM producing DataSourcePlan
- [ ] Unit test ConnectorSelectionAgent with mock ConnectorRegistry (mix of available/unavailable connectors)
- [ ] Unit test DataRetrievalAgent with mock connectors returning success/failure
- [ ] Integration test full context pipeline: IntentClassification -> DataSourcePlan -> FinalizedPlan -> DataRetrievalOutput

🤖 Generated with [Claude Code](https://claude.com/claude-code)