### PR TITLE
Wire end-to-end intent URL discovery flow

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -7,7 +7,17 @@ import {
   URLIntentParserAgent,
   IntentAgent,
   ConfidenceScorerAgent,
+  ContextPlannerAgent,
+  ConnectorSelectionAgent,
+  DataRetrievalAgent,
+  DiscoverySurfaceAgent,
+  LayoutComposerAgent,
+  ProvenanceAnnotatorAgent,
 } from "@waibspace/agents";
+import {
+  ConnectorRegistry,
+  WebFetchConnector,
+} from "@waibspace/connectors";
 import {
   ModelProviderRegistry,
   AnthropicProvider,
@@ -24,12 +34,33 @@ const bus = new EventBus();
 const modelRegistry = new ModelProviderRegistry();
 modelRegistry.register(new AnthropicProvider());
 
+// ---------- 2b. Connector Registry ----------
+const connectorRegistry = new ConnectorRegistry();
+const webFetchConnector = new WebFetchConnector("web-fetch", "WebFetch");
+await webFetchConnector.connect();
+connectorRegistry.register(webFetchConnector);
+
+console.log(
+  `[backend] Registered ${connectorRegistry.getAll().length} connector(s): ${connectorRegistry.getAll().map((c) => c.id).join(", ")}`,
+);
+
 // ---------- 3. Agent Registry ----------
 const agentRegistry = new AgentRegistry();
+// Perception
 agentRegistry.register(new InputNormalizerAgent());
 agentRegistry.register(new URLIntentParserAgent());
+// Reasoning
 agentRegistry.register(new IntentAgent());
 agentRegistry.register(new ConfidenceScorerAgent());
+// Context
+agentRegistry.register(new ContextPlannerAgent());
+agentRegistry.register(new ConnectorSelectionAgent());
+agentRegistry.register(new DataRetrievalAgent());
+// UI
+agentRegistry.register(new DiscoverySurfaceAgent());
+agentRegistry.register(new LayoutComposerAgent());
+// Safety
+agentRegistry.register(new ProvenanceAnnotatorAgent());
 
 console.log(
   `[backend] Registered ${agentRegistry.getAll().length} agents: ${agentRegistry.getAll().map((a) => a.id).join(", ")}`,
@@ -44,6 +75,7 @@ memoryStore.startAutoSave();
 const orchestrator = new Orchestrator(bus, agentRegistry, {
   modelProvider: modelRegistry,
   memoryStore,
+  connectorRegistry,
 });
 
 // ---------- 6. Memory Update Pipeline ----------

--- a/apps/frontend/src/pages/IntentResolutionPage.tsx
+++ b/apps/frontend/src/pages/IntentResolutionPage.tsx
@@ -1,54 +1,180 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useLocation } from "react-router-dom";
-import type { SurfaceSpec } from "@waibspace/types";
+import type {
+  ComposedLayout,
+  AgentStatus as AgentStatusType,
+} from "@waibspace/ui-renderer-contract";
+import type { SurfaceAction } from "@waibspace/types";
 import { useWebSocket } from "../hooks/useWebSocket";
+import { SurfaceRenderer } from "../components/SurfaceRenderer";
+import { AgentStatus } from "../components/AgentStatus";
+
+const WS_URL = `ws://${window.location.hostname}:${import.meta.env.VITE_WS_PORT || 3001}`;
 
 export default function IntentResolutionPage() {
   const location = useLocation();
-  const { send, lastMessage, status } = useWebSocket("ws://localhost:3001/ws");
-  const [surfaces, setSurfaces] = useState<SurfaceSpec[]>([]);
+  const { send, lastMessage, status } = useWebSocket(WS_URL);
+  const [layout, setLayout] = useState<ComposedLayout | null>(null);
+  const [agents, setAgents] = useState<AgentStatusType[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [hasSent, setHasSent] = useState(false);
 
   // Extract intent from path
   const intentPath = location.pathname.replace(/^\//, "");
   const intentQuery = intentPath.replace(/[-_]/g, " ");
 
+  // Send intent to backend once connected
   useEffect(() => {
-    // Send intent to backend
-    send("user.intent.url", { path: intentPath, raw: location.pathname });
-    setLoading(true);
-  }, [intentPath, send]);
+    if (status === "connected" && !hasSent) {
+      send("user.intent.url", { path: intentPath, raw: location.pathname });
+      setLoading(true);
+      setError(null);
+      setHasSent(true);
+    }
+  }, [status, hasSent, intentPath, location.pathname, send]);
 
+  // Reset on path change
   useEffect(() => {
-    // Listen for surface responses
-    if (lastMessage?.type === "surface.update") {
-      const payload = lastMessage.payload as { surfaces: SurfaceSpec[] };
-      setSurfaces(payload.surfaces);
-      setLoading(false);
+    setHasSent(false);
+    setLayout(null);
+    setLoading(true);
+    setError(null);
+  }, [intentPath]);
+
+  // Listen for responses
+  useEffect(() => {
+    if (!lastMessage) return;
+
+    switch (lastMessage.type) {
+      case "surface.update":
+        setLayout(lastMessage.payload as ComposedLayout);
+        setLoading(false);
+        break;
+      case "status": {
+        const statusPayload = lastMessage.payload as {
+          phase: string;
+          agents: AgentStatusType[];
+        };
+        setAgents(statusPayload.agents);
+        break;
+      }
+      case "error": {
+        const errorPayload = lastMessage.payload as { message: string };
+        setError(errorPayload.message);
+        setLoading(false);
+        break;
+      }
     }
   }, [lastMessage]);
 
+  const handleAction = useCallback(
+    (action: SurfaceAction) => {
+      send("user.interaction", {
+        interaction: "action",
+        target: action.id,
+        context: action.payload,
+        timestamp: Date.now(),
+      });
+    },
+    [send],
+  );
+
+  const handleInteraction = useCallback(
+    (
+      interaction: string,
+      target: string,
+      surfaceId: string,
+      surfaceType: string,
+      context?: unknown,
+    ) => {
+      send("user.interaction", {
+        interaction,
+        target,
+        surfaceId,
+        surfaceType,
+        context,
+        timestamp: Date.now(),
+      });
+    },
+    [send],
+  );
+
+  const handleRetry = useCallback(() => {
+    setHasSent(false);
+    setLayout(null);
+    setLoading(true);
+    setError(null);
+  }, []);
+
+  const hasSurfaces = layout && layout.surfaces.length > 0;
+
   return (
-    <div className="intent-resolution">
+    <div className="page intent-resolution">
       <div className="intent-header">
-        <span className="intent-label">Interpreting:</span>
-        <span className="intent-query">{intentQuery}</span>
+        <div className="intent-header-content">
+          <span className="intent-label">Resolving:</span>
+          <span className="intent-query">{intentQuery}</span>
+        </div>
+        <div className="intent-status-bar">
+          <span
+            className={`connection-dot ${status === "connected" ? "connected" : status === "connecting" ? "connecting" : "disconnected"}`}
+          />
+          <AgentStatus agents={agents} />
+        </div>
       </div>
+
       {loading ? (
         <div className="intent-loading">
-          <p>Analyzing your intent...</p>
+          <div className="intent-loading-animation">
+            <div className="intent-pulse-ring" />
+            <div className="intent-pulse-ring delay-1" />
+            <div className="intent-pulse-ring delay-2" />
+          </div>
+          <p className="intent-loading-title">
+            Analyzing your intent...
+          </p>
+          <p className="intent-loading-detail">
+            <span className="intent-loading-path">/{intentPath}</span>
+          </p>
           {status === "connected" && (
-            <p className="agent-status">Agents working...</p>
+            <p className="intent-loading-agents">
+              Agents working on your request
+            </p>
+          )}
+          {status === "connecting" && (
+            <p className="intent-loading-agents">
+              Connecting to backend...
+            </p>
           )}
         </div>
-      ) : (
+      ) : error ? (
+        <div className="intent-error">
+          <p className="intent-error-message">{error}</p>
+          <button className="action-btn risk-A" onClick={handleRetry}>
+            Retry
+          </button>
+        </div>
+      ) : hasSurfaces ? (
         <div className="intent-results">
-          {surfaces.map((s) => (
-            <div key={s.surfaceId} className="surface-placeholder">
-              <h3>{s.title}</h3>
-              <p>{s.summary}</p>
-            </div>
-          ))}
+          <SurfaceRenderer
+            layout={layout}
+            onAction={handleAction}
+            onInteraction={handleInteraction}
+          />
+          <div className="intent-provenance">
+            <span className="intent-provenance-label">
+              Results resolved from intent URL
+            </span>
+            <span className="intent-provenance-path">/{intentPath}</span>
+          </div>
+        </div>
+      ) : (
+        <div className="intent-empty">
+          <p>No results found for this intent.</p>
+          <button className="action-btn risk-A" onClick={handleRetry}>
+            Try Again
+          </button>
         </div>
       )}
     </div>

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -101,10 +101,23 @@ body {
 .intent-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: space-between;
+  gap: 0.75rem;
   padding: 0.75rem 1rem;
   background: var(--color-surface);
   border-radius: 0.5rem;
+}
+
+.intent-header-content {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.intent-status-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .intent-label {
@@ -115,20 +128,75 @@ body {
 .intent-query {
   font-weight: 600;
   color: var(--color-accent);
+  font-size: 1.125rem;
 }
 
 .intent-loading {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
-  padding: 2rem;
+  gap: 1rem;
+  padding: 4rem 2rem;
   text-align: center;
 }
 
-.intent-loading .agent-status {
-  color: var(--color-muted);
+.intent-loading-animation {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  margin-bottom: 0.5rem;
+}
+
+.intent-pulse-ring {
+  position: absolute;
+  inset: 0;
+  border: 2px solid var(--color-accent);
+  border-radius: 50%;
+  animation: intent-pulse 2s ease-out infinite;
+  opacity: 0;
+}
+
+.intent-pulse-ring.delay-1 {
+  animation-delay: 0.5s;
+}
+
+.intent-pulse-ring.delay-2 {
+  animation-delay: 1s;
+}
+
+@keyframes intent-pulse {
+  0% {
+    transform: scale(0.5);
+    opacity: 0.8;
+  }
+  100% {
+    transform: scale(1.8);
+    opacity: 0;
+  }
+}
+
+.intent-loading-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.intent-loading-detail {
   font-size: 0.875rem;
+  color: var(--color-muted);
+}
+
+.intent-loading-path {
+  font-family: monospace;
+  padding: 0.25rem 0.5rem;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 0.25rem;
+  font-size: 0.8125rem;
+}
+
+.intent-loading-agents {
+  color: var(--color-accent);
+  font-size: 0.8125rem;
+  animation: pulse 1.5s ease-in-out infinite;
 }
 
 .intent-results {
@@ -137,20 +205,50 @@ body {
   gap: 1rem;
 }
 
-.surface-placeholder {
-  padding: 1rem;
-  background: var(--color-surface);
-  border-radius: 0.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.surface-placeholder h3 {
-  margin-bottom: 0.25rem;
-}
-
-.surface-placeholder p {
+.intent-provenance {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
   color: var(--color-muted);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.intent-provenance-label {
+  opacity: 0.7;
+}
+
+.intent-provenance-path {
+  font-family: monospace;
+  padding: 0.125rem 0.375rem;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 0.25rem;
+  font-size: 0.6875rem;
+}
+
+.intent-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.intent-error-message {
+  color: #ef4444;
   font-size: 0.875rem;
+}
+
+.intent-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 3rem 2rem;
+  text-align: center;
+  color: var(--color-muted);
 }
 
 /* Surface Grid */

--- a/packages/agents/src/perception/url-intent-parser.ts
+++ b/packages/agents/src/perception/url-intent-parser.ts
@@ -92,9 +92,9 @@ export class URLIntentParserAgent extends BaseAgent {
     // Strip query string and fragment
     pathPart = pathPart.split("?")[0].split("#")[0];
 
-    // Split path into segments, splitting on / and -
+    // Split path into segments, splitting on /, -, and _
     const pathSegments = pathPart
-      .split(/[/\-]/)
+      .split(/[/\-_]/)
       .map((s) => decodeURIComponent(s).trim())
       .filter(Boolean);
 

--- a/packages/agents/src/ui/discovery-surface.ts
+++ b/packages/agents/src/ui/discovery-surface.ts
@@ -200,13 +200,18 @@ export class DiscoverySurfaceAgent extends BaseAgent {
   }
 
   private extractWebData(retrieval: DataRetrievalOutput): unknown {
-    const webResult = retrieval.results.find(
+    const webResults = retrieval.results.filter(
       (r) =>
         r.status === "fulfilled" &&
         (r.connectorId === "web" ||
+          r.connectorId === "web-fetch" ||
           r.operation.includes("search") ||
-          r.operation.includes("web")),
+          r.operation.includes("web") ||
+          r.operation.includes("fetch")),
     );
-    return webResult?.data ?? [];
+    if (webResults.length === 0) return [];
+    // Return all web data if multiple results, or the single result's data
+    if (webResults.length === 1) return webResults[0].data;
+    return webResults.map((r) => r.data);
   }
 }

--- a/packages/agents/src/ui/layout-composer.ts
+++ b/packages/agents/src/ui/layout-composer.ts
@@ -27,8 +27,8 @@ export function extractSurfaces(outputs: AgentOutput[]): SurfaceSpec[] {
       continue;
     }
 
-    // Check nested `surface` or `spec` fields
-    for (const key of ["surface", "spec"] as const) {
+    // Check nested `surface`, `spec`, or `surfaceSpec` fields
+    for (const key of ["surface", "spec", "surfaceSpec"] as const) {
       const nested = value[key];
       if (nested && typeof nested === "object" && isSurfaceSpec(nested as Record<string, unknown>)) {
         surfaces.push(nested as unknown as SurfaceSpec);

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -8,6 +8,7 @@
     "@waibspace/types": "workspace:*",
     "@waibspace/event-bus": "workspace:*",
     "@waibspace/agents": "workspace:*",
+    "@waibspace/connectors": "workspace:*",
     "@waibspace/policy": "workspace:*",
     "@waibspace/memory": "workspace:*"
   },

--- a/packages/orchestrator/src/execution-planner.ts
+++ b/packages/orchestrator/src/execution-planner.ts
@@ -13,6 +13,60 @@ export interface ExecutionPhase {
 }
 
 /**
+ * Agents within the same category that must run sequentially
+ * because they depend on each other's outputs.
+ *
+ * Each entry defines a category and ordered groups of agent IDs.
+ * Agents in the same group run in parallel; groups run sequentially.
+ */
+interface AgentOrdering {
+  category: AgentCategory;
+  groups: string[][];
+}
+
+/**
+ * For event types that require sequential execution within a category,
+ * define the agent ordering explicitly.
+ */
+const AGENT_ORDERINGS: Record<string, AgentOrdering[]> = {
+  "user.intent.url_received": [
+    {
+      category: "context",
+      groups: [
+        ["context.planner"],
+        ["context.connector-selection"],
+        ["context.data-retrieval"],
+      ],
+    },
+    {
+      category: "ui",
+      groups: [
+        ["ui.discovery-surface"],
+        ["layout-composer"],
+      ],
+    },
+  ],
+  "user.message.received": [
+    {
+      category: "context",
+      groups: [
+        ["context.planner"],
+        ["context.connector-selection"],
+        ["context.data-retrieval"],
+      ],
+    },
+    {
+      category: "ui",
+      groups: [
+        // All surface agents run in parallel, then layout composer
+        ["ui.inbox-surface", "ui.calendar-surface", "ui.discovery-surface"],
+        ["layout-composer"],
+      ],
+    },
+  ],
+};
+
+/**
  * Define the pipeline order based on event type.
  */
 function getPipelineForEvent(eventType: string): AgentCategory[] {
@@ -37,7 +91,11 @@ function getPipelineForEvent(eventType: string): AgentCategory[] {
 
 /**
  * Build an execution plan based on event type and registered agents.
- * Each phase contains all agents registered under that category.
+ *
+ * For categories that have explicit agent orderings, the category is split
+ * into sequential sub-phases. Otherwise, all agents in the category run
+ * in a single parallel phase.
+ *
  * Phases with no agents are omitted.
  */
 export function buildExecutionPlan(
@@ -45,16 +103,54 @@ export function buildExecutionPlan(
   registry: AgentRegistry,
 ): ExecutionPlan {
   const categories = getPipelineForEvent(eventType);
+  const orderings = AGENT_ORDERINGS[eventType];
 
   const phases: ExecutionPhase[] = [];
+
   for (const category of categories) {
-    const agents = registry.getByCategory(category);
-    if (agents.length > 0) {
-      phases.push({
-        id: `phase-${category}`,
-        category,
-        agents,
-      });
+    const ordering = orderings?.find((o) => o.category === category);
+
+    if (ordering) {
+      // Split this category into sequential sub-phases
+      let subIndex = 0;
+      for (const group of ordering.groups) {
+        const agents = group
+          .map((id) => registry.getById(id))
+          .filter((a): a is Agent => a !== undefined);
+
+        if (agents.length > 0) {
+          phases.push({
+            id: `phase-${category}-${subIndex}`,
+            category,
+            agents,
+          });
+          subIndex++;
+        }
+      }
+
+      // Also include any agents in this category NOT mentioned in the ordering
+      const mentionedIds = new Set(ordering.groups.flat());
+      const remainingAgents = registry
+        .getByCategory(category)
+        .filter((a) => !mentionedIds.has(a.id));
+
+      if (remainingAgents.length > 0) {
+        phases.push({
+          id: `phase-${category}-remaining`,
+          category,
+          agents: remainingAgents,
+        });
+      }
+    } else {
+      // Default: all agents in the category run in parallel
+      const agents = registry.getByCategory(category);
+      if (agents.length > 0) {
+        phases.push({
+          id: `phase-${category}`,
+          category,
+          agents,
+        });
+      }
     }
   }
 

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -3,6 +3,7 @@ import { EventBus, createEvent } from "@waibspace/event-bus";
 import { executeAgent } from "@waibspace/agents";
 import type { ModelProviderRegistry } from "@waibspace/model-provider";
 import type { MemoryStore } from "@waibspace/memory";
+import type { ConnectorRegistry } from "@waibspace/connectors";
 import { AgentRegistry } from "./agent-registry";
 import { buildExecutionPlan } from "./execution-planner";
 import { createPipelineTrace, logTrace } from "./trace";
@@ -11,6 +12,7 @@ export interface OrchestratorOptions {
   timeoutMs?: number;
   modelProvider?: ModelProviderRegistry;
   memoryStore?: MemoryStore;
+  connectorRegistry?: ConnectorRegistry;
 }
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -42,6 +44,9 @@ export class Orchestrator {
           ...(this.options?.memoryStore
             ? { memoryStore: this.options.memoryStore }
             : {}),
+          ...(this.options?.connectorRegistry
+            ? { connectorRegistry: this.options.connectorRegistry }
+            : {}),
         },
       };
 
@@ -70,9 +75,24 @@ export class Orchestrator {
     // If any UI agent outputs exist, emit a surface.composed event
     const uiOutputs = priorOutputs.filter((o) => o.category === "ui");
     if (uiOutputs.length > 0) {
+      // Check if LayoutComposerAgent produced a ComposedLayout directly
+      let composedPayload: unknown;
+      const layoutOutput = uiOutputs.find((o) => {
+        const out = o.output as Record<string, unknown> | undefined;
+        return out && "surfaces" in out && "layout" in out && "traceId" in out;
+      });
+
+      if (layoutOutput) {
+        // Use the ComposedLayout directly from the layout composer
+        composedPayload = layoutOutput.output;
+      } else {
+        // Fallback: wrap raw UI outputs
+        composedPayload = { surfaces: uiOutputs.map((o) => o.output) };
+      }
+
       const composedEvent = createEvent(
         "surface.composed",
-        { surfaces: uiOutputs.map((o) => o.output) },
+        composedPayload,
         "orchestrator",
         event.traceId,
       );


### PR DESCRIPTION
## Summary

Closes #44 — [P9-2] End-to-end Workflow 2: Intent URL Discovery

- Wires all existing agents into a complete pipeline for intent URL resolution: perception (InputNormalizer + URLIntentParser) -> reasoning (IntentAgent) -> context (ContextPlanner -> ConnectorSelection -> DataRetrieval) -> UI (DiscoverySurface -> LayoutComposer) -> safety (ProvenanceAnnotator)
- Registers ConnectorRegistry with WebFetchConnector in the backend and passes it through to agents via the orchestrator context
- Upgrades the execution planner to support sequential sub-phases within a category, so dependent agents (e.g. ContextPlanner before ConnectorSelection before DataRetrieval) run in the correct order
- Enhances IntentResolutionPage with SurfaceRenderer integration, animated loading state, error handling, retry support, provenance badges, and proper WebSocket connection management
- Fixes agent interop issues: LayoutComposer now finds `surfaceSpec` keys, DiscoverySurfaceAgent matches `web-fetch` connector ID, URLIntentParser splits on underscores

## Test plan

- [ ] Navigate to `/horror-movie-tomorrow` — should show loading animation, then discovery surface with ranked results
- [ ] Navigate to `/best-restaurants-nearby` — should resolve to discovery results
- [ ] Use browser back/forward after intent resolution — URL stays in address bar, page re-resolves
- [ ] Verify the loading state shows "Resolving: horror movie tomorrow" with pulse animation
- [ ] Verify error state appears and retry button works if backend is unreachable
- [ ] Verify provenance badge appears below results showing the intent URL
- [ ] Check that existing routes (`/`, `/inbox`, `/calendar`, etc.) still work normally
- [ ] Verify the home page ambient flow still works without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)