### PR TITLE
feat: wire MCP tools into agent pipeline

### DIFF
--- a/packages/agents/src/context/connector-selection.ts
+++ b/packages/agents/src/context/connector-selection.ts
@@ -1,5 +1,6 @@
 import type { AgentOutput } from "@waibspace/types";
 import type { ConnectorRegistry } from "@waibspace/connectors";
+import type { MCPToolInfo } from "@waibspace/connectors";
 import { BaseAgent } from "../base-agent";
 import type { AgentInput, AgentContext } from "../types";
 import type { DataSourcePlan } from "./context-planner";
@@ -56,8 +57,27 @@ export class ConnectorSelectionAgent extends BaseAgent {
 
     for (const source of dataSourcePlan.dataSources) {
       const connector = registry.get(source.connectorId);
-      const available = connector !== undefined && connector.isConnected();
+      let available = connector !== undefined && connector.isConnected();
       const trustLevel = connector?.trustLevel ?? "untrusted";
+
+      // For MCP connectors, verify the requested tool is actually discovered
+      if (available && connector?.type === "mcp") {
+        const mcpConn = connector as unknown as {
+          getDiscoveredTools(): MCPToolInfo[];
+        };
+        if (typeof mcpConn.getDiscoveredTools === "function") {
+          const tools = mcpConn.getDiscoveredTools();
+          const toolExists = tools.some((t) => t.name === source.operation);
+          if (!toolExists) {
+            this.log("MCP tool not found on connector", {
+              connectorId: source.connectorId,
+              tool: source.operation,
+              availableTools: tools.map((t) => t.name),
+            });
+            available = false;
+          }
+        }
+      }
 
       if (!available) {
         unavailableConnectors.push(source.connectorId);

--- a/packages/agents/src/context/context-planner.ts
+++ b/packages/agents/src/context/context-planner.ts
@@ -1,4 +1,5 @@
 import type { AgentOutput } from "@waibspace/types";
+import type { ConnectorRegistry, MCPToolInfo } from "@waibspace/connectors";
 import { BaseAgent } from "../base-agent";
 import type { AgentInput, AgentContext } from "../types";
 import type { IntentClassification } from "../reasoning/intent-agent";
@@ -14,7 +15,7 @@ export interface DataSourcePlan {
   reasoning: string;
 }
 
-const SYSTEM_PROMPT = `You are a context planning agent for WaibSpace, an AI-powered personal assistant.
+const BASE_SYSTEM_PROMPT = `You are a context planning agent for WaibSpace, an AI-powered personal assistant.
 
 Given an intent classification, determine which data sources need to be queried to fulfill the user's request.
 
@@ -32,7 +33,9 @@ Available connectors and their operations:
 
 - **web-fetch**:
   - fetch-url: Fetch content from a URL. Params: url (string)
-  - search-site: Search a website. Params: query (string), site (string)
+  - search-site: Search a website. Params: query (string), site (string)`;
+
+const SYSTEM_PROMPT_SUFFIX = `
 
 For each data source needed, specify:
 - connectorId: which connector to use
@@ -93,6 +96,10 @@ export class ContextPlannerAgent extends BaseAgent {
       category: intentClassification.intentCategory,
     });
 
+    // Build system prompt with available MCP tools
+    const mcpToolsSection = this.buildMCPToolsPromptSection(context);
+    const systemPrompt = BASE_SYSTEM_PROMPT + mcpToolsSection + SYSTEM_PROMPT_SUFFIX;
+
     const userMessage = [
       `Intent: ${intentClassification.primaryIntent}`,
       `Category: ${intentClassification.intentCategory}`,
@@ -106,7 +113,7 @@ export class ContextPlannerAgent extends BaseAgent {
       "reasoning",
       [{ role: "user", content: userMessage }],
       DATA_SOURCE_PLAN_SCHEMA,
-      SYSTEM_PROMPT,
+      systemPrompt,
     );
 
     const endMs = Date.now();
@@ -137,5 +144,60 @@ export class ContextPlannerAgent extends BaseAgent {
       }
     }
     return undefined;
+  }
+
+  /**
+   * Build a prompt section describing available MCP tools by querying
+   * the ConnectorRegistry for MCP-type connectors.
+   */
+  private buildMCPToolsPromptSection(context: AgentContext): string {
+    const registry = context.config?.["connectorRegistry"] as
+      | ConnectorRegistry
+      | undefined;
+    if (!registry) {
+      return "";
+    }
+
+    const mcpConnectors = registry.getByType("mcp");
+    if (mcpConnectors.length === 0) {
+      return "";
+    }
+
+    const sections: string[] = [];
+    for (const connector of mcpConnectors) {
+      const mcpConn = connector as unknown as {
+        getDiscoveredTools(): MCPToolInfo[];
+      };
+      if (typeof mcpConn.getDiscoveredTools !== "function") {
+        continue;
+      }
+
+      const tools = mcpConn.getDiscoveredTools();
+      if (tools.length === 0) {
+        continue;
+      }
+
+      const toolLines = tools.map((tool) => {
+        const desc = tool.description ? `: ${tool.description}` : "";
+        const schema = tool.inputSchema
+          ? `. Params: ${JSON.stringify(tool.inputSchema)}`
+          : "";
+        return `  - ${tool.name}${desc}${schema}`;
+      });
+
+      sections.push(
+        `\n- **${connector.id}** (MCP):\n${toolLines.join("\n")}`,
+      );
+    }
+
+    if (sections.length === 0) {
+      return "";
+    }
+
+    this.log("Including MCP tools in planning prompt", {
+      mcpConnectors: sections.length,
+    });
+
+    return sections.join("");
   }
 }


### PR DESCRIPTION
## Summary
- **ContextPlannerAgent**: Dynamically includes discovered MCP tool descriptions (name, description, input schema) in the LLM planning prompt by querying `ConnectorRegistry.getByType("mcp")` and calling `getDiscoveredTools()` on each MCP connector
- **ConnectorSelectionAgent**: Validates that requested MCP tool operations actually exist on the connector by checking discovered tools before marking retrievals as available
- **DataRetrievalAgent / MCPConnector**: Already handle MCP tools correctly — `operation` maps directly to the MCP tool name, and `MCPConnector.createProvenance()` produces proper provenance with `sourceType: "mcp"`, `sourceId: "{serverId}:{toolName}"`, and inherited trust level

No changes needed to the orchestrator or backend wiring — the `connectorRegistry` is already passed through `context.config` to all context agents.

Closes #104

## Test plan
- [ ] Register an MCP connector with discovered tools and verify ContextPlannerAgent includes them in the LLM prompt
- [ ] Verify ConnectorSelectionAgent marks MCP retrievals as unavailable when the tool name doesn't match any discovered tool
- [ ] Verify end-to-end flow: MCP tool is planned, selected, invoked via DataRetrievalAgent, and results carry correct provenance metadata
- [ ] Verify no regression for existing Gmail/Calendar/WebFetch connector flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)