### PR TITLE
feat(memory): implement MemoryStore system

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,7 @@
       "name": "@waibspace/memory",
       "version": "0.0.1",
       "dependencies": {
+        "@waibspace/event-bus": "workspace:*",
         "@waibspace/types": "workspace:*",
       },
     },

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
+    "@waibspace/event-bus": "workspace:*",
     "@waibspace/types": "workspace:*"
   },
   "scripts": {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,1 +1,1 @@
-// packages/memory
+export { MemoryStore } from "./memory-store";

--- a/packages/memory/src/memory-store.ts
+++ b/packages/memory/src/memory-store.ts
@@ -1,0 +1,124 @@
+import type { MemoryEntry, MemoryCategory } from "@waibspace/types";
+import { EventBus, createEvent } from "@waibspace/event-bus";
+
+export class MemoryStore {
+  private store: Map<string, MemoryEntry>;
+  private dirty: boolean;
+  private autoSaveInterval?: ReturnType<typeof setInterval>;
+
+  constructor(
+    private persistPath?: string,
+    private eventBus?: EventBus,
+  ) {
+    this.store = new Map();
+    this.dirty = false;
+  }
+
+  // CRUD
+
+  set(
+    category: MemoryCategory,
+    key: string,
+    value: unknown,
+    source: string,
+  ): MemoryEntry {
+    const id = `${category}:${key}`;
+    const now = Date.now();
+    const existing = this.store.get(id);
+    const entry: MemoryEntry = {
+      id,
+      category,
+      key,
+      value,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      source,
+    };
+    this.store.set(id, entry);
+    this.dirty = true;
+    if (this.eventBus) {
+      this.eventBus.emit(
+        createEvent("memory.updated", { entry }, "memory-store"),
+      );
+    }
+    return entry;
+  }
+
+  get(category: MemoryCategory, key: string): MemoryEntry | undefined {
+    return this.store.get(`${category}:${key}`);
+  }
+
+  getAll(category: MemoryCategory): MemoryEntry[] {
+    return Array.from(this.store.values()).filter(
+      (e) => e.category === category,
+    );
+  }
+
+  update(id: string, value: unknown): MemoryEntry | undefined {
+    const entry = this.store.get(id);
+    if (!entry) return undefined;
+    entry.value = value;
+    entry.updatedAt = Date.now();
+    this.dirty = true;
+    return entry;
+  }
+
+  delete(id: string): boolean {
+    this.dirty = true;
+    return this.store.delete(id);
+  }
+
+  // Query
+
+  search(category: MemoryCategory, query: string): MemoryEntry[] {
+    return this.getAll(category).filter(
+      (e) => e.key.includes(query) || JSON.stringify(e.value).includes(query),
+    );
+  }
+
+  getRecent(category: MemoryCategory, limit: number): MemoryEntry[] {
+    return this.getAll(category)
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .slice(0, limit);
+  }
+
+  // Persistence (JSON file)
+
+  async save(): Promise<void> {
+    if (!this.persistPath || !this.dirty) return;
+    const data = Array.from(this.store.values());
+    await Bun.write(this.persistPath, JSON.stringify(data, null, 2));
+    this.dirty = false;
+  }
+
+  async load(): Promise<void> {
+    if (!this.persistPath) return;
+    try {
+      const file = Bun.file(this.persistPath);
+      if (await file.exists()) {
+        const data: MemoryEntry[] = JSON.parse(await file.text());
+        for (const entry of data) {
+          this.store.set(entry.id, entry);
+        }
+      }
+    } catch {
+      // File doesn't exist or is corrupt — start fresh
+    }
+  }
+
+  // Auto-save every 30 seconds if dirty
+
+  startAutoSave(intervalMs = 30000): void {
+    this.autoSaveInterval = setInterval(() => this.save(), intervalMs);
+  }
+
+  stopAutoSave(): void {
+    if (this.autoSaveInterval) clearInterval(this.autoSaveInterval);
+  }
+
+  // Stats
+
+  size(): number {
+    return this.store.size;
+  }
+}

--- a/packages/memory/tsconfig.json
+++ b/packages/memory/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": ["src"],
   "references": [
-    { "path": "../types" }
+    { "path": "../types" },
+    { "path": "../event-bus" }
   ]
 }


### PR DESCRIPTION
## Summary
- Implement `MemoryStore` class in `packages/memory/src/memory-store.ts` with full CRUD operations (`set`, `get`, `getAll`, `update`, `delete`)
- Add search and query capabilities (`search`, `getRecent`) for filtering memory entries
- Add JSON file persistence with `save`/`load` and auto-save support (30s interval)
- Integrate with `@waibspace/event-bus` to emit `memory.updated` events on writes
- Update `package.json` and `tsconfig.json` to wire up `@waibspace/event-bus` dependency

## Test plan
- [ ] Verify `MemoryStore` CRUD operations work correctly
- [ ] Verify search filters by key and serialized value content
- [ ] Verify `getRecent` returns entries sorted by `updatedAt` descending
- [ ] Verify persistence round-trips through `save()` and `load()`
- [ ] Verify auto-save starts/stops correctly
- [ ] Verify `memory.updated` events are emitted when an EventBus is provided
- [ ] Verify `bunx tsc --build` passes for the memory package

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)