### PR TITLE
feat: implement layout composer agent

### DIFF
--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -8,7 +8,8 @@
     "@waibspace/types": "workspace:*",
     "@waibspace/event-bus": "workspace:*",
     "@waibspace/model-provider": "workspace:*",
-    "@waibspace/connectors": "workspace:*"
+    "@waibspace/connectors": "workspace:*",
+    "@waibspace/ui-renderer-contract": "workspace:*"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -28,3 +28,4 @@ export {
   DataRetrievalAgent,
   type DataRetrievalOutput,
 } from "./context";
+export { LayoutComposerAgent, extractSurfaces } from "./ui";

--- a/packages/agents/src/ui/index.ts
+++ b/packages/agents/src/ui/index.ts
@@ -1,0 +1,1 @@
+export { LayoutComposerAgent, extractSurfaces } from "./layout-composer";

--- a/packages/agents/src/ui/layout-composer.ts
+++ b/packages/agents/src/ui/layout-composer.ts
@@ -1,0 +1,164 @@
+import type { AgentOutput, SurfaceSpec, LayoutHints } from "@waibspace/types";
+import type {
+  ComposedLayout,
+  LayoutDirective,
+} from "@waibspace/ui-renderer-contract";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+
+const MAX_VISIBLE_SURFACES = 4;
+
+/**
+ * Extract SurfaceSpec objects from a list of agent outputs.
+ *
+ * Checks each output for:
+ * - Direct SurfaceSpec (has surfaceType and surfaceId)
+ * - Nested under a `surface` or `spec` property
+ */
+export function extractSurfaces(outputs: AgentOutput[]): SurfaceSpec[] {
+  const surfaces: SurfaceSpec[] = [];
+
+  for (const out of outputs) {
+    const value = out.output as Record<string, unknown> | undefined;
+    if (!value || typeof value !== "object") continue;
+
+    if (isSurfaceSpec(value)) {
+      surfaces.push(value as unknown as SurfaceSpec);
+      continue;
+    }
+
+    // Check nested `surface` or `spec` fields
+    for (const key of ["surface", "spec"] as const) {
+      const nested = value[key];
+      if (nested && typeof nested === "object" && isSurfaceSpec(nested as Record<string, unknown>)) {
+        surfaces.push(nested as unknown as SurfaceSpec);
+      }
+    }
+  }
+
+  return surfaces;
+}
+
+function isSurfaceSpec(obj: Record<string, unknown>): boolean {
+  return typeof obj["surfaceType"] === "string" && typeof obj["surfaceId"] === "string";
+}
+
+/**
+ * Deterministic layout composer agent.
+ *
+ * Collects SurfaceSpec outputs from prior UI agents, resolves position
+ * conflicts, generates LayoutDirectives, and returns a ComposedLayout.
+ */
+export class LayoutComposerAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "layout-composer",
+      name: "layout-composer",
+      type: "ui.layout-composer",
+      category: "ui",
+    });
+  }
+
+  async execute(
+    input: AgentInput,
+    context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+
+    // 1. Collect all SurfaceSpec objects from priorOutputs
+    const surfaces = extractSurfaces(input.priorOutputs);
+
+    this.log("Collected surfaces", { count: surfaces.length });
+
+    // 2. Sort by priority (highest first)
+    surfaces.sort((a, b) => b.priority - a.priority);
+
+    // 3. Resolve position conflicts
+    const resolved = this.resolvePositions(surfaces);
+
+    // 4. Generate LayoutDirectives (max 4 visible)
+    const layout = this.buildDirectives(resolved);
+
+    const endMs = Date.now();
+
+    // 5. Build ComposedLayout
+    const composed: ComposedLayout = {
+      surfaces: resolved,
+      layout,
+      timestamp: Date.now(),
+      traceId: context.traceId,
+    };
+
+    return {
+      ...this.createOutput(composed, 1.0, {
+        dataState: "transformed",
+        transformations: ["layout-composition"],
+        timestamp: startMs,
+      }),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+
+  /**
+   * Resolve position conflicts among surfaces.
+   *
+   * Rules:
+   * - Only one surface can be "primary"
+   * - "overlay" surfaces (e.g. approvals) always win their position
+   * - Extra primary-positioned surfaces get demoted to "secondary"
+   */
+  private resolvePositions(surfaces: SurfaceSpec[]): SurfaceSpec[] {
+    let hasPrimary = false;
+
+    return surfaces.map((surface) => {
+      const position = surface.layoutHints.position ?? "secondary";
+
+      // Overlays always keep their position
+      if (position === "overlay") {
+        return surface;
+      }
+
+      if (position === "primary") {
+        if (!hasPrimary) {
+          hasPrimary = true;
+          return surface;
+        }
+        // Demote duplicate primaries to secondary
+        return {
+          ...surface,
+          layoutHints: { ...surface.layoutHints, position: "secondary" as const },
+        };
+      }
+
+      return surface;
+    });
+  }
+
+  /**
+   * Map resolved surfaces to LayoutDirectives.
+   *
+   * - Assigns sequential position numbers (0 = first/top)
+   * - Width defaults to "full" for primary, "half" for secondary
+   * - Prominence defaults from layoutHints or "standard"
+   * - Max 4 visible surfaces
+   */
+  private buildDirectives(surfaces: SurfaceSpec[]): LayoutDirective[] {
+    return surfaces.slice(0, MAX_VISIBLE_SURFACES).map((surface, idx) => {
+      const hints: LayoutHints = surface.layoutHints;
+      const position = hints.position ?? "secondary";
+
+      const defaultWidth = position === "primary" ? "full" : "half";
+
+      return {
+        surfaceId: surface.surfaceId,
+        position: idx,
+        width: hints.width ?? defaultWidth,
+        prominence: hints.prominence ?? "standard",
+      };
+    });
+  }
+}

--- a/packages/agents/tsconfig.json
+++ b/packages/agents/tsconfig.json
@@ -9,6 +9,7 @@
     { "path": "../types" },
     { "path": "../event-bus" },
     { "path": "../model-provider" },
-    { "path": "../connectors" }
+    { "path": "../connectors" },
+    { "path": "../ui-renderer-contract" }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `LayoutComposerAgent` in `packages/agents/src/ui/` — a deterministic (no LLM) agent that collects `SurfaceSpec` outputs from prior UI agents, resolves position conflicts, and assembles a `ComposedLayout` with `LayoutDirective` entries
- Add `extractSurfaces` helper to pull `SurfaceSpec` objects from agent outputs (direct, or nested under `surface`/`spec` keys)
- Add `@waibspace/ui-renderer-contract` dependency to agents package (package.json + tsconfig references)
- Export `LayoutComposerAgent` and `extractSurfaces` from the agents barrel

## Key behaviors
- Surfaces sorted by priority (highest first)
- Only one surface can hold the "primary" position; extras demoted to "secondary"
- "overlay" surfaces always keep their position
- Max 4 visible surfaces get LayoutDirectives
- Width defaults: "full" for primary, "half" for secondary

## Test plan
- [ ] Verify typecheck passes (`npx tsc --build packages/agents`)
- [ ] Unit test: multiple SurfaceSpecs with conflicting primary positions — only first keeps primary
- [ ] Unit test: overlay surfaces are never demoted
- [ ] Unit test: max 4 directives generated even with more surfaces
- [ ] Unit test: extractSurfaces finds specs nested under `surface` and `spec` keys

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)