### PR TITLE
P16-1: Wire observation batches to backend

### DIFF
--- a/apps/backend/src/ws.ts
+++ b/apps/backend/src/ws.ts
@@ -175,19 +175,44 @@ export function createWebSocketHandlers(bus: EventBus, memoryStore?: MemoryStore
 
       const clientMsg = parsed as ClientMessage;
       const eventType = mapClientMessageToEventType(clientMsg);
+      const source = `ws:${ws.data.connectionId}`;
 
       console.log(
         `[ws] [trace:${traceId}] message from ${ws.data.connectionId}: ${clientMsg.type} -> ${eventType}`,
       );
 
-      // Create a WaibEvent and emit to the event bus
-      const event = createEvent(
-        eventType,
-        clientMsg.payload,
-        `ws:${ws.data.connectionId}`,
-        traceId,
-      );
-      bus.emit(event);
+      // If this is a user.interaction with a batch, emit individual events for each observation
+      if (clientMsg.type === "user.interaction" && clientMsg.payload.batch && clientMsg.payload.batch.length > 0) {
+        const { batch, ...basePayload } = clientMsg.payload;
+        console.log(
+          `[ws] [trace:${traceId}] Processing observation batch of ${batch.length} item(s)`,
+        );
+        for (const observation of batch) {
+          const obsEventType = `user.interaction.${observation.interactionType}`;
+          const obsPayload = {
+            ...basePayload,
+            interaction: observation.interactionType,
+            blockId: observation.blockId,
+            blockType: observation.blockType,
+            wasPlanned: observation.wasPlanned,
+            position: observation.position,
+            dwellMs: observation.dwellMs,
+            viewportRatio: observation.viewportRatio,
+            timestamp: observation.timestamp,
+          };
+          const obsEvent = createEvent(obsEventType, obsPayload, source, traceId);
+          bus.emit(obsEvent);
+        }
+      } else {
+        // Create a WaibEvent and emit to the event bus
+        const event = createEvent(
+          eventType,
+          clientMsg.payload,
+          source,
+          traceId,
+        );
+        bus.emit(event);
+      }
     },
 
     close(ws: ServerWebSocket<WebSocketData>) {

--- a/packages/ui-renderer-contract/src/messages.ts
+++ b/packages/ui-renderer-contract/src/messages.ts
@@ -27,6 +27,19 @@ export type ClientMessage =
         surfaceType?: string;
         context?: unknown;
         timestamp: number;
+        blockId?: string;
+        blockType?: string;
+        wasPlanned?: boolean;
+        batch?: Array<{
+          blockId: string;
+          blockType: string;
+          wasPlanned: boolean;
+          interactionType: string;
+          position?: { x: number; y: number };
+          dwellMs?: number;
+          viewportRatio?: number;
+          timestamp: number;
+        }>;
       };
     }
   | { type: "user.intent.url"; payload: { path: string; raw: string } }


### PR DESCRIPTION
## Summary
- Extended `user.interaction` ClientMessage payload in `packages/ui-renderer-contract/src/messages.ts` with optional `blockId`, `blockType`, `wasPlanned`, and `batch` fields to support ComponentBlock observation data.
- Updated the backend WebSocket handler in `apps/backend/src/ws.ts` to fan out batched observations into individual events on the event bus, so downstream agents process each observation separately.
- Verified clean compile with `bunx tsc --noEmit`.

Closes #128

## Test plan
- [ ] Send a `user.interaction` message without `batch` and verify it routes as before (single event emitted)
- [ ] Send a `user.interaction` message with a `batch` array of 3+ observations and verify each emits a separate `user.interaction.<interactionType>` event
- [ ] Confirm payload fields (`blockId`, `blockType`, `wasPlanned`, `position`, `dwellMs`, `viewportRatio`, `timestamp`) propagate correctly onto each fanned-out event
- [ ] Verify TypeScript compilation passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)