### PR TITLE
feat: observation processor for unplanned pattern detection

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -38,7 +38,7 @@ import {
   ModelProviderRegistry,
   AnthropicProvider,
 } from "@waibspace/model-provider";
-import { MemoryStore, MemoryUpdatePipeline } from "@waibspace/memory";
+import { MemoryStore, MemoryUpdatePipeline, ObservationProcessor } from "@waibspace/memory";
 import { WaibDatabase } from "@waibspace/db";
 import { BackgroundTaskScheduler, MVP_BACKGROUND_TASKS } from "./background";
 import { startServer } from "./server";
@@ -152,6 +152,10 @@ const orchestrator = new Orchestrator(bus, agentRegistry, {
 // ---------- 8. Memory Update Pipeline ----------
 const memoryPipeline = new MemoryUpdatePipeline(memoryStore, bus);
 memoryPipeline.start();
+
+// ---------- 8b. Observation Processor ----------
+const observationProcessor = new ObservationProcessor(memoryStore, bus);
+observationProcessor.start();
 
 // ---------- 9. Background Task Scheduler ----------
 const scheduler = new BackgroundTaskScheduler(bus, orchestrator, memoryStore);

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,2 +1,4 @@
 export { MemoryStore } from "./memory-store";
 export { MemoryUpdatePipeline } from "./update-pipeline";
+export { ObservationProcessor } from "./observation-processor";
+export type { ObservationProcessorOptions } from "./observation-processor";

--- a/packages/memory/src/observation-processor.ts
+++ b/packages/memory/src/observation-processor.ts
@@ -1,0 +1,150 @@
+import type { WaibEvent } from "@waibspace/types";
+import type { EventBus } from "@waibspace/event-bus";
+import { createEvent } from "@waibspace/event-bus";
+import type { MemoryStore } from "./memory-store";
+
+/** Default number of unplanned occurrences before a pattern is detected. */
+const DEFAULT_THRESHOLD = 3;
+
+/** In-memory counter for unplanned interaction patterns. */
+interface PatternCounter {
+  blockType: string;
+  interactionType: string;
+  count: number;
+  firstSeen: number;
+  lastSeen: number;
+}
+
+export interface ObservationProcessorOptions {
+  /** How many unplanned observations of the same kind trigger a pattern event. */
+  threshold?: number;
+}
+
+/**
+ * Observes `user.interaction` events on the EventBus and detects recurring
+ * patterns among *unplanned* interactions (wasPlanned === false).
+ *
+ * When a {blockType}:{interactionType} pair reaches the configured threshold,
+ * the processor:
+ *   1. Emits an `observation.pattern.detected` event on the bus.
+ *   2. Persists the learned pattern in the MemoryStore so future agents can
+ *      read it via the standard memory retrieval path.
+ */
+export class ObservationProcessor {
+  private counters = new Map<string, PatternCounter>();
+  private emittedPatterns = new Set<string>();
+  private readonly threshold: number;
+
+  constructor(
+    private memoryStore: MemoryStore,
+    private eventBus: EventBus,
+    options?: ObservationProcessorOptions,
+  ) {
+    this.threshold = options?.threshold ?? DEFAULT_THRESHOLD;
+  }
+
+  /**
+   * Begin listening for `user.interaction` events.
+   * Call this once during application startup.
+   */
+  start(): void {
+    this.eventBus.on("user.interaction", (event: WaibEvent) => {
+      this.processObservation(event);
+    });
+
+    // Also match namespaced interaction events (e.g. user.interaction.click)
+    this.eventBus.on("user.interaction.*", (event: WaibEvent) => {
+      this.processObservation(event);
+    });
+
+    console.log(
+      `[observation-processor] Started (threshold=${this.threshold})`,
+    );
+  }
+
+  /** Return all counters — useful for diagnostics / tests. */
+  getCounters(): ReadonlyMap<string, Readonly<PatternCounter>> {
+    return this.counters;
+  }
+
+  // ---- Private ----
+
+  private processObservation(event: WaibEvent): void {
+    const payload = event.payload as Record<string, unknown> | null;
+    if (!payload) return;
+
+    // Only track unplanned interactions
+    if (payload.wasPlanned !== false) return;
+
+    const blockType = payload.blockType as string | undefined;
+    const interactionType = payload.interactionType as string | undefined;
+
+    if (!blockType || !interactionType) return;
+
+    const key = `${blockType}:${interactionType}`;
+    const now = Date.now();
+
+    // Upsert counter
+    const existing = this.counters.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.lastSeen = now;
+    } else {
+      this.counters.set(key, {
+        blockType,
+        interactionType,
+        count: 1,
+        firstSeen: now,
+        lastSeen: now,
+      });
+    }
+
+    const counter = this.counters.get(key)!;
+
+    // Check threshold — only emit once per pattern key
+    if (counter.count >= this.threshold && !this.emittedPatterns.has(key)) {
+      this.emittedPatterns.add(key);
+      this.emitPattern(counter, event.traceId);
+      this.persistPattern(counter);
+    }
+  }
+
+  private emitPattern(counter: PatternCounter, traceId: string): void {
+    const patternPayload = {
+      blockType: counter.blockType,
+      interactionType: counter.interactionType,
+      count: counter.count,
+      firstSeen: counter.firstSeen,
+      lastSeen: counter.lastSeen,
+    };
+
+    this.eventBus.emit(
+      createEvent(
+        "observation.pattern.detected",
+        patternPayload,
+        "observation-processor",
+        traceId,
+      ),
+    );
+
+    console.log(
+      `[observation-processor] Pattern detected: ${counter.blockType}:${counter.interactionType} (count=${counter.count})`,
+    );
+  }
+
+  private persistPattern(counter: PatternCounter): void {
+    const memoryKey = `learned-pattern:${counter.blockType}:${counter.interactionType}`;
+    this.memoryStore.set(
+      "interaction",
+      memoryKey,
+      {
+        blockType: counter.blockType,
+        interactionType: counter.interactionType,
+        count: counter.count,
+        firstSeen: counter.firstSeen,
+        lastSeen: counter.lastSeen,
+      },
+      "observation-processor",
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Created `packages/memory/src/observation-processor.ts` — subscribes to `user.interaction` and `user.interaction.*` events on the EventBus
- For observations where `wasPlanned === false`, tracks counters per `{blockType}:{interactionType}` pair
- When a pattern count reaches the threshold (default >= 3), emits `observation.pattern.detected` event and persists the learned pattern to MemoryStore under the `interaction` category
- Exported `ObservationProcessor` from `packages/memory/src/index.ts`
- Wired the processor into `apps/backend/src/index.ts` (section 8b, after MemoryUpdatePipeline)

Closes #129

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (confirmed clean compile)
- [ ] Send 3+ `user.interaction` events with `wasPlanned: false` and matching `blockType`/`interactionType` — confirm `observation.pattern.detected` event is emitted
- [ ] Confirm learned patterns are persisted in MemoryStore under `interaction` category with `learned-pattern:` prefix
- [ ] Confirm pattern event is only emitted once per unique key (deduplication via `emittedPatterns` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)