### PR TITLE
feat: settings page with MCP connection management

### DIFF
--- a/apps/frontend/src/components/ConnectionManager.tsx
+++ b/apps/frontend/src/components/ConnectionManager.tsx
@@ -1,0 +1,370 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { MCPServer, MCPTool } from "../types/mcp";
+
+const POLL_INTERVAL = 5000;
+
+export function ConnectionManager() {
+  const [servers, setServers] = useState<MCPServer[]>([]);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [expandedServer, setExpandedServer] = useState<string | null>(null);
+  const [tools, setTools] = useState<Record<string, MCPTool[]>>({});
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Form state
+  const [formTransport, setFormTransport] = useState<"stdio" | "sse">("stdio");
+  const [formName, setFormName] = useState("");
+  const [formCommand, setFormCommand] = useState("");
+  const [formArgs, setFormArgs] = useState("");
+  const [formUrl, setFormUrl] = useState("");
+
+  const fetchServers = useCallback(async () => {
+    try {
+      const res = await fetch("/api/mcp/servers");
+      if (res.ok) {
+        const data = await res.json();
+        setServers(data);
+      }
+    } catch {
+      // silent polling failure
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchServers();
+    pollRef.current = setInterval(fetchServers, POLL_INTERVAL);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [fetchServers]);
+
+  const loadTools = async (serverId: string) => {
+    try {
+      const res = await fetch(`/api/mcp/servers/${serverId}/tools`);
+      if (res.ok) {
+        const data = await res.json();
+        setTools((prev) => ({ ...prev, [serverId]: data }));
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  const toggleExpanded = (serverId: string) => {
+    if (expandedServer === serverId) {
+      setExpandedServer(null);
+    } else {
+      setExpandedServer(serverId);
+      if (!tools[serverId]) {
+        loadTools(serverId);
+      }
+    }
+  };
+
+  const connectServer = async (id: string) => {
+    setActionLoading(id);
+    try {
+      await fetch(`/api/mcp/servers/${id}/connect`, { method: "POST" });
+      await fetchServers();
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const disconnectServer = async (id: string) => {
+    setActionLoading(id);
+    try {
+      await fetch(`/api/mcp/servers/${id}/disconnect`, { method: "POST" });
+      await fetchServers();
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const deleteServer = async (id: string) => {
+    setActionLoading(id);
+    try {
+      await fetch(`/api/mcp/servers/${id}`, { method: "DELETE" });
+      setDeleteConfirm(null);
+      await fetchServers();
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const addServer = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formName.trim()) return;
+
+    const config: Record<string, unknown> = {
+      name: formName.trim(),
+      transport: formTransport,
+    };
+
+    if (formTransport === "stdio") {
+      if (!formCommand.trim()) return;
+      config.command = formCommand.trim();
+      if (formArgs.trim()) {
+        config.args = formArgs.split(",").map((a) => a.trim()).filter(Boolean);
+      }
+    } else {
+      if (!formUrl.trim()) return;
+      config.url = formUrl.trim();
+    }
+
+    setActionLoading("add");
+    try {
+      await fetch("/api/mcp/servers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(config),
+      });
+      setFormName("");
+      setFormCommand("");
+      setFormArgs("");
+      setFormUrl("");
+      setShowAddForm(false);
+      await fetchServers();
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const getStatusClass = (server: MCPServer) => {
+    if (server.connected) return "connected";
+    return "disconnected";
+  };
+
+  const getStatusLabel = (server: MCPServer) => {
+    if (server.connected) return "Connected";
+    return "Disconnected";
+  };
+
+  if (loading) {
+    return (
+      <div className="conn-loading">
+        <span className="conn-loading-dot" />
+        Loading connections...
+      </div>
+    );
+  }
+
+  return (
+    <div className="connection-manager">
+      <div className="conn-header">
+        <h3>Connections</h3>
+        <button
+          className="conn-add-btn"
+          onClick={() => setShowAddForm(!showAddForm)}
+        >
+          {showAddForm ? "Cancel" : "+ Add Connection"}
+        </button>
+      </div>
+
+      {showAddForm && (
+        <form className="conn-form" onSubmit={addServer}>
+          <div className="conn-form-row">
+            <label className="conn-label">Transport Type</label>
+            <div className="conn-transport-selector">
+              <button
+                type="button"
+                className={`conn-transport-btn ${formTransport === "stdio" ? "active" : ""}`}
+                onClick={() => setFormTransport("stdio")}
+              >
+                stdio
+              </button>
+              <button
+                type="button"
+                className={`conn-transport-btn ${formTransport === "sse" ? "active" : ""}`}
+                onClick={() => setFormTransport("sse")}
+              >
+                HTTP
+              </button>
+            </div>
+          </div>
+
+          <div className="conn-form-row">
+            <label className="conn-label" htmlFor="conn-name">
+              Server Name
+            </label>
+            <input
+              id="conn-name"
+              className="conn-input"
+              type="text"
+              value={formName}
+              onChange={(e) => setFormName(e.target.value)}
+              placeholder="My MCP Server"
+              required
+            />
+          </div>
+
+          {formTransport === "stdio" ? (
+            <>
+              <div className="conn-form-row">
+                <label className="conn-label" htmlFor="conn-command">
+                  Command
+                </label>
+                <input
+                  id="conn-command"
+                  className="conn-input"
+                  type="text"
+                  value={formCommand}
+                  onChange={(e) => setFormCommand(e.target.value)}
+                  placeholder="npx, python, node..."
+                  required
+                />
+              </div>
+              <div className="conn-form-row">
+                <label className="conn-label" htmlFor="conn-args">
+                  Arguments (comma-separated)
+                </label>
+                <input
+                  id="conn-args"
+                  className="conn-input"
+                  type="text"
+                  value={formArgs}
+                  onChange={(e) => setFormArgs(e.target.value)}
+                  placeholder="-y, @modelcontextprotocol/server-github"
+                />
+              </div>
+            </>
+          ) : (
+            <div className="conn-form-row">
+              <label className="conn-label" htmlFor="conn-url">
+                Server URL
+              </label>
+              <input
+                id="conn-url"
+                className="conn-input"
+                type="url"
+                value={formUrl}
+                onChange={(e) => setFormUrl(e.target.value)}
+                placeholder="http://localhost:3000/sse"
+                required
+              />
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="conn-submit-btn"
+            disabled={actionLoading === "add"}
+          >
+            {actionLoading === "add" ? "Adding..." : "Add Server"}
+          </button>
+        </form>
+      )}
+
+      <div className="conn-list">
+        {servers.length === 0 && (
+          <div className="conn-empty">
+            No MCP server connections configured. Add one to get started.
+          </div>
+        )}
+
+        {servers.map((server) => (
+          <div key={server.config.id} className="conn-card">
+            <div className="conn-card-header">
+              <div className="conn-card-info">
+                <span
+                  className={`connection-dot ${getStatusClass(server)}`}
+                  title={getStatusLabel(server)}
+                />
+                <span className="conn-card-name">{server.config.name}</span>
+                <span className="conn-badge">{server.config.transport}</span>
+              </div>
+              <div className="conn-card-actions">
+                {server.connected && server.toolCount > 0 && (
+                  <span className="conn-tool-count">
+                    {server.toolCount} tool{server.toolCount !== 1 ? "s" : ""}{" "}
+                    available
+                  </span>
+                )}
+                <button
+                  className={`conn-action-btn ${server.connected ? "disconnect" : "connect"}`}
+                  onClick={() =>
+                    server.connected
+                      ? disconnectServer(server.config.id)
+                      : connectServer(server.config.id)
+                  }
+                  disabled={actionLoading === server.config.id}
+                >
+                  {actionLoading === server.config.id
+                    ? "..."
+                    : server.connected
+                      ? "Disconnect"
+                      : "Connect"}
+                </button>
+                {deleteConfirm === server.config.id ? (
+                  <div className="conn-delete-confirm">
+                    <span>Delete?</span>
+                    <button
+                      className="conn-action-btn danger"
+                      onClick={() => deleteServer(server.config.id)}
+                      disabled={actionLoading === server.config.id}
+                    >
+                      Yes
+                    </button>
+                    <button
+                      className="conn-action-btn"
+                      onClick={() => setDeleteConfirm(null)}
+                    >
+                      No
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    className="conn-action-btn danger"
+                    onClick={() => setDeleteConfirm(server.config.id)}
+                  >
+                    Delete
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {server.connected && (
+              <button
+                className="conn-expand-btn"
+                onClick={() => toggleExpanded(server.config.id)}
+              >
+                {expandedServer === server.config.id
+                  ? "Hide tools"
+                  : "Show tools"}
+              </button>
+            )}
+
+            {expandedServer === server.config.id && (
+              <div className="conn-tools">
+                {!tools[server.config.id] ? (
+                  <span className="conn-tools-loading">Loading tools...</span>
+                ) : tools[server.config.id].length === 0 ? (
+                  <span className="conn-tools-empty">
+                    No tools discovered.
+                  </span>
+                ) : (
+                  <ul className="conn-tool-list">
+                    {tools[server.config.id].map((tool) => (
+                      <li key={tool.name} className="conn-tool-item">
+                        <span className="conn-tool-name">{tool.name}</span>
+                        {tool.description && (
+                          <span className="conn-tool-desc">
+                            {tool.description}
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/Layout.tsx
+++ b/apps/frontend/src/components/Layout.tsx
@@ -1,10 +1,32 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, Link, useLocation } from "react-router-dom";
 
 export default function Layout() {
+  const location = useLocation();
+
   return (
     <div className="layout">
       <header className="layout-header">
-        <span className="logo">WaibSpace</span>
+        <Link to="/" className="logo">WaibSpace</Link>
+        <nav className="layout-nav">
+          <Link
+            to="/"
+            className={`nav-link ${location.pathname === "/" ? "active" : ""}`}
+          >
+            Home
+          </Link>
+          <Link
+            to="/tasks"
+            className={`nav-link ${location.pathname === "/tasks" ? "active" : ""}`}
+          >
+            Tasks
+          </Link>
+          <Link
+            to="/settings"
+            className={`nav-link ${location.pathname === "/settings" ? "active" : ""}`}
+          >
+            Settings
+          </Link>
+        </nav>
       </header>
 
       <main className="layout-main">

--- a/apps/frontend/src/pages/SettingsPage.tsx
+++ b/apps/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,10 @@
+import { ConnectionManager } from "../components/ConnectionManager";
+
 export default function SettingsPage() {
   return (
     <div className="page settings-page">
       <h1>Settings</h1>
-      <p className="placeholder">Settings content will be placed here.</p>
+      <ConnectionManager />
     </div>
   );
 }

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -156,6 +156,7 @@ body {
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  text-decoration: none;
 }
 
 .layout-main {
@@ -1955,4 +1956,398 @@ body {
 .surface-wrapper {
   display: flex;
   flex-direction: column;
+}
+
+/* ================================ */
+/* Navigation                       */
+/* ================================ */
+.layout-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-left: auto;
+}
+
+.nav-link {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  border-radius: var(--radius-md);
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.nav-link:hover {
+  color: var(--color-text);
+  background: var(--color-surface-hover);
+}
+
+.nav-link.active {
+  color: var(--color-accent);
+  background: var(--color-accent-subtle);
+}
+
+/* ================================ */
+/* Settings Page                    */
+/* ================================ */
+.settings-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  max-width: 48rem;
+}
+
+.settings-page h1 {
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-bold);
+  letter-spacing: -0.02em;
+}
+
+/* ================================ */
+/* Connection Manager               */
+/* ================================ */
+.connection-manager {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.conn-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.conn-header h3 {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+}
+
+.conn-add-btn {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.conn-add-btn:hover {
+  border-color: var(--color-accent);
+  background: var(--color-accent-subtle);
+}
+
+/* Add Connection Form */
+.conn-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+.conn-form-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.conn-label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.conn-input {
+  padding: 0.625rem var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: var(--text-md);
+  font-family: inherit;
+  outline: none;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.conn-input::placeholder {
+  color: var(--color-muted);
+}
+
+.conn-input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-subtle);
+}
+
+.conn-transport-selector {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.conn-transport-btn {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.conn-transport-btn:hover {
+  border-color: var(--color-accent);
+  color: var(--color-text);
+}
+
+.conn-transport-btn.active {
+  border-color: var(--color-accent);
+  background: var(--color-accent-subtle);
+  color: var(--color-accent);
+}
+
+.conn-submit-btn {
+  align-self: flex-start;
+  padding: 0.625rem var(--space-4);
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-accent);
+  color: #fff;
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: background var(--transition-fast), transform var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.conn-submit-btn:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-glow-accent);
+}
+
+.conn-submit-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+/* Server List */
+.conn-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.conn-empty {
+  padding: var(--space-6);
+  text-align: center;
+  color: var(--color-muted);
+  font-size: var(--text-md);
+  background: var(--color-surface);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+.conn-loading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-muted);
+  font-size: var(--text-md);
+}
+
+.conn-loading-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--color-accent);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+/* Server Card */
+.conn-card {
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.conn-card:hover {
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-md);
+}
+
+.conn-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.conn-card-info {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.conn-card-name {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+}
+
+.conn-badge {
+  padding: 0.125rem var(--space-2);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-muted);
+  background: var(--color-accent-muted);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.conn-card-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.conn-tool-count {
+  font-size: var(--text-sm);
+  color: var(--color-success);
+  padding: 0.125rem var(--space-2);
+  background: var(--color-success-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.conn-action-btn {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.conn-action-btn:hover:not(:disabled) {
+  border-color: var(--color-accent);
+  color: var(--color-text);
+}
+
+.conn-action-btn.connect:hover:not(:disabled) {
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+.conn-action-btn.disconnect:hover:not(:disabled) {
+  border-color: var(--color-warning);
+  color: var(--color-warning);
+}
+
+.conn-action-btn.danger {
+  border-color: rgba(239, 68, 68, 0.3);
+  color: var(--color-danger);
+}
+
+.conn-action-btn.danger:hover:not(:disabled) {
+  border-color: var(--color-danger);
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.conn-action-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.conn-delete-confirm {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-sm);
+  color: var(--color-danger);
+}
+
+/* Expand / Tools */
+.conn-expand-btn {
+  align-self: flex-start;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--color-accent);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.conn-expand-btn:hover {
+  color: var(--color-accent-hover);
+}
+
+.conn-tools {
+  padding: var(--space-3);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.conn-tools-loading,
+.conn-tools-empty {
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+}
+
+.conn-tool-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.conn-tool-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: var(--space-2);
+  border-radius: var(--radius-sm);
+  transition: background var(--transition-fast);
+}
+
+.conn-tool-item:hover {
+  background: var(--color-surface-hover);
+}
+
+.conn-tool-name {
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+}
+
+.conn-tool-desc {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
 }

--- a/apps/frontend/src/types/mcp.ts
+++ b/apps/frontend/src/types/mcp.ts
@@ -1,0 +1,18 @@
+export interface MCPServer {
+  config: {
+    id: string;
+    name: string;
+    transport: string;
+    command?: string;
+    args?: string[];
+    url?: string;
+  };
+  connected: boolean;
+  toolCount: number;
+}
+
+export interface MCPTool {
+  name: string;
+  description?: string;
+  serverId: string;
+}


### PR DESCRIPTION
## Summary
- Add `/settings` route with a full MCP server connection management UI
- New `ConnectionManager` component handles server list display, add/delete/connect/disconnect actions, and tool discovery via REST API polling
- New `MCPServer` and `MCPTool` frontend types in `types/mcp.ts`
- Add navigation links (Home, Tasks, Settings) to the layout header
- Styles use existing design tokens and match the dark theme (card-based server entries, status dots, transport badges, accordion tool list)

## Implementation Details
- **SettingsPage**: renders the `ConnectionManager` component under a "Settings" heading
- **ConnectionManager**: fetches `GET /api/mcp/servers` on mount and polls every 5s; supports adding servers (stdio with command+args, or HTTP with URL), connecting/disconnecting, deleting (with confirmation), and expanding connected servers to view discovered tools
- **Layout**: updated to use `react-router-dom` `Link` components with active state highlighting
- **Styles**: ~400 lines of new CSS covering navigation, settings page, connection form, server cards, action buttons, and tool list

## Test plan
- [ ] Navigate to `/settings` and verify the page loads with "Connections" section
- [ ] Click "+ Add Connection" and verify the form appears with transport toggle
- [ ] Switch between stdio and HTTP transport types and verify correct fields appear
- [ ] Submit the form and verify server appears in the list
- [ ] Verify connect/disconnect buttons work and status dots update
- [ ] Expand a connected server and verify tools are listed
- [ ] Delete a server with confirmation dialog
- [ ] Verify navigation links in header work and show active state
- [ ] Verify polling updates server status automatically

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)