### PR TITLE
feat: MCP server registry and connection manager

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -32,6 +32,7 @@ import {
   GmailConnector,
   GoogleCalendarConnector,
   WebFetchConnector,
+  MCPServerRegistry,
 } from "@waibspace/connectors";
 import { PolicyEngine, DEFAULT_POLICY_RULES } from "@waibspace/policy";
 import {
@@ -107,6 +108,33 @@ console.log(
 // ---------- 4. Policy Engine ----------
 const policyEngine = new PolicyEngine(DEFAULT_POLICY_RULES);
 console.log(`[backend] Policy engine initialized with ${policyEngine.getRules().length} rules`);
+
+// ---------- 4b. MCP Server Registry ----------
+const mcpRegistry = new MCPServerRegistry(policyEngine);
+const MCP_SERVERS_PATH = "./data/mcp-servers.json";
+await mcpRegistry.load(MCP_SERVERS_PATH);
+
+// Auto-connect enabled servers and register their connectors
+for (const server of mcpRegistry.getServers()) {
+  if (server.config.enabled !== false) {
+    try {
+      await mcpRegistry.connectServer(server.config.id);
+      const connector = mcpRegistry.getConnector(server.config.id);
+      if (connector) {
+        connectorRegistry.register(connector);
+      }
+      console.log(`[backend] MCP server "${server.config.name}" connected`);
+    } catch (err) {
+      console.warn(
+        `[backend] MCP server "${server.config.name}" failed to connect:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}
+console.log(
+  `[backend] MCP registry: ${mcpRegistry.getServers().length} server(s), ${mcpRegistry.getAllTools().length} tool(s)`,
+);
 
 // ---------- 5. Agent Registry ----------
 const agentRegistry = new AgentRegistry();
@@ -218,7 +246,7 @@ bus.on("surface.composed", (event: WaibEvent) => {
 });
 
 // ---------- 12. Start HTTP/WebSocket server ----------
-const server = startServer({ eventBus: bus, orchestrator, memoryStore, scheduler });
+const server = startServer({ eventBus: bus, orchestrator, memoryStore, scheduler, mcpRegistry });
 
 const PORT = Number(process.env.PORT) || 3001;
 console.log(`[backend] WaibSpace backend started`);

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -2,6 +2,7 @@ import type { EventBus } from "@waibspace/event-bus";
 import type { Orchestrator } from "@waibspace/orchestrator";
 import type { BackgroundTaskScheduler } from "./background";
 import type { MemoryStore } from "@waibspace/memory";
+import type { MCPServerRegistry } from "@waibspace/connectors";
 import {
   createWebSocketHandlers,
   type WebSocketData,
@@ -11,7 +12,7 @@ const PORT = Number(process.env.PORT) || 3001;
 
 const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "http://localhost:5173",
-  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type",
 };
 
@@ -27,6 +28,7 @@ export interface ServerDeps {
   orchestrator: Orchestrator;
   scheduler?: BackgroundTaskScheduler;
   memoryStore?: MemoryStore;
+  mcpRegistry?: MCPServerRegistry;
 }
 
 const startTime = Date.now();
@@ -99,6 +101,91 @@ export function startServer(deps: ServerDeps) {
         }
         const taskId = url.pathname.match(/^\/api\/tasks\/(.+)\/history$/)![1];
         return jsonResponse(deps.scheduler.getHistory(taskId));
+      }
+
+      // ---------- MCP Server Registry endpoints ----------
+
+      // GET /api/mcp/servers — list all servers with status
+      if (url.pathname === "/api/mcp/servers" && req.method === "GET") {
+        if (!deps.mcpRegistry) {
+          return jsonResponse({ error: "MCP registry not available" }, 503);
+        }
+        return jsonResponse(deps.mcpRegistry.getServers());
+      }
+
+      // POST /api/mcp/servers — add a new server
+      if (url.pathname === "/api/mcp/servers" && req.method === "POST") {
+        if (!deps.mcpRegistry) {
+          return jsonResponse({ error: "MCP registry not available" }, 503);
+        }
+        try {
+          const body = await req.json();
+          deps.mcpRegistry.addServer(body);
+          return jsonResponse({ ok: true, id: body.id }, 201);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return jsonResponse({ error: message }, 400);
+        }
+      }
+
+      // DELETE /api/mcp/servers/:id — remove a server
+      const deleteMatch = url.pathname.match(/^\/api\/mcp\/servers\/([^/]+)$/);
+      if (deleteMatch && req.method === "DELETE") {
+        if (!deps.mcpRegistry) {
+          return jsonResponse({ error: "MCP registry not available" }, 503);
+        }
+        try {
+          await deps.mcpRegistry.removeServer(deleteMatch[1]);
+          return jsonResponse({ ok: true });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return jsonResponse({ error: message }, 404);
+        }
+      }
+
+      // POST /api/mcp/servers/:id/connect — connect to a server
+      const connectMatch = url.pathname.match(/^\/api\/mcp\/servers\/([^/]+)\/connect$/);
+      if (connectMatch && req.method === "POST") {
+        if (!deps.mcpRegistry) {
+          return jsonResponse({ error: "MCP registry not available" }, 503);
+        }
+        try {
+          await deps.mcpRegistry.connectServer(connectMatch[1]);
+          return jsonResponse({ ok: true });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return jsonResponse({ error: message }, 500);
+        }
+      }
+
+      // POST /api/mcp/servers/:id/disconnect — disconnect from a server
+      const disconnectMatch = url.pathname.match(/^\/api\/mcp\/servers\/([^/]+)\/disconnect$/);
+      if (disconnectMatch && req.method === "POST") {
+        if (!deps.mcpRegistry) {
+          return jsonResponse({ error: "MCP registry not available" }, 503);
+        }
+        try {
+          await deps.mcpRegistry.disconnectServer(disconnectMatch[1]);
+          return jsonResponse({ ok: true });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return jsonResponse({ error: message }, 500);
+        }
+      }
+
+      // GET /api/mcp/servers/:id/tools — list tools for a server
+      const toolsMatch = url.pathname.match(/^\/api\/mcp\/servers\/([^/]+)\/tools$/);
+      if (toolsMatch && req.method === "GET") {
+        if (!deps.mcpRegistry) {
+          return jsonResponse({ error: "MCP registry not available" }, 503);
+        }
+        try {
+          const tools = deps.mcpRegistry.getServerTools(toolsMatch[1]);
+          return jsonResponse(tools);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return jsonResponse({ error: message }, 404);
+        }
       }
 
       return jsonResponse({ error: "Not found" }, 404);

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -29,5 +29,5 @@ export {
   RateLimiter,
 } from "./web-fetch";
 export type { ExtractedContent } from "./web-fetch";
-export { MCPConnector } from "./mcp";
+export { MCPConnector, MCPServerRegistry } from "./mcp";
 export type { MCPServerConfig, MCPToolInfo } from "./mcp";

--- a/packages/connectors/src/mcp/index.ts
+++ b/packages/connectors/src/mcp/index.ts
@@ -1,2 +1,3 @@
 export { MCPConnector } from "./mcp-connector";
+export { MCPServerRegistry } from "./registry";
 export type { MCPServerConfig, MCPToolInfo } from "./types";

--- a/packages/connectors/src/mcp/registry.ts
+++ b/packages/connectors/src/mcp/registry.ts
@@ -1,0 +1,163 @@
+import { MCPConnector } from "./mcp-connector";
+import type { MCPServerConfig, MCPToolInfo } from "./types";
+import type { PolicyEngine } from "@waibspace/policy";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+/**
+ * Classify an MCP tool name into a risk class for policy rule generation.
+ * - Read-only tools (list*, get*, search*, read*) → Class A (auto-approve)
+ * - Mutating tools (create, update, delete, send, write) → Class C (approval required)
+ * - Everything else → Class B (standing approval)
+ */
+function classifyTool(toolName: string): { riskClass: "A" | "B" | "C"; autoApprove: boolean } {
+  const lower = toolName.toLowerCase();
+
+  const readOnlyPrefixes = ["list", "get", "search", "read"];
+  if (readOnlyPrefixes.some((p) => lower.startsWith(p))) {
+    return { riskClass: "A", autoApprove: true };
+  }
+
+  const mutatingKeywords = ["create", "update", "delete", "send", "write"];
+  if (mutatingKeywords.some((k) => lower.includes(k))) {
+    return { riskClass: "C", autoApprove: false };
+  }
+
+  return { riskClass: "B", autoApprove: true };
+}
+
+export class MCPServerRegistry {
+  private servers = new Map<string, { config: MCPServerConfig; connector: MCPConnector }>();
+  private policyEngine: PolicyEngine | undefined;
+
+  constructor(policyEngine?: PolicyEngine) {
+    this.policyEngine = policyEngine;
+  }
+
+  /** Add a new server config (doesn't connect yet). */
+  addServer(config: MCPServerConfig): void {
+    if (this.servers.has(config.id)) {
+      throw new Error(`MCP server "${config.id}" is already registered`);
+    }
+    const connector = new MCPConnector(config);
+    this.servers.set(config.id, { config, connector });
+  }
+
+  /** Remove a server (disconnects if connected). */
+  async removeServer(id: string): Promise<void> {
+    const entry = this.servers.get(id);
+    if (!entry) {
+      throw new Error(`MCP server "${id}" not found`);
+    }
+    if (entry.connector.isConnected()) {
+      await this.disconnectServer(id);
+    }
+    this.servers.delete(id);
+  }
+
+  /** Connect to a specific server and auto-generate policy rules for discovered tools. */
+  async connectServer(id: string): Promise<void> {
+    const entry = this.servers.get(id);
+    if (!entry) {
+      throw new Error(`MCP server "${id}" not found`);
+    }
+    await entry.connector.connect();
+    this.generatePolicyRules(id, entry.connector.getDiscoveredTools());
+  }
+
+  /** Disconnect from a specific server and remove its policy rules. */
+  async disconnectServer(id: string): Promise<void> {
+    const entry = this.servers.get(id);
+    if (!entry) {
+      throw new Error(`MCP server "${id}" not found`);
+    }
+    this.removePolicyRules(id);
+    await entry.connector.disconnect();
+  }
+
+  /** Get status of all servers. */
+  getServers(): Array<{ config: MCPServerConfig; connected: boolean; toolCount: number }> {
+    return Array.from(this.servers.values()).map(({ config, connector }) => ({
+      config,
+      connected: connector.isConnected(),
+      toolCount: connector.getDiscoveredTools().length,
+    }));
+  }
+
+  /** Get a specific server's discovered tools. */
+  getServerTools(id: string): MCPToolInfo[] {
+    const entry = this.servers.get(id);
+    if (!entry) {
+      throw new Error(`MCP server "${id}" not found`);
+    }
+    return entry.connector.getDiscoveredTools();
+  }
+
+  /** Get ALL tools across ALL connected servers. */
+  getAllTools(): MCPToolInfo[] {
+    const tools: MCPToolInfo[] = [];
+    for (const { connector } of this.servers.values()) {
+      if (connector.isConnected()) {
+        tools.push(...connector.getDiscoveredTools());
+      }
+    }
+    return tools;
+  }
+
+  /** Get a connected MCPConnector by server ID. */
+  getConnector(id: string): MCPConnector | undefined {
+    return this.servers.get(id)?.connector;
+  }
+
+  /** Persist server configs to a JSON file. */
+  async save(path: string): Promise<void> {
+    const configs = Array.from(this.servers.values()).map(({ config }) => config);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify(configs, null, 2), "utf-8");
+  }
+
+  /** Load server configs from a JSON file (adds servers but does not connect). */
+  async load(path: string): Promise<void> {
+    try {
+      const raw = await readFile(path, "utf-8");
+      const configs: MCPServerConfig[] = JSON.parse(raw);
+      for (const config of configs) {
+        if (!this.servers.has(config.id)) {
+          this.addServer(config);
+        }
+      }
+    } catch {
+      // File doesn't exist or is invalid — that's fine, start empty
+    }
+  }
+
+  /** Generate policy rules for a server's discovered tools. */
+  private generatePolicyRules(serverId: string, tools: MCPToolInfo[]): void {
+    if (!this.policyEngine) return;
+
+    for (const tool of tools) {
+      const { riskClass, autoApprove } = classifyTool(tool.name);
+      const ruleId = `mcp:${serverId}:${tool.name}`;
+      this.policyEngine.addRule({
+        id: ruleId,
+        name: `MCP ${tool.serverName} - ${tool.name}`,
+        description: tool.description ?? `Auto-generated rule for MCP tool "${tool.name}"`,
+        actionPattern: tool.name,
+        riskClass,
+        autoApprove,
+      });
+    }
+  }
+
+  /** Remove all policy rules associated with a server. */
+  private removePolicyRules(serverId: string): void {
+    if (!this.policyEngine) return;
+
+    const prefix = `mcp:${serverId}:`;
+    for (const rule of this.policyEngine.getRules()) {
+      if (rule.id.startsWith(prefix)) {
+        this.policyEngine.removeRule(rule.id);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **MCPServerRegistry** (`packages/connectors/src/mcp/registry.ts`): manages multiple MCP server connections with add/remove/connect/disconnect lifecycle, tool discovery aggregation, and JSON persistence (save/load)
- **Auto-generated policy rules**: classifies discovered tools by name pattern — read-only prefixes (list/get/search/read) → Class A auto-approve, mutating keywords (create/update/delete/send/write) → Class C approval-required, everything else → Class B; rules are prefixed `mcp:{serverId}:` for clean removal on disconnect
- **REST API endpoints** in backend server: GET/POST `/api/mcp/servers`, DELETE `/api/mcp/servers/:id`, POST `.../connect` and `.../disconnect`, GET `.../tools`
- **Backend wiring**: creates MCPServerRegistry with PolicyEngine, loads from `./data/mcp-servers.json`, auto-connects enabled servers, registers connectors with main ConnectorRegistry

Closes #102

## Test plan
- [ ] Verify `MCPServerRegistry` add/remove/connect/disconnect lifecycle with a stdio MCP server
- [ ] Confirm policy rules are generated on connect and cleaned up on disconnect
- [ ] Test REST endpoints: list servers, add server, connect, get tools, disconnect, remove
- [ ] Verify `save()`/`load()` round-trips server configs correctly
- [ ] Confirm backend boots cleanly with no `mcp-servers.json` present (empty start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)