### PR TITLE
feat: implement background task scheduler

### DIFF
--- a/apps/backend/src/background/index.ts
+++ b/apps/backend/src/background/index.ts
@@ -1,0 +1,2 @@
+export { BackgroundTaskScheduler } from "./scheduler";
+export type { BackgroundTask, TaskExecution } from "./types";

--- a/apps/backend/src/background/scheduler.ts
+++ b/apps/backend/src/background/scheduler.ts
@@ -1,0 +1,126 @@
+import { EventBus, createEvent } from "@waibspace/event-bus";
+import type { Orchestrator } from "@waibspace/orchestrator";
+import type { MemoryStore } from "@waibspace/memory";
+import type { BackgroundTask, TaskExecution } from "./types";
+
+const MAX_HISTORY = 50;
+
+export class BackgroundTaskScheduler {
+  private tasks = new Map<string, BackgroundTask>();
+  private timers = new Map<string, ReturnType<typeof setInterval>>();
+  private history = new Map<string, TaskExecution[]>();
+  private running = new Set<string>();
+
+  constructor(
+    private eventBus: EventBus,
+    private orchestrator: Orchestrator,
+    private memoryStore: MemoryStore,
+  ) {}
+
+  register(task: BackgroundTask): void {
+    this.tasks.set(task.id, task);
+    this.history.set(task.id, []);
+  }
+
+  unregister(taskId: string): void {
+    this.disable(taskId);
+    this.tasks.delete(taskId);
+    this.history.delete(taskId);
+  }
+
+  enable(taskId: string): void {
+    const task = this.tasks.get(taskId);
+    if (!task) return;
+    task.enabled = true;
+    this.scheduleTask(task);
+  }
+
+  disable(taskId: string): void {
+    const task = this.tasks.get(taskId);
+    if (task) task.enabled = false;
+
+    const timer = this.timers.get(taskId);
+    if (timer) {
+      clearInterval(timer);
+      this.timers.delete(taskId);
+    }
+  }
+
+  start(): void {
+    for (const task of this.tasks.values()) {
+      if (task.enabled) this.scheduleTask(task);
+    }
+  }
+
+  stop(): void {
+    for (const timer of this.timers.values()) clearInterval(timer);
+    this.timers.clear();
+  }
+
+  private scheduleTask(task: BackgroundTask): void {
+    // Clear any existing timer for this task
+    const existing = this.timers.get(task.id);
+    if (existing) clearInterval(existing);
+
+    const timer = setInterval(() => this.executeTask(task.id), task.intervalMs);
+    this.timers.set(task.id, timer);
+  }
+
+  private async executeTask(taskId: string): Promise<void> {
+    const task = this.tasks.get(taskId);
+    if (!task || !task.enabled || this.running.has(taskId)) return;
+
+    this.running.add(taskId);
+    const startTime = Date.now();
+
+    try {
+      const event = createEvent(
+        "background.task.triggered",
+        {
+          taskId: task.id,
+          taskName: task.name,
+          allowedConnectors: task.allowedConnectors,
+          actionClass: task.actionClass,
+        },
+        "background-scheduler",
+      );
+
+      await this.orchestrator.processEvent(event);
+
+      const execution: TaskExecution = {
+        taskId,
+        timestamp: startTime,
+        durationMs: Date.now() - startTime,
+        success: true,
+      };
+      task.lastRun = startTime;
+      this.history.get(taskId)?.push(execution);
+    } catch (error) {
+      const execution: TaskExecution = {
+        taskId,
+        timestamp: startTime,
+        durationMs: Date.now() - startTime,
+        success: false,
+        error: String(error),
+      };
+      task.lastError = String(error);
+      this.history.get(taskId)?.push(execution);
+    } finally {
+      this.running.delete(taskId);
+    }
+
+    // Keep only last N executions per task
+    const hist = this.history.get(taskId);
+    if (hist && hist.length > MAX_HISTORY) {
+      this.history.set(taskId, hist.slice(-MAX_HISTORY));
+    }
+  }
+
+  getStatus(): BackgroundTask[] {
+    return Array.from(this.tasks.values());
+  }
+
+  getHistory(taskId: string): TaskExecution[] {
+    return this.history.get(taskId) ?? [];
+  }
+}

--- a/apps/backend/src/background/types.ts
+++ b/apps/backend/src/background/types.ts
@@ -1,0 +1,24 @@
+import type { RiskClass } from "@waibspace/types";
+
+export interface BackgroundTask {
+  id: string;
+  name: string;
+  description: string;
+  intervalMs: number;
+  enabled: boolean;
+  allowedConnectors: string[];
+  actionClass: RiskClass;
+  outputTarget: string; // "surface" | "memory" | "notification"
+  lastRun?: number;
+  lastResult?: unknown;
+  lastError?: string;
+}
+
+export interface TaskExecution {
+  taskId: string;
+  timestamp: number;
+  durationMs: number;
+  success: boolean;
+  result?: unknown;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
- Add `BackgroundTask` and `TaskExecution` types defining the task shape and execution records
- Implement `BackgroundTaskScheduler` class with interval-based scheduling, overlap prevention, and capped execution history (last 50 runs per task)
- Integrate with `@waibspace/event-bus`, `@waibspace/orchestrator`, and `@waibspace/memory` for event-driven task processing
- Barrel export from `apps/backend/src/background/index.ts`

Closes #39

## Test plan
- [ ] Verify `register` / `unregister` correctly add and remove tasks
- [ ] Verify `enable` / `disable` start and stop interval timers
- [ ] Verify `start` schedules all enabled tasks and `stop` clears all timers
- [ ] Verify overlapping executions are prevented via the `running` guard
- [ ] Verify execution history is capped at 50 entries per task
- [ ] Verify failed task executions record the error string

🤖 Generated with [Claude Code](https://claude.com/claude-code)