### PR TITLE
P10-2: Error handling and graceful degradation

### DIFF
--- a/apps/frontend/src/components/ErrorSurface.tsx
+++ b/apps/frontend/src/components/ErrorSurface.tsx
@@ -1,0 +1,67 @@
+import type { AgentError } from "@waibspace/ui-renderer-contract";
+
+interface ErrorSurfaceProps {
+  errors: AgentError[];
+}
+
+/**
+ * Renders user-friendly error messages when agents fail.
+ * Maps agent IDs to human-readable service names.
+ */
+export function ErrorSurface({ errors }: ErrorSurfaceProps) {
+  if (errors.length === 0) return null;
+
+  return (
+    <div className="error-surface">
+      <div className="error-surface-header">
+        <span className="error-surface-icon">!</span>
+        <span>Some data could not be loaded</span>
+      </div>
+      <ul className="error-surface-list">
+        {errors.map((err) => (
+          <li key={err.agentId} className="error-surface-item">
+            <span className="error-surface-agent">
+              {friendlyAgentName(err.agentId)}
+            </span>
+            <span className="error-surface-message">
+              {friendlyErrorMessage(err.message)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** Map agent IDs to user-friendly names */
+function friendlyAgentName(agentId: string): string {
+  const names: Record<string, string> = {
+    "data-retrieval": "Data Service",
+    "inbox-surface": "Email",
+    "calendar-surface": "Calendar",
+    "discovery-surface": "Search",
+    "context-planner": "Context",
+    "connector-selection": "Connectors",
+    "memory-retrieval": "Memory",
+    "layout-composer": "Layout",
+  };
+  return names[agentId] ?? agentId;
+}
+
+/** Convert error messages to user-friendly text */
+function friendlyErrorMessage(message: string): string {
+  if (message.includes("timed out")) {
+    return "Request timed out - please try again";
+  }
+  if (message.includes("ECONNREFUSED") || message.includes("ENOTFOUND")) {
+    return "Service temporarily unavailable";
+  }
+  if (message.includes("401") || message.includes("403")) {
+    return "Authentication required - please reconnect";
+  }
+  // Don't expose raw error messages to users
+  if (message.length > 100 || message.includes("Error:")) {
+    return "An unexpected error occurred";
+  }
+  return message;
+}

--- a/apps/frontend/src/components/StaleIndicator.tsx
+++ b/apps/frontend/src/components/StaleIndicator.tsx
@@ -1,0 +1,32 @@
+interface StaleIndicatorProps {
+  /** Timestamp when data was last successfully refreshed */
+  timestamp: number;
+  /** Whether there were errors during the last refresh */
+  hasErrors: boolean;
+}
+
+/**
+ * Small badge shown on surfaces when data might be stale
+ * (e.g., a connector was down during the last refresh).
+ */
+export function StaleIndicator({ timestamp, hasErrors }: StaleIndicatorProps) {
+  if (!hasErrors) return null;
+
+  const age = Date.now() - timestamp;
+  const ageLabel = formatAge(age);
+
+  return (
+    <span className="stale-indicator" title={`Data may be incomplete. Last update: ${ageLabel} ago`}>
+      Stale ({ageLabel})
+    </span>
+  );
+}
+
+function formatAge(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h`;
+}

--- a/apps/frontend/src/components/SurfaceRenderer.tsx
+++ b/apps/frontend/src/components/SurfaceRenderer.tsx
@@ -2,6 +2,8 @@ import type { ComposedLayout } from "@waibspace/ui-renderer-contract";
 import type { SurfaceAction } from "@waibspace/types";
 import { surfaceComponents } from "./surfaces/registry";
 import { GenericSurface } from "./surfaces/GenericSurface";
+import { ErrorSurface } from "./ErrorSurface";
+import { StaleIndicator } from "./StaleIndicator";
 
 interface SurfaceRendererProps {
   layout: ComposedLayout | null;
@@ -21,11 +23,28 @@ export function SurfaceRenderer({
   onInteraction,
 }: SurfaceRendererProps) {
   if (!layout || layout.surfaces.length === 0) {
+    // If there are errors but no surfaces, show the error surface
+    if (layout?.errors && layout.errors.length > 0) {
+      return (
+        <div className="surface-grid">
+          <div className="surface-cell full">
+            <ErrorSurface errors={layout.errors} />
+          </div>
+        </div>
+      );
+    }
     return <div className="surface-empty">No surfaces to display</div>;
   }
 
+  const hasErrors = (layout.errors?.length ?? 0) > 0;
+
   return (
     <div className="surface-grid">
+      {hasErrors && layout.errors && (
+        <div className="surface-cell full">
+          <ErrorSurface errors={layout.errors} />
+        </div>
+      )}
       {layout.surfaces.map((surface, index) => {
         const directive = layout.layout.find(
           (d) => d.surfaceId === surface.surfaceId,
@@ -38,19 +57,27 @@ export function SurfaceRenderer({
             className={`surface-cell ${directive?.width || "full"} ${directive?.prominence || "standard"}`}
             style={{ order: directive?.position ?? index }}
           >
-            <Component
-              spec={surface}
-              onAction={onAction}
-              onInteraction={(interaction, target, context) =>
-                onInteraction(
-                  interaction,
-                  target,
-                  surface.surfaceId,
-                  surface.surfaceType,
-                  context,
-                )
-              }
-            />
+            <div className="surface-wrapper">
+              {hasErrors && (
+                <StaleIndicator
+                  timestamp={layout.timestamp}
+                  hasErrors={hasErrors}
+                />
+              )}
+              <Component
+                spec={surface}
+                onAction={onAction}
+                onInteraction={(interaction, target, context) =>
+                  onInteraction(
+                    interaction,
+                    target,
+                    surface.surfaceId,
+                    surface.surfaceType,
+                    context,
+                  )
+                }
+              />
+            </div>
           </div>
         );
       })}

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -9,6 +9,7 @@ import { SurfaceRenderer } from "../components/SurfaceRenderer";
 import { AgentStatus } from "../components/AgentStatus";
 import { ChatInput } from "../components/ChatInput";
 import { WelcomeState } from "../components/WelcomeState";
+import { ErrorSurface } from "../components/ErrorSurface";
 
 const WS_URL = `ws://${window.location.hostname}:${import.meta.env.VITE_WS_PORT || 3001}`;
 
@@ -17,6 +18,7 @@ export default function HomePage() {
   const [layout, setLayout] = useState<ComposedLayout | null>(null);
   const [agents, setAgents] = useState<AgentStatusType[]>([]);
   const [hasRequestedAmbient, setHasRequestedAmbient] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   // Request ambient state on initial connection
   useEffect(() => {
@@ -32,6 +34,7 @@ export default function HomePage() {
     switch (lastMessage.type) {
       case "surface.update":
         setLayout(lastMessage.payload as ComposedLayout);
+        setErrorMessage(null); // Clear any previous standalone errors
         break;
       case "status": {
         const statusPayload = lastMessage.payload as {
@@ -39,6 +42,14 @@ export default function HomePage() {
           agents: AgentStatusType[];
         };
         setAgents(statusPayload.agents);
+        break;
+      }
+      case "error": {
+        const errorPayload = lastMessage.payload as {
+          message: string;
+          code: string;
+        };
+        setErrorMessage(errorPayload.message);
         break;
       }
     }
@@ -100,6 +111,15 @@ export default function HomePage() {
 
   return (
     <div className="page home-page">
+      {status !== "connected" && (
+        <div className={`connection-banner ${status}`}>
+          <span className="connection-banner-icon">!</span>
+          {status === "connecting"
+            ? "Reconnecting to server..."
+            : "Connection lost. Attempting to reconnect..."}
+        </div>
+      )}
+
       <div className="home-status-bar">
         <span
           className={`connection-dot ${status === "connected" ? "connected" : status === "connecting" ? "connecting" : "disconnected"}`}
@@ -115,6 +135,17 @@ export default function HomePage() {
       </div>
 
       <div className="home-content">
+        {errorMessage && (
+          <ErrorSurface
+            errors={[
+              {
+                agentId: "system",
+                message: errorMessage,
+                phase: "orchestration",
+              },
+            ]}
+          />
+        )}
         {hasSurfaces ? (
           <SurfaceRenderer
             layout={layout}

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -1235,3 +1235,145 @@ body {
   font-size: 0.75rem;
   margin-left: auto;
 }
+
+/* ===================== */
+/* Connection Banner     */
+/* ===================== */
+.connection-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  animation: slideDown 0.3s ease-out;
+}
+
+.connection-banner.disconnected {
+  background: rgba(239, 68, 68, 0.12);
+  color: #f87171;
+  border: 1px solid rgba(239, 68, 68, 0.25);
+}
+
+.connection-banner.connecting {
+  background: rgba(234, 179, 8, 0.12);
+  color: #fbbf24;
+  border: 1px solid rgba(234, 179, 8, 0.25);
+}
+
+.connection-banner-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.connection-banner.disconnected .connection-banner-icon {
+  background: rgba(239, 68, 68, 0.25);
+}
+
+.connection-banner.connecting .connection-banner-icon {
+  background: rgba(234, 179, 8, 0.25);
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ===================== */
+/* Error Surface         */
+/* ===================== */
+.error-surface {
+  padding: 0.75rem 1rem;
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.error-surface-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #f87171;
+  margin-bottom: 0.5rem;
+}
+
+.error-surface-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: rgba(239, 68, 68, 0.25);
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.error-surface-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.error-surface-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  padding: 0.25rem 0;
+}
+
+.error-surface-agent {
+  color: var(--color-text);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.error-surface-agent::after {
+  content: ":";
+}
+
+.error-surface-message {
+  color: var(--color-muted);
+}
+
+/* ===================== */
+/* Stale Indicator       */
+/* ===================== */
+.stale-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: #fbbf24;
+  background: rgba(234, 179, 8, 0.12);
+  border: 1px solid rgba(234, 179, 8, 0.2);
+  border-radius: 999px;
+  margin-bottom: 0.375rem;
+}
+
+.surface-wrapper {
+  display: flex;
+  flex-direction: column;
+}

--- a/packages/agents/src/execution-harness.ts
+++ b/packages/agents/src/execution-harness.ts
@@ -45,7 +45,7 @@ export async function executeAgent(
       error instanceof Error ? error.message : "Unknown error during agent execution";
 
     console.error(
-      `[executeAgent] Agent ${agent.id} (${agent.category}:${agent.name}) failed: ${message}`,
+      `[executeAgent] [trace:${context.traceId}] Agent ${agent.id} (${agent.category}:${agent.name}) failed after ${endMs - startMs}ms: ${message}`,
     );
 
     return {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -30,17 +30,19 @@ export class Orchestrator {
     const startMs = Date.now();
     const plan = buildExecutionPlan(event.type, this.registry);
     const timeoutMs = this.options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const traceId = event.traceId;
 
     let priorOutputs: AgentOutput[] = [];
     const phaseResults: Array<{
       category: AgentCategory;
       outputs: AgentOutput[];
     }> = [];
+    const errors: Array<{ agentId: string; error: string; phase: string }> = [];
 
     for (const phase of plan.phases) {
       const input = { event, priorOutputs };
       const context = {
-        traceId: event.traceId,
+        traceId,
         modelProvider: this.options?.modelProvider,
         config: {
           ...(this.options?.memoryStore
@@ -55,19 +57,51 @@ export class Orchestrator {
         },
       };
 
-      // Execute all agents in this phase in parallel
+      // Execute all agents in this phase in parallel with isolation
       const results = await Promise.allSettled(
         phase.agents.map((agent) =>
           executeAgent(agent, input, context, { timeoutMs }),
         ),
       );
 
-      const phaseOutputs: AgentOutput[] = results
-        .filter(
-          (r): r is PromiseFulfilledResult<AgentOutput> =>
-            r.status === "fulfilled",
-        )
-        .map((r) => r.value);
+      const phaseOutputs: AgentOutput[] = [];
+
+      for (let i = 0; i < results.length; i++) {
+        const result = results[i];
+        const agent = phase.agents[i];
+
+        if (result.status === "fulfilled") {
+          phaseOutputs.push(result.value);
+
+          // Track agent-level errors (returned as output.error)
+          const output = result.value.output as Record<string, unknown> | undefined;
+          if (output && typeof output === "object" && "error" in output) {
+            const errorMsg = String(output.error);
+            errors.push({
+              agentId: agent.id,
+              error: errorMsg,
+              phase: phase.category,
+            });
+            console.error(
+              `[Orchestrator] [trace:${traceId}] Agent ${agent.id} returned error in phase "${phase.category}": ${errorMsg}`,
+            );
+          }
+        } else {
+          // Agent threw an unhandled rejection (should be rare since executeAgent catches)
+          const errorMsg =
+            result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason);
+          errors.push({
+            agentId: agent.id,
+            error: errorMsg,
+            phase: phase.category,
+          });
+          console.error(
+            `[Orchestrator] [trace:${traceId}] Agent ${agent.id} crashed in phase "${phase.category}": ${errorMsg}`,
+          );
+        }
+      }
 
       phaseResults.push({ category: phase.category, outputs: phaseOutputs });
 
@@ -97,23 +131,63 @@ export class Orchestrator {
         composedPayload = { surfaces: surfaceOutputs.map((o) => o.output) };
       }
 
+      // Attach error info so the frontend can display partial-failure indicators
+      if (errors.length > 0) {
+        (composedPayload as Record<string, unknown>).errors = errors.map(
+          (e) => ({
+            agentId: e.agentId,
+            message: e.error,
+            phase: e.phase,
+          }),
+        );
+      }
+
       const composedEvent = createEvent(
         "surface.composed",
         composedPayload,
         "orchestrator",
-        event.traceId,
+        traceId,
       );
       this.eventBus.emit(composedEvent);
+    } else if (errors.length > 0) {
+      // No surfaces produced but there were errors - emit an error event
+      // so the frontend knows something went wrong
+      console.error(
+        `[Orchestrator] [trace:${traceId}] Pipeline produced no surfaces. ${errors.length} error(s) occurred.`,
+      );
+      const errorEvent = createEvent(
+        "surface.composed",
+        {
+          surfaces: [],
+          layout: [],
+          timestamp: Date.now(),
+          traceId,
+          errors: errors.map((e) => ({
+            agentId: e.agentId,
+            message: e.error,
+            phase: e.phase,
+          })),
+        },
+        "orchestrator",
+        traceId,
+      );
+      this.eventBus.emit(errorEvent);
     }
 
     // Log trace summary
     const trace = createPipelineTrace(
-      event.traceId,
+      traceId,
       event.type,
       startMs,
       endMs,
       phaseResults,
     );
     logTrace(trace);
+
+    if (errors.length > 0) {
+      console.warn(
+        `[Orchestrator] [trace:${traceId}] Completed with ${errors.length} error(s): ${errors.map((e) => e.agentId).join(", ")}`,
+      );
+    }
   }
 }

--- a/packages/ui-renderer-contract/src/index.ts
+++ b/packages/ui-renderer-contract/src/index.ts
@@ -1,3 +1,3 @@
-export type { ComposedLayout, LayoutDirective, AgentStatus } from "./layout";
+export type { ComposedLayout, LayoutDirective, AgentStatus, AgentError } from "./layout";
 export type { ServerMessage, ClientMessage } from "./messages";
 export { isValidServerMessage, isValidClientMessage } from "./validation";

--- a/packages/ui-renderer-contract/src/layout.ts
+++ b/packages/ui-renderer-contract/src/layout.ts
@@ -12,9 +12,16 @@ export interface AgentStatus {
   state: "pending" | "running" | "complete" | "error";
 }
 
+export interface AgentError {
+  agentId: string;
+  message: string;
+  phase: string;
+}
+
 export interface ComposedLayout {
   surfaces: SurfaceSpec[];
   layout: LayoutDirective[];
   timestamp: number;
   traceId: string;
+  errors?: AgentError[];
 }


### PR DESCRIPTION
## Summary
- **Backend error isolation**: Orchestrator now tracks per-agent errors using `Promise.allSettled`, logs them with `traceId`, and includes structured error info in the `ComposedLayout` payload so the frontend can display partial-failure indicators
- **Frontend connection indicator**: Visible connection banner when WebSocket disconnects with auto-reconnect (already had exponential backoff); auto-hides on reconnect
- **Error surfaces**: New `ErrorSurface` component shows user-friendly error messages (maps agent IDs to readable names, sanitizes raw stack traces); new `StaleIndicator` badge on surfaces when data may be incomplete
- **Structured error propagation**: New `AgentError` interface on `ComposedLayout` enables end-to-end error visibility from agent failures to UI

## Test plan
- [ ] Verify agent timeout returns partial results from completed agents (set low `timeoutMs`)
- [ ] Verify individual agent crash doesn't affect other agents in the same phase
- [ ] Verify error messages in frontend are user-friendly (no raw stack traces)
- [ ] Verify connection banner appears on WebSocket disconnect and hides on reconnect
- [ ] Verify stale indicator appears on surfaces when errors occurred during refresh
- [ ] Verify structured `traceId` logging in console for all error paths

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)