### PR TITLE
feat(agents): implement MemoryRetrievalAgent

### DIFF
--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -8,6 +8,7 @@
     "@waibspace/types": "workspace:*",
     "@waibspace/event-bus": "workspace:*",
     "@waibspace/model-provider": "workspace:*",
+    "@waibspace/memory": "workspace:*",
     "@waibspace/connectors": "workspace:*",
     "@waibspace/surfaces": "workspace:*",
     "@waibspace/ui-renderer-contract": "workspace:*"

--- a/packages/agents/src/context/index.ts
+++ b/packages/agents/src/context/index.ts
@@ -10,3 +10,7 @@ export {
   DataRetrievalAgent,
   type DataRetrievalOutput,
 } from "./data-retrieval";
+export {
+  MemoryRetrievalAgent,
+  type MemoryRetrievalOutput,
+} from "./memory-retrieval";

--- a/packages/agents/src/context/memory-retrieval.ts
+++ b/packages/agents/src/context/memory-retrieval.ts
@@ -1,0 +1,134 @@
+import type { AgentOutput, MemoryEntry, MemoryCategory } from "@waibspace/types";
+import type { MemoryStore } from "@waibspace/memory";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+import type { IntentClassification } from "../reasoning";
+
+const MAX_ENTRIES_PER_CATEGORY = 20;
+
+export interface MemoryRetrievalOutput {
+  memories: MemoryEntry[];
+  categories: string[];
+  totalRetrieved: number;
+}
+
+/**
+ * Deterministic (rule-based) agent that retrieves relevant memories
+ * from the MemoryStore based on the current intent classification.
+ *
+ * Runs early in the context phase so downstream agents have memory available.
+ */
+export class MemoryRetrievalAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "memory-retrieval",
+      name: "memory-retrieval",
+      type: "context.memory-retrieval",
+      category: "context",
+    });
+  }
+
+  async execute(
+    input: AgentInput,
+    context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+
+    const memoryStore = context.config?.["memoryStore"] as
+      | MemoryStore
+      | undefined;
+
+    if (!memoryStore) {
+      this.log("No MemoryStore in context — returning empty result");
+      return this.buildOutput([], startMs);
+    }
+
+    const intent = this.findIntentClassification(input);
+    const categoriesToRetrieve: MemoryCategory[] = ["profile"];
+
+    if (intent) {
+      const additional = this.categoriesForIntent(intent.intentCategory);
+      for (const cat of additional) {
+        if (!categoriesToRetrieve.includes(cat)) {
+          categoriesToRetrieve.push(cat);
+        }
+      }
+      this.log("Retrieving memories for intent", {
+        intentCategory: intent.intentCategory,
+        memoryCategories: categoriesToRetrieve,
+      });
+    } else {
+      this.log(
+        "No intent classification found — falling back to profile memory only",
+      );
+    }
+
+    const memories: MemoryEntry[] = [];
+
+    for (const category of categoriesToRetrieve) {
+      const entries = memoryStore.getRecent(category, MAX_ENTRIES_PER_CATEGORY);
+      memories.push(...entries);
+    }
+
+    return this.buildOutput(memories, startMs);
+  }
+
+  /**
+   * Map an intent category string to the MemoryCategories we should retrieve.
+   * Profile is always included by the caller, so we only return additional ones.
+   */
+  private categoriesForIntent(intentCategory: string): MemoryCategory[] {
+    switch (intentCategory) {
+      case "email":
+        return ["task", "interaction"];
+      case "calendar":
+        return ["task"];
+      case "discovery":
+        return ["interaction"];
+      default:
+        return [];
+    }
+  }
+
+  private findIntentClassification(
+    input: AgentInput,
+  ): IntentClassification | undefined {
+    for (const prior of input.priorOutputs) {
+      if (prior.category === "reasoning" && prior.output) {
+        const output = prior.output as Record<string, unknown>;
+        if ("primaryIntent" in output && "intentCategory" in output) {
+          return output as unknown as IntentClassification;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private buildOutput(
+    memories: MemoryEntry[],
+    startMs: number,
+  ): AgentOutput {
+    const categories = Array.from(new Set(memories.map((m) => m.category)));
+    const endMs = Date.now();
+
+    const output: MemoryRetrievalOutput = {
+      memories,
+      categories,
+      totalRetrieved: memories.length,
+    };
+
+    return {
+      ...this.createOutput(output, memories.length > 0 ? 1.0 : 0.5, {
+        sourceType: "memory",
+        dataState: "raw",
+        freshness: "recent",
+        timestamp: startMs,
+      }),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -29,6 +29,8 @@ export {
   type FinalizedPlan,
   DataRetrievalAgent,
   type DataRetrievalOutput,
+  MemoryRetrievalAgent,
+  type MemoryRetrievalOutput,
 } from "./context";
 export {
   InboxSurfaceAgent,

--- a/packages/agents/tsconfig.json
+++ b/packages/agents/tsconfig.json
@@ -9,6 +9,7 @@
     { "path": "../types" },
     { "path": "../event-bus" },
     { "path": "../model-provider" },
+    { "path": "../memory" },
     { "path": "../connectors" },
     { "path": "../surfaces" },
     { "path": "../ui-renderer-contract" }


### PR DESCRIPTION
## Summary
- Add `MemoryRetrievalAgent` in `packages/agents/src/context/memory-retrieval.ts` — a deterministic, rule-based context agent that retrieves relevant memories from `MemoryStore` based on intent classification
- Maps intent categories (`email` → profile+task+interaction, `calendar` → profile+task, `discovery` → profile+interaction) with profile memory always included as fallback
- Gracefully handles missing MemoryStore (new user) and missing intent classification
- Add `@waibspace/memory` dependency to agents package and update exports

Closes #37

## Test plan
- [ ] Verify typecheck passes for agents package
- [ ] Test with no MemoryStore in context returns empty result
- [ ] Test with no prior intent outputs returns profile-only memories
- [ ] Test email/calendar/discovery intents retrieve correct memory categories
- [ ] Test max 20 entries per category limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)