### PR TITLE
P14-1: Build BlockStateProvider (two-tier state)

### DIFF
--- a/apps/frontend/src/blocks/BlockStateStore.tsx
+++ b/apps/frontend/src/blocks/BlockStateStore.tsx
@@ -1,0 +1,158 @@
+/**
+ * BlockStateStore — Tier 2 shared block state.
+ *
+ * Provides a lightweight, per-layout shared state store that blocks can
+ * read and write via `useBlockState(key)`.  Internally the store is a
+ * `Map<string, unknown>` held in a ref.  Subscriptions are per-key so
+ * mutations only re-render the components that care about the changed key.
+ *
+ * Uses React's built-in `useSyncExternalStore` for tear-free reads.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+
+// ---------------------------------------------------------------------------
+// Store internals
+// ---------------------------------------------------------------------------
+
+type Listener = () => void;
+
+interface BlockStateStore {
+  getState(key: string): unknown;
+  setState(key: string, value: unknown): void;
+  subscribe(key: string, listener: Listener): () => void;
+  getSnapshot(key: string): unknown;
+}
+
+function createBlockStateStore(): BlockStateStore {
+  const data = new Map<string, unknown>();
+  const listeners = new Map<string, Set<Listener>>();
+
+  function notify(key: string) {
+    const subs = listeners.get(key);
+    if (subs) {
+      for (const listener of subs) {
+        listener();
+      }
+    }
+  }
+
+  return {
+    getState(key: string): unknown {
+      return data.get(key);
+    },
+
+    setState(key: string, value: unknown): void {
+      const prev = data.get(key);
+      if (Object.is(prev, value)) return; // no-op when unchanged
+      data.set(key, value);
+      notify(key);
+    },
+
+    subscribe(key: string, listener: Listener): () => void {
+      let subs = listeners.get(key);
+      if (!subs) {
+        subs = new Set();
+        listeners.set(key, subs);
+      }
+      subs.add(listener);
+      return () => {
+        subs!.delete(listener);
+        if (subs!.size === 0) {
+          listeners.delete(key);
+        }
+      };
+    },
+
+    getSnapshot(key: string): unknown {
+      return data.get(key);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// React Context
+// ---------------------------------------------------------------------------
+
+interface BlockStateContextValue {
+  getState(key: string): unknown;
+  setState(key: string, value: unknown): void;
+  /** @internal — used by useBlockState */
+  _store: BlockStateStore;
+}
+
+const BlockStateContext = createContext<BlockStateContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export interface BlockStateProviderProps {
+  children: ReactNode;
+}
+
+export function BlockStateProvider({ children }: BlockStateProviderProps) {
+  const storeRef = useRef<BlockStateStore | null>(null);
+  if (storeRef.current === null) {
+    storeRef.current = createBlockStateStore();
+  }
+  const store = storeRef.current;
+
+  const ctxValue: BlockStateContextValue = {
+    getState: store.getState,
+    setState: store.setState,
+    _store: store,
+  };
+
+  return (
+    <BlockStateContext.Provider value={ctxValue}>
+      {children}
+    </BlockStateContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hook — fine-grained subscription to a single key
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscribe to a specific key in the shared block state store.
+ *
+ * Returns `[value, setValue]` similar to `useState`, but backed by the
+ * shared store so sibling blocks can coordinate through it.
+ *
+ * Only re-renders when the subscribed key changes.
+ */
+export function useBlockState(key: string): [unknown, (value: unknown) => void] {
+  const ctx = useContext(BlockStateContext);
+  if (!ctx) {
+    throw new Error("useBlockState must be used within a <BlockStateProvider>");
+  }
+
+  const { _store: store } = ctx;
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => store.subscribe(key, onStoreChange),
+    [store, key],
+  );
+
+  const getSnapshot = useCallback(() => store.getSnapshot(key), [store, key]);
+
+  const value = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  const setValue = useCallback(
+    (next: unknown) => store.setState(key, next),
+    [store, key],
+  );
+
+  return [value, setValue];
+}
+
+export { BlockStateContext };


### PR DESCRIPTION
## Summary
- Adds `BlockStateProvider` React context and `useBlockState(key)` hook for tier-2 shared block state
- Internal store uses a `Map<string, unknown>` held in a ref with per-key listener sets
- Uses React's built-in `useSyncExternalStore` for tear-free, fine-grained re-renders — only components subscribed to a changed key re-render
- No external dependencies

## Details
The two-tier state model separates local component state (tier 1, standard React state) from shared cross-block state (tier 2, this provider). Agents declare state shape via `ComponentStateDefinition` on blocks, and sibling blocks coordinate through the shared store.

Closes #120
Blocked by #117

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (confirmed in this PR)
- [ ] Wrap a component tree in `<BlockStateProvider>` and use `useBlockState` from multiple children
- [ ] Confirm that setting state from one child re-renders only subscribers of that key
- [ ] Confirm `useBlockState` throws outside of provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)