### PR TITLE
Implement surface renderer core

### DIFF
--- a/apps/frontend/src/components/AgentStatus.tsx
+++ b/apps/frontend/src/components/AgentStatus.tsx
@@ -1,0 +1,19 @@
+import type { AgentStatus as AgentStatusType } from "@waibspace/ui-renderer-contract";
+
+export function AgentStatus({ agents }: { agents: AgentStatusType[] }) {
+  const running = agents.filter((a) => a.state === "running");
+  const complete = agents.filter((a) => a.state === "complete");
+
+  if (agents.length === 0) return null;
+
+  return (
+    <div className="agent-status">
+      <span>
+        {complete.length}/{agents.length} agents complete
+      </span>
+      {running.length > 0 && (
+        <span className="agent-running">Processing...</span>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/SurfaceRenderer.tsx
+++ b/apps/frontend/src/components/SurfaceRenderer.tsx
@@ -1,0 +1,59 @@
+import type { ComposedLayout } from "@waibspace/ui-renderer-contract";
+import type { SurfaceAction } from "@waibspace/types";
+import { surfaceComponents } from "./surfaces/registry";
+import { GenericSurface } from "./surfaces/GenericSurface";
+
+interface SurfaceRendererProps {
+  layout: ComposedLayout | null;
+  onAction: (action: SurfaceAction) => void;
+  onInteraction: (
+    interaction: string,
+    target: string,
+    surfaceId: string,
+    surfaceType: string,
+    context?: unknown,
+  ) => void;
+}
+
+export function SurfaceRenderer({
+  layout,
+  onAction,
+  onInteraction,
+}: SurfaceRendererProps) {
+  if (!layout || layout.surfaces.length === 0) {
+    return <div className="surface-empty">No surfaces to display</div>;
+  }
+
+  return (
+    <div className="surface-grid">
+      {layout.surfaces.map((surface, index) => {
+        const directive = layout.layout.find(
+          (d) => d.surfaceId === surface.surfaceId,
+        );
+        const Component =
+          surfaceComponents[surface.surfaceType] || GenericSurface;
+        return (
+          <div
+            key={surface.surfaceId}
+            className={`surface-cell ${directive?.width || "full"} ${directive?.prominence || "standard"}`}
+            style={{ order: directive?.position ?? index }}
+          >
+            <Component
+              spec={surface}
+              onAction={onAction}
+              onInteraction={(interaction, target, context) =>
+                onInteraction(
+                  interaction,
+                  target,
+                  surface.surfaceId,
+                  surface.surfaceType,
+                  context,
+                )
+              }
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/surfaces/GenericSurface.tsx
+++ b/apps/frontend/src/components/surfaces/GenericSurface.tsx
@@ -1,0 +1,28 @@
+import type { SurfaceProps } from "./registry";
+
+export function GenericSurface({ spec, onAction }: SurfaceProps) {
+  return (
+    <div className="surface generic-surface">
+      <div className="surface-header">
+        <h3>{spec.title}</h3>
+        {spec.summary && <p className="surface-summary">{spec.summary}</p>}
+      </div>
+      <div className="surface-content">
+        <pre>{JSON.stringify(spec.data, null, 2)}</pre>
+      </div>
+      {spec.actions.length > 0 && (
+        <div className="surface-actions">
+          {spec.actions.map((action) => (
+            <button
+              key={action.id}
+              onClick={() => onAction(action)}
+              className={`action-btn risk-${action.riskClass}`}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/surfaces/registry.ts
+++ b/apps/frontend/src/components/surfaces/registry.ts
@@ -1,0 +1,14 @@
+import type { SurfaceSpec, SurfaceAction } from "@waibspace/types";
+
+export interface SurfaceProps {
+  spec: SurfaceSpec;
+  onAction: (action: SurfaceAction) => void;
+  onInteraction: (interaction: string, target: string, context?: unknown) => void;
+}
+
+// For now, all surface types use GenericSurface as placeholder
+// Real components will be built in P6-2
+export const surfaceComponents: Record<
+  string,
+  React.ComponentType<SurfaceProps>
+> = {};

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -1,8 +1,90 @@
+import { useEffect, useState, useCallback } from "react";
+import type { ComposedLayout, AgentStatus as AgentStatusType } from "@waibspace/ui-renderer-contract";
+import type { SurfaceAction } from "@waibspace/types";
+import { useWebSocket } from "../hooks/useWebSocket";
+import { SurfaceRenderer } from "../components/SurfaceRenderer";
+import { AgentStatus } from "../components/AgentStatus";
+import { ChatInput } from "../components/ChatInput";
+
+const WS_URL = `ws://${window.location.hostname}:${import.meta.env.VITE_WS_PORT || 3001}`;
+
 export default function HomePage() {
+  const { send, lastMessage, status } = useWebSocket(WS_URL);
+  const [layout, setLayout] = useState<ComposedLayout | null>(null);
+  const [agents, setAgents] = useState<AgentStatusType[]>([]);
+
+  useEffect(() => {
+    if (!lastMessage) return;
+
+    switch (lastMessage.type) {
+      case "surface.update":
+        setLayout(lastMessage.payload as ComposedLayout);
+        break;
+      case "status": {
+        const statusPayload = lastMessage.payload as { phase: string; agents: AgentStatusType[] };
+        setAgents(statusPayload.agents);
+        break;
+      }
+    }
+  }, [lastMessage]);
+
+  const handleAction = useCallback(
+    (action: SurfaceAction) => {
+      send("user.interaction", {
+        interaction: "action",
+        target: action.id,
+        context: action.payload,
+        timestamp: Date.now(),
+      });
+    },
+    [send],
+  );
+
+  const handleInteraction = useCallback(
+    (
+      interaction: string,
+      target: string,
+      surfaceId: string,
+      surfaceType: string,
+      context?: unknown,
+    ) => {
+      send("user.interaction", {
+        interaction,
+        target,
+        surfaceId,
+        surfaceType,
+        context,
+        timestamp: Date.now(),
+      });
+    },
+    [send],
+  );
+
+  const handleSend = useCallback(
+    (text: string) => {
+      send("user.message", { text });
+    },
+    [send],
+  );
+
   return (
     <div className="page home-page">
-      <h1>WaibSpace Home</h1>
-      <p className="placeholder">Surface renderer will be placed here.</p>
+      <div className="home-status-bar">
+        {status !== "connected" && (
+          <span className="connection-status">{status}...</span>
+        )}
+        <AgentStatus agents={agents} />
+      </div>
+
+      <SurfaceRenderer
+        layout={layout}
+        onAction={handleAction}
+        onInteraction={handleInteraction}
+      />
+
+      <div className="home-chat">
+        <ChatInput onSend={handleSend} />
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -152,3 +152,191 @@ body {
   color: var(--color-muted);
   font-size: 0.875rem;
 }
+
+/* Surface Grid */
+.surface-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1rem;
+}
+
+.surface-cell {
+  min-width: 0;
+}
+
+.surface-cell.full {
+  grid-column: span 12;
+}
+
+.surface-cell.half {
+  grid-column: span 6;
+}
+
+.surface-cell.third {
+  grid-column: span 4;
+}
+
+/* Surface Card */
+.surface {
+  padding: 1rem;
+  background: var(--color-surface);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 0.5rem;
+}
+
+.surface-header h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.surface-summary {
+  color: var(--color-muted);
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+}
+
+.surface-content {
+  margin-bottom: 0.75rem;
+}
+
+.surface-content pre {
+  font-size: 0.8125rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-muted);
+  background: var(--color-bg);
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  overflow-x: auto;
+}
+
+.surface-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.action-btn {
+  padding: 0.375rem 0.75rem;
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.action-btn:hover {
+  opacity: 0.85;
+}
+
+.action-btn.risk-A {
+  background: #22c55e;
+  color: #fff;
+}
+
+.action-btn.risk-B {
+  background: #eab308;
+  color: #000;
+}
+
+.action-btn.risk-C {
+  background: #ef4444;
+  color: #fff;
+}
+
+/* Surface Empty */
+.surface-empty {
+  color: var(--color-muted);
+  text-align: center;
+  padding: 2rem;
+}
+
+/* Agent Status */
+.agent-status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.8125rem;
+  color: var(--color-muted);
+}
+
+.agent-running {
+  color: var(--color-accent);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+/* Home Page */
+.home-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: 1rem;
+}
+
+.home-status-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 1.5rem;
+}
+
+.connection-status {
+  font-size: 0.8125rem;
+  color: var(--color-muted);
+}
+
+.home-chat {
+  margin-top: auto;
+}
+
+/* Chat Input */
+.chat-input {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.chat-input textarea {
+  flex: 1;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.9375rem;
+  font-family: inherit;
+  resize: none;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.chat-input textarea:focus {
+  border-color: var(--color-accent);
+}
+
+.chat-input button {
+  padding: 0.625rem 1rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: var(--color-accent);
+  color: #fff;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.chat-input button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.chat-input button:not(:disabled):hover {
+  opacity: 0.85;
+}


### PR DESCRIPTION
## Summary
- Add `SurfaceRenderer` component that maps `ComposedLayout` surfaces into a responsive CSS grid, resolving each surface type from the component registry with `GenericSurface` as fallback
- Add `GenericSurface` fallback renderer displaying title, summary, JSON data, and risk-classified action buttons
- Add `AgentStatus` component showing agent completion progress with a processing indicator
- Update `HomePage` to connect via WebSocket, track `ComposedLayout` and `AgentStatus[]` state from server messages, and render `SurfaceRenderer` + `ChatInput`
- Add CSS for surface grid (full/half/third widths), surface cards, action buttons with risk-class colors, agent status bar, and chat input

Closes #30

## Test plan
- [ ] Verify `bunx vite build` passes (confirmed locally)
- [ ] Verify `SurfaceRenderer` renders empty state when layout is null
- [ ] Verify `GenericSurface` renders title, summary, data, and action buttons
- [ ] Verify action buttons apply correct risk-class colors (A=green, B=yellow, C=red)
- [ ] Verify grid layout responds to width directives (full, half, third)
- [ ] Verify `AgentStatus` shows progress and hides when no agents present
- [ ] Verify HomePage connects WebSocket and updates layout on `surface.update` messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)