### PR TITLE
feat: implement surface spec system

### DIFF
--- a/packages/surfaces/src/builder.ts
+++ b/packages/surfaces/src/builder.ts
@@ -1,0 +1,84 @@
+import type {
+  SurfaceSpec,
+  SurfaceAction,
+  SurfaceAffordance,
+  LayoutHints,
+  ProvenanceMetadata,
+} from "@waibspace/types";
+
+export class SurfaceSpecBuilder {
+  private spec: Partial<SurfaceSpec>;
+
+  constructor(surfaceType: string) {
+    this.spec = {
+      surfaceType,
+      surfaceId: crypto.randomUUID(),
+      actions: [],
+      affordances: [],
+      layoutHints: {},
+      confidence: 1,
+    };
+  }
+
+  setTitle(title: string): this {
+    this.spec.title = title;
+    return this;
+  }
+
+  setSummary(summary: string): this {
+    this.spec.summary = summary;
+    return this;
+  }
+
+  setPriority(priority: number): this {
+    this.spec.priority = priority;
+    return this;
+  }
+
+  setData(data: unknown): this {
+    this.spec.data = data;
+    return this;
+  }
+
+  addAction(action: SurfaceAction): this {
+    this.spec.actions!.push(action);
+    return this;
+  }
+
+  addAffordance(affordance: SurfaceAffordance): this {
+    this.spec.affordances!.push(affordance);
+    return this;
+  }
+
+  setLayout(hints: LayoutHints): this {
+    this.spec.layoutHints = hints;
+    return this;
+  }
+
+  setProvenance(provenance: ProvenanceMetadata): this {
+    this.spec.provenance = provenance;
+    return this;
+  }
+
+  setConfidence(confidence: number): this {
+    this.spec.confidence = confidence;
+    return this;
+  }
+
+  build(): SurfaceSpec {
+    if (!this.spec.title) {
+      throw new Error("SurfaceSpec requires a title");
+    }
+    if (!this.spec.provenance) {
+      throw new Error("SurfaceSpec requires provenance metadata");
+    }
+    if (this.spec.priority === undefined) {
+      throw new Error("SurfaceSpec requires a priority");
+    }
+    if (this.spec.data === undefined) {
+      throw new Error("SurfaceSpec requires data");
+    }
+
+    return this.spec as SurfaceSpec;
+  }
+}

--- a/packages/surfaces/src/factories.ts
+++ b/packages/surfaces/src/factories.ts
@@ -1,0 +1,135 @@
+import type { SurfaceSpec, ProvenanceMetadata } from "@waibspace/types";
+import { SurfaceSpecBuilder } from "./builder";
+import type {
+  InboxSurfaceData,
+  CalendarSurfaceData,
+  DiscoverySurfaceData,
+  ApprovalSurfaceData,
+} from "./surface-data";
+
+export class SurfaceFactory {
+  static inbox(
+    data: InboxSurfaceData,
+    provenance: ProvenanceMetadata
+  ): SurfaceSpec {
+    return new SurfaceSpecBuilder("inbox")
+      .setTitle(`Inbox (${data.unreadCount} unread)`)
+      .setSummary(
+        `${data.totalCount} messages, ${data.unreadCount} unread`
+      )
+      .setPriority(70)
+      .setData(data)
+      .setLayout({
+        position: "primary",
+        prominence: "standard",
+      })
+      .addAction({
+        id: "mark-read",
+        label: "Mark All Read",
+        actionType: "inbox.markAllRead",
+        riskClass: "A",
+      })
+      .addAction({
+        id: "archive",
+        label: "Archive",
+        actionType: "inbox.archive",
+        riskClass: "A",
+      })
+      .addAction({
+        id: "reply",
+        label: "Reply",
+        actionType: "inbox.reply",
+        riskClass: "B",
+      })
+      .setProvenance(provenance)
+      .build();
+  }
+
+  static calendar(
+    data: CalendarSurfaceData,
+    provenance: ProvenanceMetadata
+  ): SurfaceSpec {
+    return new SurfaceSpecBuilder("calendar")
+      .setTitle("Calendar")
+      .setSummary(
+        `${data.events.length} events, ${data.freeSlots.length} free slots`
+      )
+      .setPriority(60)
+      .setData(data)
+      .setLayout({
+        position: "secondary",
+        prominence: "standard",
+      })
+      .setProvenance(provenance)
+      .build();
+  }
+
+  static discovery(
+    data: DiscoverySurfaceData,
+    provenance: ProvenanceMetadata
+  ): SurfaceSpec {
+    return new SurfaceSpecBuilder("discovery")
+      .setTitle(`Results for "${data.query}"`)
+      .setSummary(`${data.results.length} results found`)
+      .setPriority(80)
+      .setData(data)
+      .setLayout({
+        position: "primary",
+        prominence: "hero",
+      })
+      .setProvenance(provenance)
+      .build();
+  }
+
+  static approval(data: ApprovalSurfaceData): SurfaceSpec {
+    return new SurfaceSpecBuilder("approval")
+      .setTitle("Approval Required")
+      .setSummary(data.actionDescription)
+      .setPriority(100)
+      .setData(data)
+      .setLayout({
+        position: "overlay",
+        prominence: "hero",
+      })
+      .addAction({
+        id: "approve",
+        label: "Approve",
+        actionType: "approval.approve",
+        riskClass: data.riskClass,
+        payload: { approvalId: data.approvalId },
+      })
+      .addAction({
+        id: "deny",
+        label: "Deny",
+        actionType: "approval.deny",
+        riskClass: "A",
+        payload: { approvalId: data.approvalId },
+      })
+      .setProvenance({
+        sourceType: "system",
+        sourceId: "policy-engine",
+        trustLevel: "trusted",
+        timestamp: Date.now(),
+        freshness: "realtime",
+        dataState: "raw",
+      })
+      .build();
+  }
+
+  static generic(
+    title: string,
+    data: unknown,
+    provenance: ProvenanceMetadata
+  ): SurfaceSpec {
+    return new SurfaceSpecBuilder("generic")
+      .setTitle(title)
+      .setPriority(50)
+      .setData(data)
+      .setLayout({
+        position: "secondary",
+        prominence: "compact",
+      })
+      .setProvenance(provenance)
+      .build();
+  }
+}

--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -1,1 +1,9 @@
-// packages/surfaces
+export { SurfaceSpecBuilder } from "./builder";
+export { SurfaceFactory } from "./factories";
+export { SurfaceTypeRegistry, createDefaultRegistry } from "./registry";
+export type {
+  InboxSurfaceData,
+  CalendarSurfaceData,
+  DiscoverySurfaceData,
+  ApprovalSurfaceData,
+} from "./surface-data";

--- a/packages/surfaces/src/registry.ts
+++ b/packages/surfaces/src/registry.ts
@@ -1,0 +1,48 @@
+import type { SurfaceSpec } from "@waibspace/types";
+
+interface RegistryEntry {
+  type: string;
+  requiredFields: string[];
+}
+
+export class SurfaceTypeRegistry {
+  private entries: Map<string, RegistryEntry> = new Map();
+
+  register(type: string, requiredFields: string[]): void {
+    this.entries.set(type, { type, requiredFields });
+  }
+
+  isValid(spec: SurfaceSpec): boolean {
+    const entry = this.entries.get(spec.surfaceType);
+    if (!entry) {
+      return false;
+    }
+
+    const data = spec.data as Record<string, unknown> | null;
+    if (!data || typeof data !== "object") {
+      return entry.requiredFields.length === 0;
+    }
+
+    return entry.requiredFields.every((field) => field in data);
+  }
+
+  getRegistered(): string[] {
+    return Array.from(this.entries.keys());
+  }
+}
+
+export function createDefaultRegistry(): SurfaceTypeRegistry {
+  const registry = new SurfaceTypeRegistry();
+  registry.register("inbox", ["emails", "totalCount", "unreadCount"]);
+  registry.register("calendar", ["events", "freeSlots", "dateRange"]);
+  registry.register("discovery", ["query", "results", "sources"]);
+  registry.register("approval", [
+    "approvalId",
+    "actionDescription",
+    "riskClass",
+    "context",
+    "consequences",
+  ]);
+  registry.register("generic", []);
+  return registry;
+}

--- a/packages/surfaces/src/surface-data.ts
+++ b/packages/surfaces/src/surface-data.ts
@@ -1,0 +1,52 @@
+import type { SurfaceAction, RiskClass } from "@waibspace/types";
+import type { ProvenanceMetadata } from "@waibspace/types";
+
+export interface InboxSurfaceData {
+  emails: Array<{
+    id: string;
+    from: string;
+    subject: string;
+    snippet: string;
+    date: string;
+    isUnread: boolean;
+    urgency: "high" | "medium" | "low";
+    suggestedReply?: string;
+  }>;
+  totalCount: number;
+  unreadCount: number;
+}
+
+export interface CalendarSurfaceData {
+  events: Array<{
+    id: string;
+    title: string;
+    start: string;
+    end: string;
+    location?: string;
+    attendees?: string[];
+    conflictWith?: string;
+  }>;
+  freeSlots: Array<{ start: string; end: string }>;
+  dateRange: { start: string; end: string };
+}
+
+export interface DiscoverySurfaceData {
+  query: string;
+  results: Array<{
+    title: string;
+    description: string;
+    url?: string;
+    relevanceScore: number;
+    matchReasons: string[];
+    actions?: SurfaceAction[];
+  }>;
+  sources: ProvenanceMetadata[];
+}
+
+export interface ApprovalSurfaceData {
+  approvalId: string;
+  actionDescription: string;
+  riskClass: RiskClass;
+  context: unknown;
+  consequences: string[];
+}


### PR DESCRIPTION
## Summary
- Add `SurfaceSpecBuilder` with fluent API for constructing validated `SurfaceSpec` objects
- Add `SurfaceFactory` with preset factories (inbox, calendar, discovery, approval, generic) using appropriate defaults for priority, layout, and actions
- Add `SurfaceTypeRegistry` for registering surface types with required field validation, pre-registered with all five built-in types
- Add surface data type definitions (`InboxSurfaceData`, `CalendarSurfaceData`, `DiscoverySurfaceData`, `ApprovalSurfaceData`)

Closes #24

## Test plan
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [ ] Verify builder validates required fields (title, provenance, priority, data)
- [ ] Verify factory methods produce specs with correct defaults
- [ ] Verify registry validates surface data against required fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)