### PR TITLE
P10-6: Performance profiling and timing breakdowns

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -48,7 +48,13 @@ const bus = new EventBus();
 
 // ---------- 2. Model Provider ----------
 const modelRegistry = new ModelProviderRegistry();
-modelRegistry.register(new AnthropicProvider());
+const anthropicProvider = new AnthropicProvider();
+modelRegistry.register(anthropicProvider);
+
+// Pre-warm the Anthropic API connection (non-blocking)
+anthropicProvider.warmUp().catch(() => {
+  // Errors already logged inside warmUp()
+});
 
 // ---------- 3. Connector Registry ----------
 const connectorRegistry = new ConnectorRegistry();

--- a/packages/model-provider/src/anthropic-provider.ts
+++ b/packages/model-provider/src/anthropic-provider.ts
@@ -10,6 +10,7 @@ export class AnthropicProvider implements ModelProvider {
   id = "anthropic";
   name = "Anthropic";
   private client: Anthropic;
+  private _warmedUp = false;
 
   constructor(apiKey?: string) {
     this.client = new Anthropic({
@@ -17,7 +18,35 @@ export class AnthropicProvider implements ModelProvider {
     });
   }
 
+  /**
+   * Pre-warm the API connection by sending a minimal request.
+   * This resolves DNS, establishes TLS, and prepares the HTTP/2 connection
+   * so the first real request is faster.
+   */
+  async warmUp(): Promise<void> {
+    if (this._warmedUp) return;
+    const startMs = Date.now();
+    try {
+      await this.client.messages.create({
+        model: "claude-haiku-4-5-20251001",
+        max_tokens: 1,
+        messages: [{ role: "user", content: "hi" }],
+      });
+      this._warmedUp = true;
+      console.log(
+        `[model-provider:anthropic] Connection pre-warmed in ${Date.now() - startMs}ms`,
+      );
+    } catch (error) {
+      // Non-fatal — connection will be established on first real request
+      console.warn(
+        `[model-provider:anthropic] Warm-up failed (${Date.now() - startMs}ms): ${error instanceof Error ? error.message : error}`,
+      );
+    }
+  }
+
   async complete(request: CompletionRequest): Promise<CompletionResponse> {
+    const startMs = Date.now();
+
     const response = await this.client.messages.create({
       model: request.model,
       max_tokens: request.maxTokens ?? 1024,
@@ -31,8 +60,14 @@ export class AnthropicProvider implements ModelProvider {
       })),
     });
 
+    const durationMs = Date.now() - startMs;
     const textContent = response.content.find((block) => block.type === "text");
     const content = textContent?.type === "text" ? textContent.text : "";
+
+    console.log(
+      `[model-provider:anthropic] ${request.model} complete: ${durationMs}ms ` +
+        `(in=${response.usage.input_tokens} out=${response.usage.output_tokens} tokens)`,
+    );
 
     return {
       content,

--- a/packages/model-provider/src/config.ts
+++ b/packages/model-provider/src/config.ts
@@ -9,6 +9,24 @@ export interface ModelRoleConfig {
   uiGeneration: { provider: string; model: string };
 }
 
+/**
+ * Default model configuration optimized for latency vs. quality tradeoffs:
+ *
+ * - reasoning (sonnet): Used by context-planner for complex planning tasks.
+ *   Needs higher capability for multi-step reasoning about data sources.
+ *
+ * - classification (haiku): Used by intent-agent for intent classification.
+ *   Haiku is fast enough for structured classification and keeps latency low.
+ *
+ * - summarization (haiku): Used by inbox-surface, calendar-surface, discovery-surface.
+ *   These run in parallel so fast model helps meet the 3s target.
+ *
+ * - uiGeneration (sonnet): Used by layout-composer for complex UI composition.
+ *   Needs higher capability to produce well-structured layouts.
+ *
+ * Simple agents like confidence-scorer and provenance-annotator don't use LLM calls
+ * (they use heuristic/rule-based logic), so no model config needed for them.
+ */
 export const DEFAULT_MODEL_CONFIG: ModelRoleConfig = {
   reasoning: { provider: "anthropic", model: "claude-sonnet-4-6" },
   classification: {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -34,10 +34,13 @@ export class Orchestrator {
     let priorOutputs: AgentOutput[] = [];
     const phaseResults: Array<{
       category: AgentCategory;
+      startMs: number;
+      endMs: number;
       outputs: AgentOutput[];
     }> = [];
 
     for (const phase of plan.phases) {
+      const phaseStartMs = Date.now();
       const input = { event, priorOutputs };
       const context = {
         traceId: event.traceId,
@@ -69,7 +72,13 @@ export class Orchestrator {
         )
         .map((r) => r.value);
 
-      phaseResults.push({ category: phase.category, outputs: phaseOutputs });
+      const phaseEndMs = Date.now();
+      phaseResults.push({
+        category: phase.category,
+        startMs: phaseStartMs,
+        endMs: phaseEndMs,
+        outputs: phaseOutputs,
+      });
 
       // Accumulate outputs for the next phase
       priorOutputs = [...priorOutputs, ...phaseOutputs];

--- a/packages/orchestrator/src/trace.ts
+++ b/packages/orchestrator/src/trace.ts
@@ -10,6 +10,9 @@ export interface PipelineTrace {
 
 export interface PhaseTrace {
   category: AgentCategory;
+  startMs: number;
+  endMs: number;
+  durationMs: number;
   agents: Array<{
     agentId: string;
     agentType: string;
@@ -44,6 +47,8 @@ export function createPipelineTrace(
   endMs: number,
   phaseResults: Array<{
     category: AgentCategory;
+    startMs: number;
+    endMs: number;
     outputs: AgentOutput[];
   }>,
 ): PipelineTrace {
@@ -54,6 +59,9 @@ export function createPipelineTrace(
     endMs,
     phases: phaseResults.map((phase) => ({
       category: phase.category,
+      startMs: phase.startMs,
+      endMs: phase.endMs,
+      durationMs: phase.endMs - phase.startMs,
       agents: phase.outputs.map((output) => ({
         agentId: output.agentId,
         agentType: output.agentType,
@@ -66,26 +74,64 @@ export function createPipelineTrace(
 }
 
 /**
- * Log a pipeline trace summary to the console.
+ * Aggregate phase traces by category for the timing summary.
+ */
+function aggregateByCategory(
+  phases: PhaseTrace[],
+): Map<AgentCategory, { durationMs: number; agents: Array<{ agentId: string; durationMs: number }> }> {
+  const categories = new Map<
+    AgentCategory,
+    { durationMs: number; agents: Array<{ agentId: string; durationMs: number }> }
+  >();
+
+  for (const phase of phases) {
+    const existing = categories.get(phase.category);
+    if (existing) {
+      existing.durationMs += phase.durationMs;
+      existing.agents.push(
+        ...phase.agents.map((a) => ({ agentId: a.agentId, durationMs: a.durationMs })),
+      );
+    } else {
+      categories.set(phase.category, {
+        durationMs: phase.durationMs,
+        agents: phase.agents.map((a) => ({ agentId: a.agentId, durationMs: a.durationMs })),
+      });
+    }
+  }
+
+  return categories;
+}
+
+/**
+ * Log a pipeline trace summary to the console with per-category timing breakdown.
+ *
+ * Output format:
+ *   [trace:xxx] Pipeline complete in 2340ms
+ *     perception: 45ms (input-normalizer: 12ms, url-parser: 33ms)
+ *     reasoning: 890ms (intent-agent: 850ms, confidence-scorer: 40ms)
+ *     ...
  */
 export function logTrace(trace: PipelineTrace): void {
   const totalDuration = trace.endMs - trace.startMs;
-  const totalAgents = trace.phases.reduce(
-    (sum, phase) => sum + phase.agents.length,
-    0,
-  );
+  const categories = aggregateByCategory(trace.phases);
 
-  console.log(
-    `[Orchestrator] trace=${trace.traceId} event=${trace.eventType} ` +
-      `phases=${trace.phases.length} agents=${totalAgents} duration=${totalDuration}ms`,
-  );
+  console.log(`[trace:${trace.traceId}] Pipeline complete in ${totalDuration}ms`);
 
+  for (const [category, data] of categories) {
+    const agentDetails = data.agents
+      .map((a) => `${a.agentId}: ${a.durationMs}ms`)
+      .join(", ");
+    console.log(`  ${category}: ${data.durationMs}ms (${agentDetails})`);
+  }
+
+  // Log slow agents as warnings (> 1 second)
   for (const phase of trace.phases) {
     for (const agent of phase.agents) {
-      console.log(
-        `  [${phase.category}] ${agent.agentId} (${agent.agentType}) ` +
-          `status=${agent.status} confidence=${agent.confidence} duration=${agent.durationMs}ms`,
-      );
+      if (agent.durationMs > 1000) {
+        console.warn(
+          `[trace:${trace.traceId}] SLOW AGENT: ${agent.agentId} took ${agent.durationMs}ms (${agent.status})`,
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- **Enhanced trace logging**: Pipeline completion now logs a clear per-category timing breakdown (e.g., `perception: 45ms (input-normalizer: 12ms, url-parser: 33ms)`), with slow agent warnings (>1s)
- **Model provider timing**: Anthropic provider logs request duration and token counts for every LLM call, enabling bottleneck identification
- **Connection pre-warming**: Added `warmUp()` method to Anthropic provider, called non-blocking at startup to pre-establish TLS/HTTP2 connections
- **Model config documentation**: Documented the rationale for model role assignments (haiku for classification/summarization, sonnet for reasoning/UI generation) and confirmed simple agents (confidence-scorer, provenance-annotator) use heuristic logic without LLM calls

Closes #50

## Test plan
- [ ] Start backend and verify warm-up log message appears: `[model-provider:anthropic] Connection pre-warmed in Xms`
- [ ] Send a user message and verify timing breakdown appears in console logs
- [ ] Verify per-model-call timing logs with token counts appear
- [ ] Verify slow agent warnings appear for agents exceeding 1s
- [ ] Run `npx tsc --noEmit` to confirm type safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)