### PR TITLE
feat: home surface with welcome state and provenance display

### DIFF
--- a/apps/frontend/src/components/ProvenanceBadge.tsx
+++ b/apps/frontend/src/components/ProvenanceBadge.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import type { ProvenanceMetadata } from "@waibspace/types";
+
+function formatTimeAgo(timestamp: number): string {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 60) return "just now";
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  return `${Math.floor(seconds / 86400)}d ago`;
+}
+
+export function ProvenanceBadge({
+  provenance,
+}: {
+  provenance: ProvenanceMetadata;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const trustColor = {
+    trusted: "#22c55e",
+    "semi-trusted": "#eab308",
+    untrusted: "#f97316",
+  }[provenance.trustLevel];
+
+  const trustIcon = {
+    trusted: "\u2713",
+    "semi-trusted": "\u26A0",
+    untrusted: "\u26A1",
+  }[provenance.trustLevel];
+
+  const timeAgo = formatTimeAgo(provenance.timestamp);
+
+  return (
+    <div
+      className="provenance-badge"
+      onClick={() => setExpanded(!expanded)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") setExpanded(!expanded);
+      }}
+    >
+      <span className="trust-indicator" style={{ color: trustColor }}>
+        {trustIcon}
+      </span>
+      <span className="provenance-source">from {provenance.sourceType}</span>
+      <span className="provenance-freshness">{timeAgo}</span>
+      {expanded && (
+        <div className="provenance-details">
+          <div>Trust: {provenance.trustLevel}</div>
+          <div>State: {provenance.dataState}</div>
+          {provenance.transformations?.length && (
+            <div>
+              Transforms: {provenance.transformations.join(" \u2192 ")}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/WelcomeState.tsx
+++ b/apps/frontend/src/components/WelcomeState.tsx
@@ -1,0 +1,42 @@
+function getSuggestions(hour: number): string[] {
+  if (hour < 12) {
+    return ["Check email", "Today's schedule"];
+  }
+  if (hour < 17) {
+    return ["Inbox summary", "Upcoming meetings"];
+  }
+  return ["Tomorrow's plan", "Unread messages"];
+}
+
+export function WelcomeState({
+  onSuggest,
+}: {
+  onSuggest: (text: string) => void;
+}) {
+  const hour = new Date().getHours();
+  const greeting =
+    hour < 12
+      ? "Good morning"
+      : hour < 17
+        ? "Good afternoon"
+        : "Good evening";
+  const suggestions = getSuggestions(hour);
+
+  return (
+    <div className="welcome">
+      <h2>{greeting}</h2>
+      <p>What would you like to do?</p>
+      <div className="suggestions">
+        {suggestions.map((s) => (
+          <button
+            key={s}
+            onClick={() => onSuggest(s)}
+            className="suggestion-btn"
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/surfaces/GenericSurface.tsx
+++ b/apps/frontend/src/components/surfaces/GenericSurface.tsx
@@ -1,10 +1,14 @@
 import type { SurfaceProps } from "./registry";
+import { ProvenanceBadge } from "../ProvenanceBadge";
 
 export function GenericSurface({ spec, onAction }: SurfaceProps) {
   return (
     <div className="surface generic-surface">
       <div className="surface-header">
-        <h3>{spec.title}</h3>
+        <div className="surface-header-top">
+          <h3>{spec.title}</h3>
+          <ProvenanceBadge provenance={spec.provenance} />
+        </div>
         {spec.summary && <p className="surface-summary">{spec.summary}</p>}
       </div>
       <div className="surface-content">

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useState, useCallback } from "react";
-import type { ComposedLayout, AgentStatus as AgentStatusType } from "@waibspace/ui-renderer-contract";
+import type {
+  ComposedLayout,
+  AgentStatus as AgentStatusType,
+} from "@waibspace/ui-renderer-contract";
 import type { SurfaceAction } from "@waibspace/types";
 import { useWebSocket } from "../hooks/useWebSocket";
 import { SurfaceRenderer } from "../components/SurfaceRenderer";
 import { AgentStatus } from "../components/AgentStatus";
 import { ChatInput } from "../components/ChatInput";
+import { WelcomeState } from "../components/WelcomeState";
 
 const WS_URL = `ws://${window.location.hostname}:${import.meta.env.VITE_WS_PORT || 3001}`;
 
@@ -12,6 +16,15 @@ export default function HomePage() {
   const { send, lastMessage, status } = useWebSocket(WS_URL);
   const [layout, setLayout] = useState<ComposedLayout | null>(null);
   const [agents, setAgents] = useState<AgentStatusType[]>([]);
+  const [hasRequestedAmbient, setHasRequestedAmbient] = useState(false);
+
+  // Request ambient state on initial connection
+  useEffect(() => {
+    if (status === "connected" && !hasRequestedAmbient) {
+      send("user.message", { text: "show ambient state" });
+      setHasRequestedAmbient(true);
+    }
+  }, [status, hasRequestedAmbient, send]);
 
   useEffect(() => {
     if (!lastMessage) return;
@@ -21,7 +34,10 @@ export default function HomePage() {
         setLayout(lastMessage.payload as ComposedLayout);
         break;
       case "status": {
-        const statusPayload = lastMessage.payload as { phase: string; agents: AgentStatusType[] };
+        const statusPayload = lastMessage.payload as {
+          phase: string;
+          agents: AgentStatusType[];
+        };
         setAgents(statusPayload.agents);
         break;
       }
@@ -67,20 +83,35 @@ export default function HomePage() {
     [send],
   );
 
+  const hasSurfaces = layout && layout.surfaces.length > 0;
+
   return (
     <div className="page home-page">
       <div className="home-status-bar">
-        {status !== "connected" && (
-          <span className="connection-status">{status}...</span>
-        )}
+        <span
+          className={`connection-dot ${status === "connected" ? "connected" : status === "connecting" ? "connecting" : "disconnected"}`}
+        />
+        <span className="connection-label">
+          {status === "connected"
+            ? "Connected"
+            : status === "connecting"
+              ? "Connecting..."
+              : "Disconnected"}
+        </span>
         <AgentStatus agents={agents} />
       </div>
 
-      <SurfaceRenderer
-        layout={layout}
-        onAction={handleAction}
-        onInteraction={handleInteraction}
-      />
+      <div className="home-content">
+        {hasSurfaces ? (
+          <SurfaceRenderer
+            layout={layout}
+            onAction={handleAction}
+            onInteraction={handleInteraction}
+          />
+        ) : (
+          <WelcomeState onSuggest={handleSend} />
+        )}
+      </div>
 
       <div className="home-chat">
         <ChatInput onSend={handleSend} />

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -340,3 +340,136 @@ body {
 .chat-input button:not(:disabled):hover {
   opacity: 0.85;
 }
+
+/* Connection Status Indicator */
+.connection-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.connection-dot.connected {
+  background: #22c55e;
+}
+
+.connection-dot.connecting {
+  background: #eab308;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.connection-dot.disconnected {
+  background: #ef4444;
+}
+
+.connection-label {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
+/* Home Content */
+.home-content {
+  flex: 1;
+  overflow-y: auto;
+}
+
+/* Welcome State */
+.welcome {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 4rem 1rem;
+  gap: 0.75rem;
+}
+
+.welcome h2 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.welcome p {
+  color: var(--color-muted);
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.suggestions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.suggestion-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.5rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+}
+
+.suggestion-btn:hover {
+  border-color: var(--color-accent);
+  background: rgba(99, 102, 241, 0.1);
+}
+
+/* Provenance Badge */
+.provenance-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--color-muted);
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+}
+
+.trust-indicator {
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.provenance-source {
+  white-space: nowrap;
+}
+
+.provenance-freshness {
+  opacity: 0.7;
+}
+
+.provenance-details {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 10;
+  margin-top: 0.375rem;
+  padding: 0.625rem 0.75rem;
+  background: var(--color-surface);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+/* Surface Header Top (with provenance) */
+.surface-header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- **P6-5**: Updated `HomePage` to be the full ambient landing experience -- requests ambient state on connect, shows connection status indicator, renders `WelcomeState` when no surfaces are available (with time-of-day greetings and contextual quick-action suggestions), and always shows chat input at bottom
- **P6-6**: Created `ProvenanceBadge` component with trust-level color coding, source type, freshness display, and expandable details panel; integrated into `GenericSurface` header
- Added CSS styles for welcome state, provenance badges, connection status dot, and suggestion buttons

Closes #34, Closes #36

## Test plan
- [ ] Verify HomePage shows WelcomeState with correct greeting based on time of day
- [ ] Verify suggestion buttons dispatch messages via WebSocket
- [ ] Verify connection status dot reflects WebSocket state (green/yellow/red)
- [ ] Verify surfaces render with ProvenanceBadge in header showing trust indicator, source, and freshness
- [ ] Verify clicking ProvenanceBadge expands to show trust level, data state, and transformations
- [ ] Verify ambient state request is sent on initial connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)