### PR TITLE
feat: SQLite database, MCP catalog connection flow, pipeline reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,5 @@ PORT=3001
 ANTHROPIC_API_KEY=your_anthropic_api_key_here       # Required
 OPENAI_API_KEY=your_openai_api_key_here             # Optional
 
-# External services (Gmail, Calendar, etc.) are connected through
-# the Settings UI via MCP servers — no env vars needed.
+# External services are connected via MCP servers —
+# managed through chat or the Settings UI. No env vars needed.

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ apps/backend/data/*
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+apps/backend/.env

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,6 +11,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@waibspace/db": "workspace:*",
     "@waibspace/types": "workspace:*",
     "@waibspace/event-bus": "workspace:*",
     "@waibspace/orchestrator": "workspace:*",

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -21,6 +21,7 @@ import {
   CalendarSurfaceAgent,
   DiscoverySurfaceAgent,
   ApprovalSurfaceAgent,
+  ConnectionSurfaceAgent,
   LayoutComposerAgent,
   // Safety agents
   ProvenanceAnnotatorAgent,
@@ -38,12 +39,17 @@ import {
   AnthropicProvider,
 } from "@waibspace/model-provider";
 import { MemoryStore, MemoryUpdatePipeline } from "@waibspace/memory";
+import { WaibDatabase } from "@waibspace/db";
 import { BackgroundTaskScheduler, MVP_BACKGROUND_TASKS } from "./background";
 import { startServer } from "./server";
 import { broadcast } from "./ws";
 
 // ---------- 1. Event Bus ----------
 const bus = new EventBus();
+
+// ---------- 1b. Database ----------
+const db = new WaibDatabase("./data/waibspace.db");
+console.log("[backend] SQLite database initialized");
 
 // ---------- 2. Model Provider ----------
 const modelRegistry = new ModelProviderRegistry();
@@ -69,9 +75,8 @@ const policyEngine = new PolicyEngine(DEFAULT_POLICY_RULES);
 console.log(`[backend] Policy engine initialized with ${policyEngine.getRules().length} rules`);
 
 // ---------- 4b. MCP Server Registry ----------
-const mcpRegistry = new MCPServerRegistry(policyEngine);
-const MCP_SERVERS_PATH = "./data/mcp-servers.json";
-await mcpRegistry.load(MCP_SERVERS_PATH);
+const mcpRegistry = new MCPServerRegistry(policyEngine, db);
+await mcpRegistry.load();
 
 // Auto-connect enabled servers and register their connectors
 for (const server of mcpRegistry.getServers()) {
@@ -119,6 +124,7 @@ agentRegistry.register(new InboxSurfaceAgent());
 agentRegistry.register(new CalendarSurfaceAgent());
 agentRegistry.register(new DiscoverySurfaceAgent());
 agentRegistry.register(new ApprovalSurfaceAgent());
+agentRegistry.register(new ConnectionSurfaceAgent());
 agentRegistry.register(new LayoutComposerAgent());
 
 // Safety agents
@@ -132,9 +138,7 @@ console.log(
 );
 
 // ---------- 6. Memory Store ----------
-const memoryStore = new MemoryStore("./data/memory.json", bus);
-await memoryStore.load();
-memoryStore.startAutoSave();
+const memoryStore = new MemoryStore(db, bus);
 
 // ---------- 7. Orchestrator ----------
 const orchestrator = new Orchestrator(bus, agentRegistry, {
@@ -142,6 +146,7 @@ const orchestrator = new Orchestrator(bus, agentRegistry, {
   memoryStore,
   connectorRegistry,
   policyEngine,
+  db,
 });
 
 // ---------- 8. Memory Update Pipeline ----------
@@ -205,7 +210,7 @@ bus.on("surface.composed", (event: WaibEvent) => {
 });
 
 // ---------- 12. Start HTTP/WebSocket server ----------
-const server = startServer({ eventBus: bus, orchestrator, memoryStore, scheduler, mcpRegistry });
+const server = startServer({ eventBus: bus, orchestrator, memoryStore, scheduler, mcpRegistry, connectorRegistry, db });
 
 const PORT = Number(process.env.PORT) || 3001;
 console.log(`[backend] WaibSpace backend started`);

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -2,7 +2,10 @@ import type { EventBus } from "@waibspace/event-bus";
 import type { Orchestrator } from "@waibspace/orchestrator";
 import type { BackgroundTaskScheduler } from "./background";
 import type { MemoryStore } from "@waibspace/memory";
-import type { MCPServerRegistry } from "@waibspace/connectors";
+import type { WaibDatabase } from "@waibspace/db";
+import type { MCPServerRegistry, MCPServerConfig } from "@waibspace/connectors";
+import { findTemplate, MCP_SERVER_CATALOG } from "@waibspace/connectors";
+import type { ConnectorRegistry } from "@waibspace/connectors";
 import {
   createWebSocketHandlers,
   type WebSocketData,
@@ -29,6 +32,8 @@ export interface ServerDeps {
   scheduler?: BackgroundTaskScheduler;
   memoryStore?: MemoryStore;
   mcpRegistry?: MCPServerRegistry;
+  connectorRegistry?: ConnectorRegistry;
+  db?: WaibDatabase;
 }
 
 const startTime = Date.now();
@@ -185,6 +190,122 @@ export function startServer(deps: ServerDeps) {
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           return jsonResponse({ error: message }, 404);
+        }
+      }
+
+      // GET /api/logs?limit=50&level=error — query event logs
+      if (url.pathname === "/api/logs" && req.method === "GET") {
+        if (!deps.db) {
+          return jsonResponse({ error: "Database not available" }, 503);
+        }
+        const limit = Number(url.searchParams.get("limit") ?? "50");
+        const level = url.searchParams.get("level") ?? undefined;
+        const traceId = url.searchParams.get("trace") ?? undefined;
+
+        let rows;
+        if (traceId) {
+          rows = deps.db.getEventsByTrace(traceId);
+        } else {
+          rows = deps.db.getRecentEvents(limit, level);
+        }
+
+        return jsonResponse(
+          rows.map((r) => ({
+            ...r,
+            payload: JSON.parse(r.payload),
+          })),
+        );
+      }
+
+      // GET /api/mcp/catalog — list available MCP server templates
+      if (url.pathname === "/api/mcp/catalog" && req.method === "GET") {
+        return jsonResponse(
+          MCP_SERVER_CATALOG.map((t) => ({
+            id: t.id,
+            name: t.name,
+            description: t.description,
+            icon: t.icon,
+            categories: t.categories,
+            credentialCount: t.requiredCredentials.length,
+          })),
+        );
+      }
+
+      // POST /api/mcp/setup — set up an MCP server from catalog template
+      if (url.pathname === "/api/mcp/setup" && req.method === "POST") {
+        if (!deps.mcpRegistry) {
+          return jsonResponse({ error: "MCP registry not available" }, 503);
+        }
+        try {
+          const body = (await req.json()) as {
+            templateId: string;
+            credentials: Record<string, string>;
+          };
+          const { templateId, credentials } = body;
+
+          // Look up template
+          const template = findTemplate(templateId);
+          if (!template) {
+            return jsonResponse({ error: `Unknown service: ${templateId}` }, 400);
+          }
+
+          // Validate required credentials
+          for (const cred of template.requiredCredentials) {
+            if (!credentials[cred.key]) {
+              return jsonResponse(
+                { error: `Missing required credential: ${cred.label}` },
+                400,
+              );
+            }
+          }
+
+          // Build MCPServerConfig from template
+          const config: MCPServerConfig = {
+            id: `catalog-${template.id}`,
+            name: template.name,
+            transport: "stdio",
+            command: template.command,
+            args: [...template.args],
+            env: { ...(template.defaultEnv ?? {}), ...credentials },
+            trustLevel: template.trustLevel,
+            enabled: true,
+          };
+
+          // Remove existing server if reconnecting
+          try {
+            await deps.mcpRegistry.removeServer(config.id);
+          } catch {
+            // Not found — that's fine
+          }
+
+          // Add, connect, and register connector
+          deps.mcpRegistry.addServer(config);
+          await deps.mcpRegistry.connectServer(config.id);
+
+          if (deps.connectorRegistry) {
+            const connector = deps.mcpRegistry.getConnector(config.id);
+            if (connector) {
+              deps.connectorRegistry.register(connector);
+            }
+          }
+
+          // Persist
+          await deps.mcpRegistry.save();
+
+          // Return discovered tools
+          const tools = deps.mcpRegistry.getServerTools(config.id);
+          return jsonResponse({
+            ok: true,
+            id: config.id,
+            name: template.name,
+            tools: tools.map((t) => ({
+              name: t.name,
+              description: t.description,
+            })),
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return jsonResponse({ error: message }, 500);
         }
       }
 

--- a/apps/frontend/src/components/Layout.tsx
+++ b/apps/frontend/src/components/Layout.tsx
@@ -1,7 +1,31 @@
-import { Outlet, Link, useLocation } from "react-router-dom";
+import { useState } from "react";
+import { Outlet, Link, useLocation, useNavigate } from "react-router-dom";
 
 export default function Layout() {
   const location = useLocation();
+  const navigate = useNavigate();
+  const [globalInput, setGlobalInput] = useState("");
+
+  const handleGlobalSubmit = () => {
+    const text = globalInput.trim();
+    if (!text) return;
+    // Navigate to home page where the WebSocket chat lives,
+    // passing the message via location state
+    setGlobalInput("");
+    if (location.pathname !== "/") {
+      navigate("/", { state: { pendingMessage: text } });
+    } else {
+      // Dispatch a custom event that HomePage can listen for
+      window.dispatchEvent(new CustomEvent("waibspace:global-message", { detail: text }));
+    }
+  };
+
+  const handleGlobalKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleGlobalSubmit();
+    }
+  };
 
   return (
     <div className="layout">
@@ -33,14 +57,28 @@ export default function Layout() {
         <Outlet />
       </main>
 
-      <footer className="layout-footer">
-        <input
-          className="input-bar"
-          type="text"
-          placeholder="Type a message…"
-          aria-label="Message input"
-        />
-      </footer>
+      {location.pathname !== "/" && (
+        <footer className="layout-footer">
+          <div className="global-input-bar">
+            <input
+              className="input-bar"
+              type="text"
+              value={globalInput}
+              onChange={(e) => setGlobalInput(e.target.value)}
+              onKeyDown={handleGlobalKeyDown}
+              placeholder="Type a message..."
+              aria-label="Message input"
+            />
+            <button
+              className="global-send-btn"
+              onClick={handleGlobalSubmit}
+              disabled={!globalInput.trim()}
+            >
+              Send
+            </button>
+          </div>
+        </footer>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/components/surfaces/ConnectionGuideSurface.tsx
+++ b/apps/frontend/src/components/surfaces/ConnectionGuideSurface.tsx
@@ -1,0 +1,255 @@
+import { useState } from "react";
+import type { SurfaceProps } from "./registry";
+
+interface ConnectionGuideData {
+  step: "browse" | "credentials" | "connecting" | "success" | "error";
+  message: string;
+  availableServices: Array<{
+    id: string;
+    name: string;
+    description: string;
+    icon: string;
+    categories: string[];
+  }>;
+  selectedService?: {
+    id: string;
+    name: string;
+    icon: string;
+    description: string;
+  };
+  credentialFields?: Array<{
+    key: string;
+    label: string;
+    helpText: string;
+    helpUrl?: string;
+    sensitive: boolean;
+  }>;
+  discoveredTools?: Array<{ name: string; description?: string }>;
+  errorDetail?: string;
+}
+
+export function ConnectionGuideSurface({
+  spec,
+  onInteraction,
+}: SurfaceProps) {
+  const data = spec.data as ConnectionGuideData;
+
+  // Local state for the connect flow (credentials → connecting → success/error)
+  const [localStep, setLocalStep] = useState<
+    "idle" | "connecting" | "success" | "error"
+  >("idle");
+  const [credentials, setCredentials] = useState<Record<string, string>>({});
+  const [discoveredTools, setDiscoveredTools] = useState<
+    Array<{ name: string; description?: string }>
+  >([]);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  // The active step: use localStep override if we're in the connect flow, otherwise use data.step
+  const activeStep = localStep !== "idle" ? localStep : data.step;
+
+  const handleSelectService = (serviceId: string) => {
+    onInteraction("select-service", serviceId, { service: serviceId });
+  };
+
+  const handleCredentialChange = (key: string, value: string) => {
+    setCredentials((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleConnect = async () => {
+    if (!data.selectedService) return;
+
+    setLocalStep("connecting");
+
+    const backendPort = import.meta.env.VITE_WS_PORT || 3001;
+    const backendHost = window.location.hostname;
+
+    try {
+      const res = await fetch(
+        `http://${backendHost}:${backendPort}/api/mcp/setup`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            templateId: data.selectedService.id,
+            credentials,
+          }),
+        },
+      );
+
+      const result = (await res.json()) as {
+        ok?: boolean;
+        tools?: Array<{ name: string; description?: string }>;
+        error?: string;
+      };
+
+      if (result.ok && result.tools) {
+        setDiscoveredTools(result.tools);
+        setLocalStep("success");
+      } else {
+        setErrorMessage(result.error || "Connection failed");
+        setLocalStep("error");
+      }
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : "Network error");
+      setLocalStep("error");
+    }
+  };
+
+  const handleRetry = () => {
+    setLocalStep("idle");
+    setErrorMessage("");
+  };
+
+  return (
+    <div className="surface connection-guide-surface">
+      <div className="surface-header">
+        <h3>{spec.title}</h3>
+      </div>
+
+      <div className="connection-guide-content">
+        {activeStep !== "connecting" &&
+          activeStep !== "success" &&
+          activeStep !== "error" && (
+            <p className="connection-guide-message">{data.message}</p>
+          )}
+
+        {/* Browse step: show service catalog */}
+        {activeStep === "browse" && (
+          <div className="connection-service-list">
+            {data.availableServices.map((service) => (
+              <button
+                key={service.id}
+                className="connection-service-card"
+                onClick={() => handleSelectService(service.id)}
+              >
+                <span className="connection-service-icon">{service.icon}</span>
+                <div className="connection-service-info">
+                  <span className="connection-service-name">
+                    {service.name}
+                  </span>
+                  <span className="connection-service-desc">
+                    {service.description}
+                  </span>
+                </div>
+                <span className="connection-service-arrow">&rarr;</span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Credentials step: show input fields */}
+        {activeStep === "credentials" && data.selectedService && (
+          <div className="connection-credentials-section">
+            <div className="connection-selected-service">
+              <span className="connection-service-icon">
+                {data.selectedService.icon}
+              </span>
+              <div className="connection-service-info">
+                <span className="connection-service-name">
+                  {data.selectedService.name}
+                </span>
+                <span className="connection-service-desc">
+                  {data.selectedService.description}
+                </span>
+              </div>
+            </div>
+
+            {data.credentialFields && data.credentialFields.length > 0 ? (
+              <div className="connection-credential-fields">
+                {data.credentialFields.map((field) => (
+                  <div key={field.key} className="connection-credential-field">
+                    <label className="connection-credential-label">
+                      {field.label}
+                    </label>
+                    <input
+                      type={field.sensitive ? "password" : "text"}
+                      className="connection-credential-input"
+                      placeholder={field.label}
+                      value={credentials[field.key] || ""}
+                      onChange={(e) =>
+                        handleCredentialChange(field.key, e.target.value)
+                      }
+                    />
+                    <p className="connection-credential-help">
+                      {field.helpText}
+                      {field.helpUrl && (
+                        <>
+                          {" "}
+                          <a
+                            href={field.helpUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="connection-help-link"
+                          >
+                            Get it here &rarr;
+                          </a>
+                        </>
+                      )}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="connection-no-creds-message">
+                No credentials needed — just click Connect!
+              </p>
+            )}
+
+            <button className="connection-connect-btn" onClick={handleConnect}>
+              Connect {data.selectedService.name}
+            </button>
+          </div>
+        )}
+
+        {/* Connecting step: loading */}
+        {activeStep === "connecting" && (
+          <div className="connection-loading-section">
+            <div className="connection-spinner" />
+            <p className="connection-loading-message">
+              Setting up {data.selectedService?.name || "connection"}...
+            </p>
+          </div>
+        )}
+
+        {/* Success step */}
+        {activeStep === "success" && (
+          <div className="connection-success-section">
+            <div className="connection-success-icon">&check;</div>
+            <p className="connection-success-message">
+              {data.selectedService?.name || "Service"} connected successfully!
+            </p>
+            {discoveredTools.length > 0 && (
+              <div className="connection-tools-list">
+                <p className="connection-tools-label">Available tools:</p>
+                {discoveredTools.map((tool, i) => (
+                  <div key={i} className="connection-tool-item">
+                    <span className="connection-tool-name">{tool.name}</span>
+                    {tool.description && (
+                      <span className="connection-tool-desc">
+                        {tool.description}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Error step */}
+        {activeStep === "error" && (
+          <div className="connection-error-section">
+            <p className="connection-error-message">
+              {errorMessage ||
+                data.errorDetail ||
+                "Something went wrong. Please try again."}
+            </p>
+            <button className="connection-retry-btn" onClick={handleRetry}>
+              Try Again
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/surfaces/registry.ts
+++ b/apps/frontend/src/components/surfaces/registry.ts
@@ -4,6 +4,7 @@ import { CalendarSurface } from "./CalendarSurface";
 import { DiscoverySurface } from "./DiscoverySurface";
 import { ApprovalSurface } from "./ApprovalSurface";
 import { GenericSurface } from "./GenericSurface";
+import { ConnectionGuideSurface } from "./ConnectionGuideSurface";
 
 export interface SurfaceProps {
   spec: SurfaceSpec;
@@ -20,4 +21,5 @@ export const surfaceComponents: Record<
   discovery: DiscoverySurface,
   approval: ApprovalSurface,
   generic: GenericSurface,
+  "connection-guide": ConnectionGuideSurface,
 };

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
+import { useLocation } from "react-router-dom";
 import type {
   ComposedLayout,
   AgentStatus as AgentStatusType,
@@ -15,6 +16,7 @@ const WS_URL = `ws://${window.location.hostname}:${import.meta.env.VITE_WS_PORT 
 
 export default function HomePage() {
   const { send, lastMessage, status } = useWebSocket(WS_URL);
+  const location = useLocation();
   const [layout, setLayout] = useState<ComposedLayout | null>(null);
   const [agents, setAgents] = useState<AgentStatusType[]>([]);
   const [hasRequestedAmbient, setHasRequestedAmbient] = useState(false);
@@ -29,6 +31,30 @@ export default function HomePage() {
       setIsLoading(true);
     }
   }, [status, hasRequestedAmbient, send]);
+
+  // Handle messages from the global input bar
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const text = (e as CustomEvent).detail as string;
+      if (text && status === "connected") {
+        send("user.message", { text });
+        setIsLoading(true);
+      }
+    };
+    window.addEventListener("waibspace:global-message", handler);
+    return () => window.removeEventListener("waibspace:global-message", handler);
+  }, [send, status]);
+
+  // Handle pending message from navigation (global bar on other pages)
+  useEffect(() => {
+    const state = location.state as { pendingMessage?: string } | null;
+    if (state?.pendingMessage && status === "connected") {
+      send("user.message", { text: state.pendingMessage });
+      setIsLoading(true);
+      // Clear the state so it doesn't re-send on re-render
+      window.history.replaceState({}, "");
+    }
+  }, [location.state, status, send]);
 
   useEffect(() => {
     if (!lastMessage) return;
@@ -163,7 +189,7 @@ export default function HomePage() {
       </div>
 
       <div className="home-chat">
-        <ChatInput onSend={handleSend} />
+        <ChatInput onSend={handleSend} placeholder="Ask WaibSpace anything..." />
       </div>
     </div>
   );

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -171,6 +171,33 @@ body {
   border-top: 1px solid var(--color-border);
 }
 
+.global-input-bar {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.global-send-btn {
+  padding: 0.625rem 1.25rem;
+  background: var(--color-accent, #00c896);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md, 8px);
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 0.2s;
+}
+
+.global-send-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.global-send-btn:not(:disabled):hover {
+  opacity: 0.85;
+}
+
 .input-bar {
   width: 100%;
   padding: 0.625rem var(--space-3);
@@ -2350,4 +2377,328 @@ body {
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
   line-height: var(--leading-relaxed);
+}
+
+/* ================================ */
+/* Connection Guide Surface         */
+/* ================================ */
+.connection-guide-surface {
+  max-width: 560px;
+}
+
+.connection-guide-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.connection-guide-message {
+  font-size: var(--text-md);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+}
+
+/* Service list (browse step) */
+.connection-service-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.connection-service-card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  text-align: left;
+  color: var(--color-text);
+  font-family: inherit;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.connection-service-card:hover {
+  border-color: var(--color-accent);
+  background: var(--color-surface-hover);
+}
+
+.connection-service-icon {
+  font-size: var(--text-2xl);
+  flex-shrink: 0;
+  width: 2rem;
+  text-align: center;
+}
+
+.connection-service-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.connection-service-name {
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+}
+
+.connection-service-desc {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+}
+
+.connection-service-arrow {
+  font-size: var(--text-lg);
+  color: var(--color-muted);
+  flex-shrink: 0;
+  transition: color var(--transition-fast), transform var(--transition-fast);
+}
+
+.connection-service-card:hover .connection-service-arrow {
+  color: var(--color-accent);
+  transform: translateX(2px);
+}
+
+/* Credentials step */
+.connection-credentials-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.connection-selected-service {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+.connection-credential-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.connection-credential-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.connection-credential-label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.connection-credential-input {
+  padding: 0.625rem var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: var(--text-md);
+  font-family: inherit;
+  outline: none;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.connection-credential-input::placeholder {
+  color: var(--color-muted);
+}
+
+.connection-credential-input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-subtle);
+}
+
+.connection-credential-help {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+}
+
+.connection-help-link {
+  color: var(--color-accent);
+  text-decoration: none;
+  font-weight: var(--weight-medium);
+}
+
+.connection-help-link:hover {
+  text-decoration: underline;
+}
+
+.connection-no-creds-message {
+  font-size: var(--text-md);
+  color: var(--color-text-secondary);
+  text-align: center;
+  padding: var(--space-4) 0;
+  margin: 0;
+}
+
+.connection-connect-btn {
+  padding: var(--space-3) var(--space-6);
+  border: none;
+  border-radius: var(--radius-md);
+  background: #00c896;
+  color: #fff;
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  font-family: inherit;
+  cursor: pointer;
+  transition: background var(--transition-fast), transform var(--transition-fast);
+}
+
+.connection-connect-btn:hover {
+  background: #00b586;
+}
+
+.connection-connect-btn:active {
+  transform: scale(0.98);
+}
+
+/* Loading step */
+.connection-loading-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-8) 0;
+}
+
+.connection-spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 3px solid var(--color-border-strong);
+  border-top-color: #00c896;
+  border-radius: 50%;
+  animation: connection-spin 0.8s linear infinite;
+}
+
+@keyframes connection-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.connection-loading-message {
+  font-size: var(--text-md);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+/* Success step */
+.connection-success-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-6) 0;
+}
+
+.connection-success-icon {
+  width: 3rem;
+  height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(0, 200, 150, 0.15);
+  color: #00c896;
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-bold);
+}
+
+.connection-success-message {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.connection-tools-list {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.connection-tools-label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+.connection-tool-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.connection-tool-name {
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+}
+
+.connection-tool-desc {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+/* Error step */
+.connection-error-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-6) 0;
+}
+
+.connection-error-message {
+  font-size: var(--text-md);
+  color: #ff5050;
+  text-align: center;
+  line-height: var(--leading-relaxed);
+  margin: 0;
+}
+
+.connection-retry-btn {
+  padding: var(--space-2) var(--space-5);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text);
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.connection-retry-btn:hover {
+  border-color: var(--color-accent);
+  background: var(--color-accent-subtle);
 }

--- a/packages/agents/src/context/connector-selection.ts
+++ b/packages/agents/src/context/connector-selection.ts
@@ -33,9 +33,11 @@ export class ConnectorSelectionAgent extends BaseAgent {
     const startMs = Date.now();
 
     const dataSourcePlan = this.findDataSourcePlan(input);
-    if (!dataSourcePlan) {
-      throw new Error(
-        "ConnectorSelectionAgent requires DataSourcePlan from prior outputs",
+    if (!dataSourcePlan || dataSourcePlan.dataSources.length === 0) {
+      return this.createOutput(
+        { retrievals: [], unavailableConnectors: [] },
+        0,
+        { dataState: "raw", timestamp: startMs },
       );
     }
 

--- a/packages/agents/src/context/context-planner.ts
+++ b/packages/agents/src/context/context-planner.ts
@@ -86,8 +86,10 @@ export class ContextPlannerAgent extends BaseAgent {
 
     const intentClassification = this.findIntentClassification(input);
     if (!intentClassification) {
-      throw new Error(
-        "ContextPlannerAgent requires IntentClassification from prior outputs",
+      return this.createOutput(
+        { dataSources: [], reasoning: "No intent classification available" },
+        0,
+        { dataState: "raw", timestamp: startMs },
       );
     }
 

--- a/packages/agents/src/context/data-retrieval.ts
+++ b/packages/agents/src/context/data-retrieval.ts
@@ -41,8 +41,10 @@ export class DataRetrievalAgent extends BaseAgent {
 
     const finalizedPlan = this.findFinalizedPlan(input);
     if (!finalizedPlan) {
-      throw new Error(
-        "DataRetrievalAgent requires FinalizedPlan from prior outputs",
+      return this.createOutput(
+        { results: [], totalAttempted: 0, totalSucceeded: 0, totalFailed: 0 },
+        0,
+        { dataState: "raw", timestamp: startMs },
       );
     }
 
@@ -82,7 +84,7 @@ export class DataRetrievalAgent extends BaseAgent {
         return {
           connectorId: retrieval.connectorId,
           operation: retrieval.operation,
-          data: response.data,
+          data: this.truncateData(response.data),
           provenance: response.provenance,
         };
       }),
@@ -152,6 +154,54 @@ export class DataRetrievalAgent extends BaseAgent {
         durationMs: endMs - startMs,
       },
     };
+  }
+
+  /**
+   * Truncate large data to prevent blowing up LLM token limits.
+   * MCP tools can return megabytes of data (e.g. all unseen emails).
+   * Cap at ~50KB which is roughly 12k tokens.
+   */
+  private truncateData(data: unknown): unknown {
+    const MAX_DATA_SIZE = 50_000;
+
+    // MCP tools return [{type: "text", text: "..."}] — truncate the text content
+    if (Array.isArray(data)) {
+      return data.map((item: unknown) => {
+        if (
+          typeof item === "object" &&
+          item !== null &&
+          (item as Record<string, unknown>).type === "text" &&
+          typeof (item as Record<string, unknown>).text === "string"
+        ) {
+          const text = (item as Record<string, string>).text;
+          if (text.length > MAX_DATA_SIZE) {
+            // Try to parse as JSON array and take first N items
+            try {
+              const parsed = JSON.parse(text);
+              if (Array.isArray(parsed)) {
+                let truncated = parsed.slice(0, 20);
+                let serialized = JSON.stringify(truncated);
+                while (serialized.length > MAX_DATA_SIZE && truncated.length > 1) {
+                  truncated = truncated.slice(0, Math.ceil(truncated.length / 2));
+                  serialized = JSON.stringify(truncated);
+                }
+                return { type: "text", text: serialized };
+              }
+            } catch {
+              // Not JSON, just truncate raw text
+            }
+            return { type: "text", text: text.slice(0, MAX_DATA_SIZE) + "\n...[truncated]" };
+          }
+        }
+        return item;
+      });
+    }
+
+    const str = JSON.stringify(data);
+    if (str.length > MAX_DATA_SIZE) {
+      return JSON.parse(str.slice(0, MAX_DATA_SIZE));
+    }
+    return data;
   }
 
   private findFinalizedPlan(

--- a/packages/agents/src/execution-harness.ts
+++ b/packages/agents/src/execution-harness.ts
@@ -5,7 +5,7 @@ export interface ExecutionOptions {
   timeoutMs?: number;
 }
 
-const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
 
 export async function executeAgent(
   agent: Agent,

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -38,6 +38,7 @@ export {
   CalendarSurfaceAgent,
   DiscoverySurfaceAgent,
   ApprovalSurfaceAgent,
+  ConnectionSurfaceAgent,
   LayoutComposerAgent,
   extractSurfaces,
 } from "./ui";

--- a/packages/agents/src/reasoning/intent-agent.ts
+++ b/packages/agents/src/reasoning/intent-agent.ts
@@ -20,12 +20,19 @@ Analyze the user's input and classify their intent. WaibSpace supports the follo
 - **Calendar management**: view upcoming events, check availability, schedule meetings
 - **Discovery**: find information, movies, restaurants, services, recommendations
 - **Task management**: create tasks, list tasks, complete/update tasks
+- **Service connection**: connect Gmail, connect Google Calendar, link accounts, set up integrations
 
 For each input, determine:
-1. The primary intent (e.g., "check_email", "find_movie", "schedule_meeting", "create_task")
-2. The intent category (one of: "email", "calendar", "discovery", "task", "general")
-3. Any entities mentioned (e.g., genre, date, time, person, subject)
-4. Which downstream agents should handle this (e.g., "context.email", "context.calendar", "ui.discovery")
+1. The primary intent (e.g., "check_email", "find_movie", "schedule_meeting", "create_task", "connect_service")
+2. The intent category (one of: "email", "calendar", "discovery", "task", "connection", "general")
+3. Any entities mentioned (e.g., genre, date, time, person, subject, service name)
+4. Which downstream agents should handle this (e.g., "context.email", "context.calendar", "ui.discovery", "ui.connection-surface")
+
+When the user wants to connect, link, or set up a service (Gmail, Calendar, email, etc.), classify as:
+- primaryIntent: "connect_service"
+- intentCategory: "connection"
+- entities: include "service" with the service name (e.g., "gmail", "calendar")
+- suggestedAgents: ["ui.connection-surface"]
 5. Your confidence level (0-1)
 6. A brief reasoning explanation
 

--- a/packages/agents/src/ui/approval-surface.ts
+++ b/packages/agents/src/ui/approval-surface.ts
@@ -24,9 +24,10 @@ export class ApprovalSurfaceAgent extends BaseAgent {
 
     const policyDecision = this.findPolicyDecision(input);
     if (!policyDecision) {
-      throw new Error(
-        "ApprovalSurfaceAgent requires a PolicyDecision with approval_required verdict",
-      );
+      return this.createOutput(null, 0, {
+        dataState: "raw",
+        timestamp: startMs,
+      });
     }
 
     this.log("Building approval surface", {

--- a/packages/agents/src/ui/calendar-surface.ts
+++ b/packages/agents/src/ui/calendar-surface.ts
@@ -107,9 +107,10 @@ export class CalendarSurfaceAgent extends BaseAgent {
 
     const retrievalOutput = this.findDataRetrieval(input);
     if (!retrievalOutput) {
-      throw new Error(
-        "CalendarSurfaceAgent requires DataRetrievalOutput from prior outputs",
-      );
+      return this.createOutput(null, 0, {
+        dataState: "raw",
+        timestamp: startMs,
+      });
     }
 
     const calendarData = this.extractCalendarData(retrievalOutput);

--- a/packages/agents/src/ui/connection-surface.ts
+++ b/packages/agents/src/ui/connection-surface.ts
@@ -1,0 +1,186 @@
+import type { AgentOutput } from "@waibspace/types";
+import {
+  SurfaceFactory,
+  type ConnectionGuideSurfaceData,
+} from "@waibspace/surfaces";
+import {
+  MCP_SERVER_CATALOG,
+  findTemplate,
+} from "@waibspace/connectors";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+import type { IntentClassification } from "../reasoning/intent-agent";
+
+export class ConnectionSurfaceAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "ui.connection-surface",
+      name: "ConnectionSurfaceAgent",
+      type: "surface-builder",
+      category: "ui",
+    });
+  }
+
+  async execute(
+    input: AgentInput,
+    context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+
+    const intent = this.findIntentClassification(input);
+
+    // Only produce a surface if the intent is connection-related
+    // or if this is a service selection interaction
+    const isConnectionIntent = intent?.intentCategory === "connection";
+    const isServiceSelection = this.isServiceSelectionEvent(input);
+
+    if (!isConnectionIntent && !isServiceSelection) {
+      // Return empty output — this agent has nothing to contribute
+      return this.createEmptyOutput(startMs);
+    }
+
+    // Determine which service the user wants
+    const serviceId = this.identifyService(intent, input);
+
+    let surfaceData: ConnectionGuideSurfaceData;
+
+    if (serviceId) {
+      const template = findTemplate(serviceId);
+      if (template) {
+        // Found in catalog — show credentials step
+        surfaceData = {
+          step: "credentials",
+          message: template.requiredCredentials.length > 0
+            ? `To connect ${template.name}, you'll need to provide the following credentials. Click the help links if you need guidance getting them.`
+            : `${template.name} doesn't require any credentials. Click Connect to set it up!`,
+          availableServices: this.catalogToServices(),
+          selectedService: {
+            id: template.id,
+            name: template.name,
+            icon: template.icon,
+            description: template.description,
+          },
+          credentialFields: template.requiredCredentials.map((c) => ({
+            key: c.key,
+            label: c.label,
+            helpText: c.helpText,
+            helpUrl: c.helpUrl,
+            sensitive: c.sensitive,
+          })),
+        };
+        this.log("Producing credentials step", { service: template.id, credCount: template.requiredCredentials.length });
+      } else {
+        // Not in catalog — show browse with suggestion
+        surfaceData = {
+          step: "browse",
+          message: `I don't have "${serviceId}" in my catalog yet. You can add it manually in Settings, or pick from one of these available services:`,
+          availableServices: this.catalogToServices(),
+        };
+        this.log("Service not found in catalog", { query: serviceId });
+      }
+    } else {
+      // No specific service — show catalog browser
+      surfaceData = {
+        step: "browse",
+        message: "Which service would you like to connect? Pick one below, or tell me what you're looking for.",
+        availableServices: this.catalogToServices(),
+      };
+      this.log("Showing catalog browser");
+    }
+
+    const endMs = Date.now();
+
+    const provenance = {
+      sourceType: "agent" as const,
+      sourceId: this.id,
+      trustLevel: "trusted" as const,
+      timestamp: startMs,
+      freshness: "realtime" as const,
+      dataState: "transformed" as const,
+      transformations: ["catalog-lookup"],
+    };
+
+    const surfaceSpec = SurfaceFactory.connectionGuide(surfaceData, provenance);
+
+    return {
+      ...this.createOutput(
+        { surfaceSpec },
+        0.9,
+        provenance,
+      ),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+
+  private findIntentClassification(input: AgentInput): IntentClassification | undefined {
+    for (const prior of input.priorOutputs) {
+      if (prior.category === "reasoning" && prior.output) {
+        const output = prior.output as Record<string, unknown>;
+        if ("primaryIntent" in output && "intentCategory" in output) {
+          return output as unknown as IntentClassification;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private isServiceSelectionEvent(input: AgentInput): boolean {
+    const payload = input.event.payload as Record<string, unknown> | undefined;
+    return payload?.interaction === "select-service";
+  }
+
+  private identifyService(
+    intent: IntentClassification | undefined,
+    input: AgentInput,
+  ): string | undefined {
+    // 1. Check interaction event payload (service selection)
+    const payload = input.event.payload as Record<string, unknown> | undefined;
+    if (payload?.interaction === "select-service") {
+      const target = payload.target as string | undefined;
+      const ctx = payload.context as Record<string, unknown> | undefined;
+      return target || (ctx?.service as string) || undefined;
+    }
+
+    // 2. Check intent entities
+    if (intent?.entities?.service) {
+      return intent.entities.service;
+    }
+
+    // 3. Try to extract from the raw text
+    if (intent?.primaryIntent === "connect_service" && intent?.reasoning) {
+      // The reasoning may mention the service name
+      const text = (payload?.text as string) || intent.reasoning;
+      const lower = text.toLowerCase();
+
+      // Quick keyword checks
+      const keywords = ["gmail", "email", "google", "slack", "github", "drive", "search", "filesystem", "files", "brave", "memory"];
+      for (const kw of keywords) {
+        if (lower.includes(kw)) return kw;
+      }
+    }
+
+    return undefined;
+  }
+
+  private catalogToServices(): ConnectionGuideSurfaceData["availableServices"] {
+    return MCP_SERVER_CATALOG.map((t) => ({
+      id: t.id,
+      name: t.name,
+      description: t.description,
+      icon: t.icon,
+      categories: t.categories,
+    }));
+  }
+
+  private createEmptyOutput(startMs: number): AgentOutput {
+    const endMs = Date.now();
+    return {
+      ...this.createOutput(null, 0),
+      timing: { startMs, endMs, durationMs: endMs - startMs },
+    };
+  }
+}

--- a/packages/agents/src/ui/discovery-surface.ts
+++ b/packages/agents/src/ui/discovery-surface.ts
@@ -94,9 +94,10 @@ export class DiscoverySurfaceAgent extends BaseAgent {
     const intentClassification = this.findIntentClassification(input);
 
     if (!retrievalOutput) {
-      throw new Error(
-        "DiscoverySurfaceAgent requires DataRetrievalOutput from prior outputs",
-      );
+      return this.createOutput(null, 0, {
+        dataState: "raw",
+        timestamp: startMs,
+      });
     }
 
     const webData = this.extractWebData(retrievalOutput);

--- a/packages/agents/src/ui/inbox-surface.ts
+++ b/packages/agents/src/ui/inbox-surface.ts
@@ -78,21 +78,33 @@ export class InboxSurfaceAgent extends BaseAgent {
 
     const retrievalOutput = this.findDataRetrieval(input);
     if (!retrievalOutput) {
-      throw new Error(
-        "InboxSurfaceAgent requires DataRetrievalOutput from prior outputs",
-      );
+      return this.createOutput(null, 0, {
+        dataState: "raw",
+        timestamp: startMs,
+      });
     }
 
     const gmailData = this.extractGmailData(retrievalOutput);
     const calendarData = this.extractCalendarData(input);
 
+    // If no email data found, skip LLM call
+    if (!gmailData || (Array.isArray(gmailData) && gmailData.length === 0)) {
+      return this.createOutput(null, 0, {
+        dataState: "raw",
+        timestamp: startMs,
+      });
+    }
+
+    // Truncate email data to avoid hitting token limits
+    const truncatedData = this.truncateEmailData(gmailData);
+
     this.log("Building inbox surface", {
-      emailCount: Array.isArray(gmailData) ? gmailData.length : 0,
+      emailDataSize: JSON.stringify(truncatedData).length,
       hasCalendarContext: calendarData !== undefined,
     });
 
     const userMessage = JSON.stringify({
-      emails: gmailData,
+      emails: truncatedData,
       calendarContext: calendarData,
     });
 
@@ -155,12 +167,85 @@ export class InboxSurfaceAgent extends BaseAgent {
   }
 
   private extractGmailData(retrieval: DataRetrievalOutput): unknown {
-    const gmailResult = retrieval.results.find(
+    // Find email-related results from any connector (gmail, catalog-gmail, MCP mail, etc.)
+    const emailResults = retrieval.results.filter(
       (r) =>
         r.status === "fulfilled" &&
-        (r.connectorId === "gmail" || r.operation.includes("email")),
+        (r.connectorId.includes("gmail") ||
+          r.connectorId.includes("mail") ||
+          r.operation.includes("email") ||
+          r.operation.includes("message") ||
+          r.operation.includes("inbox")),
     );
-    return gmailResult?.data ?? [];
+
+    if (emailResults.length === 0) return [];
+
+    // MCP tools return [{type: "text", text: "..."}] — extract and parse the text content
+    const allData: unknown[] = [];
+    for (const result of emailResults) {
+      const parsed = this.parseMCPContent(result.data);
+      if (parsed !== undefined) {
+        allData.push(parsed);
+      } else {
+        allData.push(result.data);
+      }
+    }
+    return allData;
+  }
+
+  /**
+   * Parse MCP tool response format: [{type: "text", text: "...json..."}]
+   */
+  private parseMCPContent(data: unknown): unknown | undefined {
+    if (!Array.isArray(data)) return undefined;
+    const textBlock = data.find(
+      (item: unknown) =>
+        typeof item === "object" &&
+        item !== null &&
+        (item as Record<string, unknown>).type === "text",
+    );
+    if (!textBlock) return undefined;
+    const text = (textBlock as Record<string, unknown>).text;
+    if (typeof text !== "string") return undefined;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  /**
+   * Truncate email data to keep the LLM prompt under token limits.
+   * Keeps at most 20 emails, truncates body text to 500 chars each.
+   */
+  private truncateEmailData(data: unknown): unknown {
+    const MAX_EMAILS = 20;
+    const MAX_BODY_LENGTH = 500;
+    const MAX_TOTAL_LENGTH = 50_000; // ~12k tokens
+
+    if (Array.isArray(data)) {
+      const truncated = data.slice(0, MAX_EMAILS).map((item: unknown) => {
+        if (typeof item === "object" && item !== null) {
+          const email = { ...(item as Record<string, unknown>) };
+          // Truncate common body fields
+          for (const key of ["text", "body", "snippet", "content", "html"]) {
+            if (typeof email[key] === "string" && (email[key] as string).length > MAX_BODY_LENGTH) {
+              email[key] = (email[key] as string).slice(0, MAX_BODY_LENGTH) + "...";
+            }
+          }
+          return email;
+        }
+        return item;
+      });
+      return truncated;
+    }
+
+    // If it's a single large string, truncate it
+    const str = JSON.stringify(data);
+    if (str.length > MAX_TOTAL_LENGTH) {
+      return JSON.parse(str.slice(0, MAX_TOTAL_LENGTH));
+    }
+    return data;
   }
 
   private extractCalendarData(input: AgentInput): unknown | undefined {

--- a/packages/agents/src/ui/index.ts
+++ b/packages/agents/src/ui/index.ts
@@ -2,4 +2,5 @@ export { InboxSurfaceAgent } from "./inbox-surface";
 export { CalendarSurfaceAgent } from "./calendar-surface";
 export { DiscoverySurfaceAgent } from "./discovery-surface";
 export { ApprovalSurfaceAgent } from "./approval-surface";
+export { ConnectionSurfaceAgent } from "./connection-surface";
 export { LayoutComposerAgent, extractSurfaces } from "./layout-composer";

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
+    "@waibspace/db": "workspace:*",
     "@waibspace/policy": "workspace:*",
     "@waibspace/types": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -31,3 +31,5 @@ export {
 export type { ExtractedContent } from "./web-fetch";
 export { MCPConnector, MCPServerRegistry } from "./mcp";
 export type { MCPServerConfig, MCPToolInfo } from "./mcp";
+export { MCP_SERVER_CATALOG, findTemplate, searchCatalog } from "./mcp";
+export type { MCPServerTemplate, MCPCredentialSpec } from "./mcp";

--- a/packages/connectors/src/mcp/catalog.ts
+++ b/packages/connectors/src/mcp/catalog.ts
@@ -1,0 +1,245 @@
+import type { TrustLevel } from "@waibspace/types";
+
+export interface MCPCredentialSpec {
+  key: string;
+  label: string;
+  helpText: string;
+  helpUrl?: string;
+  sensitive: boolean;
+}
+
+export interface MCPServerTemplate {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  npmPackage: string;
+  command: string;
+  args: string[];
+  requiredCredentials: MCPCredentialSpec[];
+  defaultEnv?: Record<string, string>;
+  categories: string[];
+  trustLevel: TrustLevel;
+}
+
+export const MCP_SERVER_CATALOG: MCPServerTemplate[] = [
+  {
+    id: "github",
+    name: "GitHub",
+    description:
+      "Manage repositories, issues, pull requests, and code reviews",
+    icon: "💻",
+    npmPackage: "@modelcontextprotocol/server-github",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-github"],
+    requiredCredentials: [
+      {
+        key: "GITHUB_PERSONAL_ACCESS_TOKEN",
+        label: "GitHub Personal Access Token",
+        helpText:
+          "Create a token at GitHub Settings → Developer settings → Personal access tokens → Tokens (classic). Select the scopes you need (repo, read:org recommended).",
+        helpUrl: "https://github.com/settings/tokens",
+        sensitive: true,
+      },
+    ],
+    categories: ["development", "code"],
+    trustLevel: "semi-trusted",
+  },
+  {
+    id: "filesystem",
+    name: "Filesystem",
+    description: "Read, write, and manage files on your computer",
+    icon: "📁",
+    npmPackage: "@modelcontextprotocol/server-filesystem",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-filesystem"],
+    requiredCredentials: [],
+    categories: ["system", "files"],
+    trustLevel: "semi-trusted",
+  },
+  {
+    id: "gmail",
+    name: "Gmail",
+    description:
+      "Read, search, and manage your Gmail inbox and send emails",
+    icon: "📧",
+    npmPackage: "mcp-mail-server",
+    command: "npx",
+    args: ["-y", "mcp-mail-server"],
+    requiredCredentials: [
+      {
+        key: "EMAIL_USER",
+        label: "Email Address",
+        helpText: "Your full Gmail address (e.g. you@gmail.com).",
+        sensitive: false,
+      },
+      {
+        key: "EMAIL_PASS",
+        label: "App Password",
+        helpText:
+          "Go to your Google Account → Security → 2-Step Verification → App passwords. Create a new app password for 'Mail'. Copy the 16-character code (spaces are fine).",
+        helpUrl: "https://myaccount.google.com/apppasswords",
+        sensitive: true,
+      },
+    ],
+    // Pre-filled env vars for Gmail's IMAP/SMTP servers
+    defaultEnv: {
+      IMAP_HOST: "imap.gmail.com",
+      IMAP_PORT: "993",
+      IMAP_SECURE: "true",
+      SMTP_HOST: "smtp.gmail.com",
+      SMTP_PORT: "465",
+      SMTP_SECURE: "true",
+    },
+    categories: ["email", "communication", "google"],
+    trustLevel: "semi-trusted",
+  },
+  {
+    id: "gdrive",
+    name: "Google Drive",
+    description: "Search and access files in your Google Drive",
+    icon: "💾",
+    npmPackage: "@modelcontextprotocol/server-gdrive",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-gdrive"],
+    requiredCredentials: [],
+    categories: ["productivity", "files", "google"],
+    trustLevel: "semi-trusted",
+  },
+  {
+    id: "slack",
+    name: "Slack",
+    description:
+      "Read messages, post updates, and manage channels in Slack",
+    icon: "💬",
+    npmPackage: "@modelcontextprotocol/server-slack",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-slack"],
+    requiredCredentials: [
+      {
+        key: "SLACK_BOT_TOKEN",
+        label: "Slack Bot Token",
+        helpText:
+          "Create a Slack app at api.slack.com/apps, add Bot Token Scopes (channels:read, chat:write, etc.), then install to your workspace. Copy the Bot User OAuth Token (starts with xoxb-).",
+        helpUrl: "https://api.slack.com/apps",
+        sensitive: true,
+      },
+      {
+        key: "SLACK_TEAM_ID",
+        label: "Slack Team/Workspace ID",
+        helpText:
+          "Found in Slack → Settings & administration → Workspace settings, or in the URL when using Slack in a browser.",
+        sensitive: false,
+      },
+    ],
+    categories: ["communication", "messaging"],
+    trustLevel: "semi-trusted",
+  },
+  {
+    id: "brave-search",
+    name: "Brave Search",
+    description: "Search the web privately using Brave Search API",
+    icon: "🔍",
+    npmPackage: "@modelcontextprotocol/server-brave-search",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-brave-search"],
+    requiredCredentials: [
+      {
+        key: "BRAVE_API_KEY",
+        label: "Brave Search API Key",
+        helpText:
+          "Sign up for a free API key at brave.com/search/api. The free tier includes 2,000 queries/month.",
+        helpUrl: "https://brave.com/search/api/",
+        sensitive: true,
+      },
+    ],
+    categories: ["search", "web"],
+    trustLevel: "semi-trusted",
+  },
+  {
+    id: "memory",
+    name: "Memory",
+    description: "Persistent memory storage using a knowledge graph",
+    icon: "🧠",
+    npmPackage: "@modelcontextprotocol/server-memory",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-memory"],
+    requiredCredentials: [],
+    categories: ["system", "memory"],
+    trustLevel: "trusted",
+  },
+];
+
+/**
+ * Find a template by exact ID, name match, or category match.
+ */
+export function findTemplate(
+  idOrName: string,
+): MCPServerTemplate | undefined {
+  const lower = idOrName.toLowerCase().trim();
+
+  // Exact ID match
+  const exact = MCP_SERVER_CATALOG.find((t) => t.id === lower);
+  if (exact) return exact;
+
+  // Name match (case-insensitive)
+  const byName = MCP_SERVER_CATALOG.find(
+    (t) => t.name.toLowerCase() === lower,
+  );
+  if (byName) return byName;
+
+  // Common aliases
+  const aliases: Record<string, string> = {
+    gmail: "gmail",
+    "google mail": "gmail",
+    "google email": "gmail",
+    email: "gmail",
+    mail: "gmail",
+    inbox: "gmail",
+    drive: "gdrive",
+    "google drive": "gdrive",
+    git: "github",
+    code: "github",
+    repo: "github",
+    repos: "github",
+    repository: "github",
+    search: "brave-search",
+    "web search": "brave-search",
+    brave: "brave-search",
+    files: "filesystem",
+    "file system": "filesystem",
+    fs: "filesystem",
+    chat: "slack",
+    messaging: "slack",
+  };
+
+  const aliasId = aliases[lower];
+  if (aliasId) return MCP_SERVER_CATALOG.find((t) => t.id === aliasId);
+
+  // Partial match on name or description
+  const partial = MCP_SERVER_CATALOG.find(
+    (t) =>
+      t.name.toLowerCase().includes(lower) ||
+      t.description.toLowerCase().includes(lower),
+  );
+  if (partial) return partial;
+
+  // Category match
+  return MCP_SERVER_CATALOG.find((t) =>
+    t.categories.some((c) => c.includes(lower)),
+  );
+}
+
+/**
+ * Search the catalog by query, returning all matches.
+ */
+export function searchCatalog(query: string): MCPServerTemplate[] {
+  const lower = query.toLowerCase().trim();
+  return MCP_SERVER_CATALOG.filter(
+    (t) =>
+      t.id.includes(lower) ||
+      t.name.toLowerCase().includes(lower) ||
+      t.description.toLowerCase().includes(lower) ||
+      t.categories.some((c) => c.includes(lower)),
+  );
+}

--- a/packages/connectors/src/mcp/index.ts
+++ b/packages/connectors/src/mcp/index.ts
@@ -1,3 +1,5 @@
 export { MCPConnector } from "./mcp-connector";
 export { MCPServerRegistry } from "./registry";
 export type { MCPServerConfig, MCPToolInfo } from "./types";
+export { MCP_SERVER_CATALOG, findTemplate, searchCatalog } from "./catalog";
+export type { MCPServerTemplate, MCPCredentialSpec } from "./catalog";

--- a/packages/connectors/src/mcp/mcp-connector.ts
+++ b/packages/connectors/src/mcp/mcp-connector.ts
@@ -123,7 +123,10 @@ export class MCPConnector extends BaseConnector {
       return new StdioClientTransport({
         command: this.serverConfig.command,
         args: this.serverConfig.args,
-        env: this.serverConfig.env,
+        env: {
+          ...process.env,
+          ...(this.serverConfig.env ?? {}),
+        } as Record<string, string>,
       });
     }
 

--- a/packages/connectors/src/mcp/registry.ts
+++ b/packages/connectors/src/mcp/registry.ts
@@ -1,7 +1,10 @@
 import { MCPConnector } from "./mcp-connector";
 import type { MCPServerConfig, MCPToolInfo } from "./types";
 import type { PolicyEngine } from "@waibspace/policy";
+import type { WaibDatabase, MCPServerRow } from "@waibspace/db";
+import type { TrustLevel } from "@waibspace/types";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync, renameSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 /**
@@ -29,9 +32,11 @@ function classifyTool(toolName: string): { riskClass: "A" | "B" | "C"; autoAppro
 export class MCPServerRegistry {
   private servers = new Map<string, { config: MCPServerConfig; connector: MCPConnector }>();
   private policyEngine: PolicyEngine | undefined;
+  private db?: WaibDatabase;
 
-  constructor(policyEngine?: PolicyEngine) {
+  constructor(policyEngine?: PolicyEngine, db?: WaibDatabase) {
     this.policyEngine = policyEngine;
+    this.db = db;
   }
 
   /** Add a new server config (doesn't connect yet). */
@@ -109,15 +114,67 @@ export class MCPServerRegistry {
     return this.servers.get(id)?.connector;
   }
 
-  /** Persist server configs to a JSON file. */
-  async save(path: string): Promise<void> {
+  private configToRow(config: MCPServerConfig): MCPServerRow {
+    return {
+      id: config.id,
+      name: config.name,
+      transport: config.transport,
+      command: config.command ?? null,
+      args: config.args ? JSON.stringify(config.args) : null,
+      env: config.env ? JSON.stringify(config.env) : null,
+      url: config.url ?? null,
+      trust_level: config.trustLevel ?? "semi-trusted",
+      enabled: config.enabled !== false ? 1 : 0,
+      created_at: Date.now(),
+    };
+  }
+
+  private rowToConfig(row: MCPServerRow): MCPServerConfig {
+    return {
+      id: row.id,
+      name: row.name,
+      transport: row.transport as "stdio" | "sse",
+      command: row.command ?? undefined,
+      args: row.args ? JSON.parse(row.args) : undefined,
+      env: row.env ? JSON.parse(row.env) : undefined,
+      url: row.url ?? undefined,
+      trustLevel: (row.trust_level as TrustLevel) ?? "semi-trusted",
+      enabled: row.enabled === 1,
+    };
+  }
+
+  /** Persist server configs. When db is provided, saves to SQLite. Otherwise saves to JSON file. */
+  async save(path?: string): Promise<void> {
+    if (this.db) {
+      for (const { config } of this.servers.values()) {
+        this.db.saveMCPServer(this.configToRow(config));
+      }
+      return;
+    }
+
+    if (!path) return;
     const configs = Array.from(this.servers.values()).map(({ config }) => config);
     await mkdir(dirname(path), { recursive: true });
     await writeFile(path, JSON.stringify(configs, null, 2), "utf-8");
   }
 
-  /** Load server configs from a JSON file (adds servers but does not connect). */
-  async load(path: string): Promise<void> {
+  /** Load server configs. When db is provided, loads from SQLite. Otherwise loads from JSON file. */
+  async load(path?: string): Promise<void> {
+    if (this.db) {
+      // Migrate legacy JSON if it exists
+      this.migrateJsonIfNeeded();
+
+      const rows = this.db.getMCPServers();
+      for (const row of rows) {
+        const config = this.rowToConfig(row);
+        if (!this.servers.has(config.id)) {
+          this.addServer(config);
+        }
+      }
+      return;
+    }
+
+    if (!path) return;
     try {
       const raw = await readFile(path, "utf-8");
       const configs: MCPServerConfig[] = JSON.parse(raw);
@@ -128,6 +185,24 @@ export class MCPServerRegistry {
       }
     } catch {
       // File doesn't exist or is invalid — that's fine, start empty
+    }
+  }
+
+  /** Migrate legacy JSON file to SQLite if it exists. */
+  private migrateJsonIfNeeded(): void {
+    if (!this.db) return;
+    const jsonPath = "./data/mcp-servers.json";
+    if (existsSync(jsonPath)) {
+      try {
+        const configs: MCPServerConfig[] = JSON.parse(readFileSync(jsonPath, "utf-8"));
+        for (const config of configs) {
+          this.db.saveMCPServer(this.configToRow(config));
+        }
+        renameSync(jsonPath, jsonPath + ".migrated");
+        console.log(`[mcp-registry] Migrated ${configs.length} servers from JSON to SQLite`);
+      } catch {
+        // ignore migration errors
+      }
     }
   }
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@waibspace/db",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -1,0 +1,282 @@
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface MemoryRow {
+  id: string;
+  category: string;
+  key: string;
+  value: string; // JSON-stringified
+  source: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface MCPServerRow {
+  id: string;
+  name: string;
+  transport: string;
+  command: string | null;
+  args: string | null; // JSON-stringified string[]
+  env: string | null; // JSON-stringified Record<string, string>
+  url: string | null;
+  trust_level: string;
+  enabled: number; // 0 or 1
+  created_at: number;
+}
+
+export interface EventLogRow {
+  id: string;
+  event_type: string;
+  source: string;
+  trace_id: string;
+  payload: string; // JSON-stringified
+  level: string;
+  created_at: number;
+}
+
+export class WaibDatabase {
+  private db: Database;
+
+  constructor(dbPath: string) {
+    mkdirSync(dirname(dbPath), { recursive: true });
+    this.db = new Database(dbPath);
+    this.db.exec("PRAGMA journal_mode = WAL");
+    this.db.exec("PRAGMA foreign_keys = ON");
+    this.migrate();
+  }
+
+  private migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS memory (
+        id         TEXT PRIMARY KEY,
+        category   TEXT NOT NULL,
+        key        TEXT NOT NULL,
+        value      TEXT NOT NULL,
+        source     TEXT NOT NULL DEFAULT '',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_memory_category ON memory(category);
+      CREATE INDEX IF NOT EXISTS idx_memory_updated  ON memory(updated_at);
+    `);
+
+    // FTS5 virtual table for full-text search on memory
+    this.db.exec(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+        id,
+        key,
+        value,
+        content=memory,
+        content_rowid=rowid
+      );
+    `);
+
+    // Triggers to keep FTS in sync
+    this.db.exec(`
+      CREATE TRIGGER IF NOT EXISTS memory_ai AFTER INSERT ON memory BEGIN
+        INSERT INTO memory_fts(rowid, id, key, value)
+        VALUES (new.rowid, new.id, new.key, new.value);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS memory_ad AFTER DELETE ON memory BEGIN
+        INSERT INTO memory_fts(memory_fts, rowid, id, key, value)
+        VALUES ('delete', old.rowid, old.id, old.key, old.value);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS memory_au AFTER UPDATE ON memory BEGIN
+        INSERT INTO memory_fts(memory_fts, rowid, id, key, value)
+        VALUES ('delete', old.rowid, old.id, old.key, old.value);
+        INSERT INTO memory_fts(rowid, id, key, value)
+        VALUES (new.rowid, new.id, new.key, new.value);
+      END;
+    `);
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS event_log (
+        id          TEXT PRIMARY KEY,
+        event_type  TEXT NOT NULL,
+        source      TEXT NOT NULL,
+        trace_id    TEXT NOT NULL,
+        payload     TEXT NOT NULL DEFAULT '{}',
+        level       TEXT NOT NULL DEFAULT 'info',
+        created_at  INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_event_log_trace ON event_log(trace_id);
+      CREATE INDEX IF NOT EXISTS idx_event_log_level ON event_log(level);
+      CREATE INDEX IF NOT EXISTS idx_event_log_created ON event_log(created_at);
+
+      CREATE TABLE IF NOT EXISTS mcp_servers (
+        id          TEXT PRIMARY KEY,
+        name        TEXT NOT NULL,
+        transport   TEXT NOT NULL,
+        command     TEXT,
+        args        TEXT,
+        env         TEXT,
+        url         TEXT,
+        trust_level TEXT NOT NULL DEFAULT 'semi-trusted',
+        enabled     INTEGER NOT NULL DEFAULT 1,
+        created_at  INTEGER NOT NULL
+      );
+    `);
+  }
+
+  // ---- Memory CRUD ----
+
+  setMemory(entry: {
+    id: string;
+    category: string;
+    key: string;
+    value: unknown;
+    source: string;
+    createdAt: number;
+    updatedAt: number;
+  }): void {
+    this.db
+      .query(
+        `INSERT INTO memory (id, category, key, value, source, created_at, updated_at)
+         VALUES ($id, $category, $key, $value, $source, $created_at, $updated_at)
+         ON CONFLICT(id) DO UPDATE SET
+           value = excluded.value,
+           source = excluded.source,
+           updated_at = excluded.updated_at`,
+      )
+      .run({
+        $id: entry.id,
+        $category: entry.category,
+        $key: entry.key,
+        $value: JSON.stringify(entry.value),
+        $source: entry.source,
+        $created_at: entry.createdAt,
+        $updated_at: entry.updatedAt,
+      });
+  }
+
+  getMemory(id: string): MemoryRow | null {
+    return (
+      (this.db.query("SELECT * FROM memory WHERE id = $id").get({ $id: id }) as MemoryRow | null) ??
+      null
+    );
+  }
+
+  getAllMemory(category: string): MemoryRow[] {
+    return this.db
+      .query("SELECT * FROM memory WHERE category = $category")
+      .all({ $category: category }) as MemoryRow[];
+  }
+
+  searchMemory(category: string, query: string): MemoryRow[] {
+    // Use FTS5 for full-text search, join back to memory for full row
+    return this.db
+      .query(
+        `SELECT m.* FROM memory m
+         JOIN memory_fts fts ON m.rowid = fts.rowid
+         WHERE m.category = $category
+           AND memory_fts MATCH $query`,
+      )
+      .all({ $category: category, $query: query }) as MemoryRow[];
+  }
+
+  getRecentMemory(category: string, limit: number): MemoryRow[] {
+    return this.db
+      .query(
+        "SELECT * FROM memory WHERE category = $category ORDER BY updated_at DESC LIMIT $limit",
+      )
+      .all({ $category: category, $limit: limit }) as MemoryRow[];
+  }
+
+  deleteMemory(id: string): boolean {
+    const result = this.db.query("DELETE FROM memory WHERE id = $id").run({ $id: id });
+    return result.changes > 0;
+  }
+
+  // ---- MCP Server CRUD ----
+
+  saveMCPServer(row: MCPServerRow): void {
+    this.db
+      .query(
+        `INSERT INTO mcp_servers (id, name, transport, command, args, env, url, trust_level, enabled, created_at)
+         VALUES ($id, $name, $transport, $command, $args, $env, $url, $trust_level, $enabled, $created_at)
+         ON CONFLICT(id) DO UPDATE SET
+           name = excluded.name,
+           transport = excluded.transport,
+           command = excluded.command,
+           args = excluded.args,
+           env = excluded.env,
+           url = excluded.url,
+           trust_level = excluded.trust_level,
+           enabled = excluded.enabled`,
+      )
+      .run({
+        $id: row.id,
+        $name: row.name,
+        $transport: row.transport,
+        $command: row.command,
+        $args: row.args,
+        $env: row.env,
+        $url: row.url,
+        $trust_level: row.trust_level,
+        $enabled: row.enabled,
+        $created_at: row.created_at,
+      });
+  }
+
+  getMCPServers(): MCPServerRow[] {
+    return this.db.query("SELECT * FROM mcp_servers").all() as MCPServerRow[];
+  }
+
+  deleteMCPServer(id: string): boolean {
+    const result = this.db.query("DELETE FROM mcp_servers WHERE id = $id").run({ $id: id });
+    return result.changes > 0;
+  }
+
+  // ---- Event Log ----
+
+  logEvent(entry: {
+    id: string;
+    eventType: string;
+    source: string;
+    traceId: string;
+    payload: unknown;
+    level: "info" | "warn" | "error";
+    createdAt: number;
+  }): void {
+    this.db
+      .query(
+        `INSERT INTO event_log (id, event_type, source, trace_id, payload, level, created_at)
+         VALUES ($id, $event_type, $source, $trace_id, $payload, $level, $created_at)`,
+      )
+      .run({
+        $id: entry.id,
+        $event_type: entry.eventType,
+        $source: entry.source,
+        $trace_id: entry.traceId,
+        $payload: JSON.stringify(entry.payload),
+        $level: entry.level,
+        $created_at: entry.createdAt,
+      });
+  }
+
+  getEventsByTrace(traceId: string): EventLogRow[] {
+    return this.db
+      .query("SELECT * FROM event_log WHERE trace_id = $trace_id ORDER BY created_at ASC")
+      .all({ $trace_id: traceId }) as EventLogRow[];
+  }
+
+  getRecentEvents(limit: number, level?: string): EventLogRow[] {
+    if (level) {
+      return this.db
+        .query("SELECT * FROM event_log WHERE level = $level ORDER BY created_at DESC LIMIT $limit")
+        .all({ $level: level, $limit: limit }) as EventLogRow[];
+    }
+    return this.db
+      .query("SELECT * FROM event_log ORDER BY created_at DESC LIMIT $limit")
+      .all({ $limit: limit }) as EventLogRow[];
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,2 @@
+export { WaibDatabase } from "./database";
+export type { MemoryRow, MCPServerRow, EventLogRow } from "./database";

--- a/packages/db/src/migrations.ts
+++ b/packages/db/src/migrations.ts
@@ -1,0 +1,129 @@
+import type { Database } from "bun:sqlite";
+
+export function runMigrations(db: Database): void {
+  // Schema version tracking
+  db.run(`CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY,
+    applied_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+  )`);
+
+  const currentVersion =
+    (
+      db
+        .prepare(`SELECT MAX(version) as v FROM schema_version`)
+        .get() as { v: number | null }
+    )?.v ?? 0;
+
+  if (currentVersion < 1) {
+    migration001(db);
+    db.run(`INSERT INTO schema_version (version) VALUES (1)`);
+  }
+}
+
+function migration001(db: Database): void {
+  // Phase 1 tables (active)
+
+  db.run(`CREATE TABLE IF NOT EXISTS memory_entries (
+    id TEXT PRIMARY KEY,
+    category TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    source TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  )`);
+  db.run(
+    `CREATE INDEX IF NOT EXISTS idx_memory_category ON memory_entries(category)`
+  );
+  db.run(
+    `CREATE INDEX IF NOT EXISTS idx_memory_updated ON memory_entries(updated_at DESC)`
+  );
+
+  db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+    key, value, source,
+    content='memory_entries',
+    content_rowid='rowid'
+  )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS mcp_servers (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    transport TEXT NOT NULL,
+    command TEXT,
+    args TEXT,
+    env TEXT,
+    url TEXT,
+    trust_level TEXT NOT NULL DEFAULT 'semi-trusted',
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+  )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS event_log (
+    id TEXT PRIMARY KEY,
+    event_type TEXT NOT NULL,
+    source TEXT NOT NULL,
+    trace_id TEXT NOT NULL,
+    payload TEXT,
+    created_at INTEGER NOT NULL
+  )`);
+  db.run(
+    `CREATE INDEX IF NOT EXISTS idx_events_trace ON event_log(trace_id)`
+  );
+  db.run(
+    `CREATE INDEX IF NOT EXISTS idx_events_type ON event_log(event_type, created_at DESC)`
+  );
+
+  db.run(`CREATE TABLE IF NOT EXISTS user_preferences (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at INTEGER NOT NULL
+  )`);
+
+  // Phase 2 tables (schema only, populated later)
+
+  db.run(`CREATE TABLE IF NOT EXISTS component_templates (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    surface_type TEXT NOT NULL,
+    description TEXT,
+    template TEXT NOT NULL,
+    tags TEXT,
+    version INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+  )`);
+  db.run(
+    `CREATE INDEX IF NOT EXISTS idx_templates_type ON component_templates(surface_type)`
+  );
+
+  db.run(`CREATE TABLE IF NOT EXISTS compositions (
+    id TEXT PRIMARY KEY,
+    intent TEXT NOT NULL,
+    templates_used TEXT NOT NULL,
+    surface_spec TEXT NOT NULL,
+    success_count INTEGER NOT NULL DEFAULT 0,
+    failure_count INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+    last_used_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+  )`);
+  db.run(
+    `CREATE INDEX IF NOT EXISTS idx_compositions_intent ON compositions(intent)`
+  );
+
+  db.run(`CREATE TABLE IF NOT EXISTS user_feedback (
+    id TEXT PRIMARY KEY,
+    surface_id TEXT NOT NULL,
+    surface_type TEXT NOT NULL,
+    feedback_type TEXT NOT NULL,
+    signal TEXT NOT NULL,
+    value TEXT,
+    trace_id TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+  )`);
+  db.run(
+    `CREATE INDEX IF NOT EXISTS idx_feedback_surface ON user_feedback(surface_id)`
+  );
+  db.run(
+    `CREATE INDEX IF NOT EXISTS idx_feedback_type ON user_feedback(surface_type, feedback_type)`
+  );
+}

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../types" }
+  ]
+}

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
+    "@waibspace/db": "workspace:*",
     "@waibspace/event-bus": "workspace:*",
     "@waibspace/types": "workspace:*"
   },

--- a/packages/memory/src/memory-store.ts
+++ b/packages/memory/src/memory-store.ts
@@ -1,17 +1,65 @@
 import type { MemoryEntry, MemoryCategory } from "@waibspace/types";
+import type { WaibDatabase, MemoryRow } from "@waibspace/db";
 import { EventBus, createEvent } from "@waibspace/event-bus";
+import { existsSync, renameSync, readFileSync } from "node:fs";
 
 export class MemoryStore {
   private store: Map<string, MemoryEntry>;
   private dirty: boolean;
   private autoSaveInterval?: ReturnType<typeof setInterval>;
+  private db?: WaibDatabase;
+  private persistPath?: string;
+  private eventBus?: EventBus;
 
-  constructor(
-    private persistPath?: string,
-    private eventBus?: EventBus,
-  ) {
+  constructor(dbOrPath?: WaibDatabase | string, eventBus?: EventBus) {
     this.store = new Map();
     this.dirty = false;
+    this.eventBus = eventBus;
+
+    if (typeof dbOrPath === "string") {
+      this.persistPath = dbOrPath;
+    } else if (dbOrPath) {
+      this.db = dbOrPath;
+      this.migrateJsonIfNeeded();
+    }
+  }
+
+  /** Migrate legacy JSON file to SQLite if it exists. */
+  private migrateJsonIfNeeded(): void {
+    if (!this.db) return;
+    const jsonPath = "./data/memory.json";
+    if (existsSync(jsonPath)) {
+      try {
+        const entries: MemoryEntry[] = JSON.parse(readFileSync(jsonPath, "utf-8"));
+        for (const entry of entries) {
+          this.db.setMemory({
+            id: entry.id,
+            category: entry.category,
+            key: entry.key,
+            value: entry.value,
+            source: entry.source,
+            createdAt: entry.createdAt,
+            updatedAt: entry.updatedAt,
+          });
+        }
+        renameSync(jsonPath, jsonPath + ".migrated");
+        console.log(`[memory] Migrated ${entries.length} entries from JSON to SQLite`);
+      } catch {
+        // ignore migration errors
+      }
+    }
+  }
+
+  private rowToEntry(row: MemoryRow): MemoryEntry {
+    return {
+      id: row.id,
+      category: row.category as MemoryCategory,
+      key: row.key,
+      value: JSON.parse(row.value),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      source: row.source,
+    };
   }
 
   // CRUD
@@ -24,6 +72,18 @@ export class MemoryStore {
   ): MemoryEntry {
     const id = `${category}:${key}`;
     const now = Date.now();
+
+    if (this.db) {
+      const existingRow = this.db.getMemory(id);
+      const createdAt = existingRow ? existingRow.created_at : now;
+      this.db.setMemory({ id, category, key, value, source, createdAt, updatedAt: now });
+      const entry: MemoryEntry = { id, category, key, value, createdAt, updatedAt: now, source };
+      if (this.eventBus) {
+        this.eventBus.emit(createEvent("memory.updated", { entry }, "memory-store"));
+      }
+      return entry;
+    }
+
     const existing = this.store.get(id);
     const entry: MemoryEntry = {
       id,
@@ -45,16 +105,41 @@ export class MemoryStore {
   }
 
   get(category: MemoryCategory, key: string): MemoryEntry | undefined {
+    if (this.db) {
+      const row = this.db.getMemory(`${category}:${key}`);
+      return row ? this.rowToEntry(row) : undefined;
+    }
     return this.store.get(`${category}:${key}`);
   }
 
   getAll(category: MemoryCategory): MemoryEntry[] {
+    if (this.db) {
+      return this.db.getAllMemory(category).map((row) => this.rowToEntry(row));
+    }
     return Array.from(this.store.values()).filter(
       (e) => e.category === category,
     );
   }
 
   update(id: string, value: unknown): MemoryEntry | undefined {
+    if (this.db) {
+      const row = this.db.getMemory(id);
+      if (!row) return undefined;
+      const entry = this.rowToEntry(row);
+      entry.value = value;
+      entry.updatedAt = Date.now();
+      this.db.setMemory({
+        id: entry.id,
+        category: entry.category,
+        key: entry.key,
+        value: entry.value,
+        source: entry.source,
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+      });
+      return entry;
+    }
+
     const entry = this.store.get(id);
     if (!entry) return undefined;
     entry.value = value;
@@ -64,6 +149,9 @@ export class MemoryStore {
   }
 
   delete(id: string): boolean {
+    if (this.db) {
+      return this.db.deleteMemory(id);
+    }
     this.dirty = true;
     return this.store.delete(id);
   }
@@ -71,20 +159,34 @@ export class MemoryStore {
   // Query
 
   search(category: MemoryCategory, query: string): MemoryEntry[] {
+    if (this.db) {
+      try {
+        return this.db.searchMemory(category, query).map((row) => this.rowToEntry(row));
+      } catch {
+        // FTS query syntax error — fall back to basic filtering
+        return this.getAll(category).filter(
+          (e) => e.key.includes(query) || JSON.stringify(e.value).includes(query),
+        );
+      }
+    }
     return this.getAll(category).filter(
       (e) => e.key.includes(query) || JSON.stringify(e.value).includes(query),
     );
   }
 
   getRecent(category: MemoryCategory, limit: number): MemoryEntry[] {
+    if (this.db) {
+      return this.db.getRecentMemory(category, limit).map((row) => this.rowToEntry(row));
+    }
     return this.getAll(category)
       .sort((a, b) => b.updatedAt - a.updatedAt)
       .slice(0, limit);
   }
 
-  // Persistence (JSON file)
+  // Persistence (JSON file — legacy fallback)
 
   async save(): Promise<void> {
+    if (this.db) return; // SQLite writes are immediate
     if (!this.persistPath || !this.dirty) return;
     const data = Array.from(this.store.values());
     await Bun.write(this.persistPath, JSON.stringify(data, null, 2));
@@ -92,6 +194,7 @@ export class MemoryStore {
   }
 
   async load(): Promise<void> {
+    if (this.db) return; // SQLite needs no explicit load
     if (!this.persistPath) return;
     try {
       const file = Bun.file(this.persistPath);
@@ -109,6 +212,7 @@ export class MemoryStore {
   // Auto-save every 30 seconds if dirty
 
   startAutoSave(intervalMs = 30000): void {
+    if (this.db) return; // No-op for SQLite
     this.autoSaveInterval = setInterval(() => this.save(), intervalMs);
   }
 

--- a/packages/model-provider/src/anthropic-provider.ts
+++ b/packages/model-provider/src/anthropic-provider.ts
@@ -83,7 +83,7 @@ export class AnthropicProvider implements ModelProvider {
   async completeStructured<T>(
     request: StructuredCompletionRequest,
   ): Promise<T> {
-    const schemaInstruction = `\n\nRespond ONLY with valid JSON matching this schema:\n${JSON.stringify(request.responseSchema, null, 2)}`;
+    const schemaInstruction = `\n\nRespond ONLY with valid JSON matching this schema. Do NOT wrap in markdown fences. Output raw JSON only:\n${JSON.stringify(request.responseSchema, null, 2)}`;
 
     const systemPrompt = (request.system ?? "") + schemaInstruction;
 
@@ -92,6 +92,37 @@ export class AnthropicProvider implements ModelProvider {
       system: systemPrompt,
     });
 
-    return JSON.parse(response.content) as T;
+    return this.parseStructuredResponse<T>(response.content);
+  }
+
+  private parseStructuredResponse<T>(content: string): T {
+    // Try direct parse first
+    try {
+      return JSON.parse(content) as T;
+    } catch {
+      // Strip markdown fences if present
+      const fenceMatch = content.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
+      if (fenceMatch) {
+        try {
+          return JSON.parse(fenceMatch[1]) as T;
+        } catch {
+          // fall through
+        }
+      }
+
+      // Try to find first { ... } or [ ... ] block
+      const jsonMatch = content.match(/(\{[\s\S]*\}|\[[\s\S]*\])/);
+      if (jsonMatch) {
+        try {
+          return JSON.parse(jsonMatch[1]) as T;
+        } catch {
+          // fall through
+        }
+      }
+
+      throw new Error(
+        `Failed to parse structured response as JSON. Raw content: ${content.slice(0, 200)}`,
+      );
+    }
   }
 }

--- a/packages/orchestrator/src/execution-planner.ts
+++ b/packages/orchestrator/src/execution-planner.ts
@@ -59,7 +59,7 @@ const AGENT_ORDERINGS: Record<string, AgentOrdering[]> = {
       category: "ui",
       groups: [
         // All surface agents run in parallel, then layout composer
-        ["ui.inbox-surface", "ui.calendar-surface", "ui.discovery-surface"],
+        ["ui.inbox-surface", "ui.calendar-surface", "ui.discovery-surface", "ui.connection-surface"],
         ["layout-composer"],
       ],
     },

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -5,6 +5,7 @@ import type { ModelProviderRegistry } from "@waibspace/model-provider";
 import type { MemoryStore } from "@waibspace/memory";
 import type { ConnectorRegistry } from "@waibspace/connectors";
 import type { PolicyEngine } from "@waibspace/policy";
+import type { WaibDatabase } from "@waibspace/db";
 import { AgentRegistry } from "./agent-registry";
 import { buildExecutionPlan } from "./execution-planner";
 import { createPipelineTrace, logTrace } from "./trace";
@@ -15,9 +16,10 @@ export interface OrchestratorOptions {
   memoryStore?: MemoryStore;
   connectorRegistry?: ConnectorRegistry;
   policyEngine?: PolicyEngine;
+  db?: WaibDatabase;
 }
 
-const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
 
 export class Orchestrator {
   constructor(
@@ -26,11 +28,42 @@ export class Orchestrator {
     private options?: OrchestratorOptions,
   ) {}
 
+  private logToDb(
+    eventType: string,
+    source: string,
+    traceId: string,
+    payload: unknown,
+    level: "info" | "warn" | "error" = "info",
+  ): void {
+    try {
+      this.options?.db?.logEvent({
+        id: `${traceId}-${source}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+        eventType,
+        source,
+        traceId,
+        payload,
+        level,
+        createdAt: Date.now(),
+      });
+    } catch {
+      // DB logging should never break the pipeline
+    }
+  }
+
   async processEvent(event: WaibEvent): Promise<void> {
     const startMs = Date.now();
     const plan = buildExecutionPlan(event.type, this.registry);
     const timeoutMs = this.options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const traceId = event.traceId;
+
+    this.logToDb("pipeline.start", "orchestrator", traceId, {
+      eventType: event.type,
+      payload: event.payload,
+      phases: plan.phases.map((p) => ({
+        category: p.category,
+        agents: p.agents.map((a) => a.id),
+      })),
+    });
 
     let priorOutputs: AgentOutput[] = [];
     const phaseResults: Array<{
@@ -85,9 +118,26 @@ export class Orchestrator {
               error: errorMsg,
               phase: phase.category,
             });
+            this.logToDb("agent.error", agent.id, traceId, {
+              phase: phase.category,
+              error: errorMsg,
+              durationMs: result.value.timing?.durationMs,
+            }, "error");
             console.error(
               `[Orchestrator] [trace:${traceId}] Agent ${agent.id} returned error in phase "${phase.category}": ${errorMsg}`,
             );
+          } else {
+            // Log successful agent completion with output summary
+            // Include full output for context agents (planner, connector-selection, data-retrieval)
+            const isContextAgent = phase.category === "context";
+            this.logToDb("agent.complete", agent.id, traceId, {
+              phase: phase.category,
+              confidence: result.value.confidence,
+              durationMs: result.value.timing?.durationMs,
+              hasOutput: result.value.output != null,
+              outputKeys: output && typeof output === "object" ? Object.keys(output) : [],
+              ...(isContextAgent ? { output: result.value.output } : {}),
+            }, "info");
           }
         } else {
           // Agent threw an unhandled rejection (should be rare since executeAgent catches)
@@ -100,6 +150,10 @@ export class Orchestrator {
             error: errorMsg,
             phase: phase.category,
           });
+          this.logToDb("agent.crash", agent.id, traceId, {
+            phase: phase.category,
+            error: errorMsg,
+          }, "error");
           console.error(
             `[Orchestrator] [trace:${traceId}] Agent ${agent.id} crashed in phase "${phase.category}": ${errorMsg}`,
           );
@@ -192,6 +246,14 @@ export class Orchestrator {
       phaseResults,
     );
     logTrace(trace);
+
+    this.logToDb("pipeline.complete", "orchestrator", traceId, {
+      eventType: event.type,
+      durationMs: endMs - startMs,
+      totalErrors: errors.length,
+      errors: errors.length > 0 ? errors : undefined,
+      surfaceCount: surfaceOutputs.length,
+    }, errors.length > 0 ? "warn" : "info");
 
     if (errors.length > 0) {
       console.warn(

--- a/packages/surfaces/src/factories.ts
+++ b/packages/surfaces/src/factories.ts
@@ -5,6 +5,7 @@ import type {
   CalendarSurfaceData,
   DiscoverySurfaceData,
   ApprovalSurfaceData,
+  ConnectionGuideSurfaceData,
 } from "./surface-data";
 
 export class SurfaceFactory {
@@ -113,6 +114,26 @@ export class SurfaceFactory {
         freshness: "realtime",
         dataState: "raw",
       })
+      .build();
+  }
+
+  static connectionGuide(
+    data: ConnectionGuideSurfaceData,
+    provenance: ProvenanceMetadata
+  ): SurfaceSpec {
+    const title = data.selectedService
+      ? `Connect ${data.selectedService.name}`
+      : "Connect a Service";
+    return new SurfaceSpecBuilder("connection-guide")
+      .setTitle(title)
+      .setSummary(data.message)
+      .setPriority(90)
+      .setData(data)
+      .setLayout({
+        position: "primary",
+        prominence: "hero",
+      })
+      .setProvenance(provenance)
       .build();
   }
 

--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -6,4 +6,5 @@ export type {
   CalendarSurfaceData,
   DiscoverySurfaceData,
   ApprovalSurfaceData,
+  ConnectionGuideSurfaceData,
 } from "./surface-data";

--- a/packages/surfaces/src/registry.ts
+++ b/packages/surfaces/src/registry.ts
@@ -43,6 +43,7 @@ export function createDefaultRegistry(): SurfaceTypeRegistry {
     "context",
     "consequences",
   ]);
+  registry.register("connection-guide", ["step", "message", "availableServices"]);
   registry.register("generic", []);
   return registry;
 }

--- a/packages/surfaces/src/surface-data.ts
+++ b/packages/surfaces/src/surface-data.ts
@@ -50,3 +50,30 @@ export interface ApprovalSurfaceData {
   context: unknown;
   consequences: string[];
 }
+
+export interface ConnectionGuideSurfaceData {
+  step: "browse" | "credentials" | "connecting" | "success" | "error";
+  message: string;
+  availableServices: Array<{
+    id: string;
+    name: string;
+    description: string;
+    icon: string;
+    categories: string[];
+  }>;
+  selectedService?: {
+    id: string;
+    name: string;
+    icon: string;
+    description: string;
+  };
+  credentialFields?: Array<{
+    key: string;
+    label: string;
+    helpText: string;
+    helpUrl?: string;
+    sensitive: boolean;
+  }>;
+  discoveredTools?: Array<{ name: string; description?: string }>;
+  errorDetail?: string;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,7 @@
       "@waibspace/memory": ["./packages/memory/src/index.ts"],
       "@waibspace/surfaces": ["./packages/surfaces/src/index.ts"],
       "@waibspace/model-provider": ["./packages/model-provider/src/index.ts"],
+      "@waibspace/db": ["./packages/db/src/index.ts"],
       "@waibspace/ui-renderer-contract": ["./packages/ui-renderer-contract/src/index.ts"]
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     { "path": "packages/memory" },
     { "path": "packages/surfaces" },
     { "path": "packages/model-provider" },
+    { "path": "packages/db" },
     { "path": "packages/ui-renderer-contract" },
     { "path": "apps/backend" },
     { "path": "apps/frontend" }


### PR DESCRIPTION
## Summary
- **SQLite database** (`packages/db`): persistent storage for memory, MCP server configs, and event logs with FTS5 full-text search. Replaces fragile JSON file persistence.
- **MCP server catalog**: built-in templates for Gmail (IMAP/SMTP), GitHub, Slack, Google Drive, Brave Search, Filesystem, Memory — users connect services by entering simple credentials (e.g., app passwords), not developer OAuth keys.
- **Connection guide surface**: conversational UI flow — browse catalog → enter credentials → connect — with direct REST call to `POST /api/mcp/setup`.
- **Pipeline reliability fixes**: robust JSON parsing for LLM responses, graceful empty output from agents when upstream data is missing, 30s timeouts, MCP data truncation (50KB cap), proper env var merging for MCP transports.
- **Event logging**: every agent result logged to SQLite with `GET /api/logs` query endpoint for debugging.
- **UI fixes**: eliminated dual text fields on home page, added working global input bar with cross-page message routing.

## Test plan
- [ ] `bunx tsc --noEmit` passes cleanly
- [ ] Backend starts, creates `waibspace.db` in `./data/`
- [ ] "connect my Gmail" → credentials step with email + app password fields
- [ ] Entering credentials + Connect → MCP server connects, tools discovered
- [ ] "check my email" → inbox surface renders with real email data
- [ ] `GET /api/logs?level=error` returns pipeline errors for debugging
- [ ] Settings page MCP management still works
- [ ] No OAuth imports or SecretStore references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)