### PR TITLE
fix: Gmail inbox wrong unread count, stale/missing emails

### DIFF
--- a/packages/agents/src/context/context-planner.ts
+++ b/packages/agents/src/context/context-planner.ts
@@ -22,9 +22,11 @@ Given an intent classification, determine which data sources need to be queried 
 Available connectors and their operations:
 
 - **gmail**:
-  - list-emails: List recent emails. Params: maxResults (number), labelIds (string[])
+  - list-emails: List emails. Params: maxResults (number, default 10), labelIds (string[] e.g. ["INBOX"], ["UNREAD"], ["STARRED"]), query (string, supports Gmail search syntax: "is:unread", "newer_than:7d", "from:address", "subject:text", "in:inbox", etc.)
+    - For inbox/email intents with no specific filter, default to query: "is:unread newer_than:7d" with maxResults: 10 to show recent unread emails
   - get-email: Get a specific email. Params: emailId (string)
   - search-emails: Search emails by query. Params: query (string), maxResults (number)
+  - get-inbox-stats: Get inbox label statistics including total unread count. No params required.
 
 - **google-calendar**:
   - list-events: List upcoming calendar events. Params: timeMin (string), timeMax (string), maxResults (number)

--- a/packages/agents/src/context/data-retrieval.ts
+++ b/packages/agents/src/context/data-retrieval.ts
@@ -13,6 +13,7 @@ interface RetrievalResult {
   status: "fulfilled" | "rejected";
   data?: unknown;
   provenance?: ProvenanceMetadata;
+  metadata?: Record<string, unknown>;
   error?: string;
 }
 
@@ -86,6 +87,7 @@ export class DataRetrievalAgent extends BaseAgent {
           operation: retrieval.operation,
           data: this.truncateData(response.data),
           provenance: response.provenance,
+          metadata: response.metadata,
         };
       }),
     );
@@ -100,6 +102,7 @@ export class DataRetrievalAgent extends BaseAgent {
             status: "fulfilled" as const,
             data: result.value.data,
             provenance: result.value.provenance,
+            metadata: result.value.metadata,
           };
         } else {
           this.log("Retrieval failed", {

--- a/packages/agents/src/ui/inbox-surface.ts
+++ b/packages/agents/src/ui/inbox-surface.ts
@@ -84,7 +84,7 @@ export class InboxSurfaceAgent extends BaseAgent {
       });
     }
 
-    const gmailData = this.extractGmailData(retrievalOutput);
+    const { data: gmailData, totalUnread: gmailTotalUnread } = this.extractGmailData(retrievalOutput);
     const calendarData = this.extractCalendarData(input);
 
     // If no email data found, skip LLM call
@@ -116,7 +116,8 @@ export class InboxSurfaceAgent extends BaseAgent {
       SYSTEM_PROMPT,
     );
 
-    const unreadCount = analysis.emails.filter((e) => e.isUnread).length;
+    const batchUnreadCount = analysis.emails.filter((e) => e.isUnread).length;
+    const unreadCount = gmailTotalUnread ?? batchUnreadCount;
 
     const surfaceData: InboxSurfaceData = {
       emails: analysis.emails,
@@ -166,7 +167,7 @@ export class InboxSurfaceAgent extends BaseAgent {
     return undefined;
   }
 
-  private extractGmailData(retrieval: DataRetrievalOutput): unknown {
+  private extractGmailData(retrieval: DataRetrievalOutput): { data: unknown; totalUnread: number | undefined } {
     // Find email-related results from any connector (gmail, catalog-gmail, MCP mail, etc.)
     const emailResults = retrieval.results.filter(
       (r) =>
@@ -178,7 +179,30 @@ export class InboxSurfaceAgent extends BaseAgent {
           r.operation.includes("inbox")),
     );
 
-    if (emailResults.length === 0) return [];
+    if (emailResults.length === 0) return { data: [], totalUnread: undefined };
+
+    // Extract totalUnread from connector metadata if available
+    let totalUnread: number | undefined;
+    for (const result of emailResults) {
+      const meta = (result as Record<string, unknown>).metadata as Record<string, unknown> | undefined;
+      if (meta && typeof meta.totalUnread === "number") {
+        totalUnread = meta.totalUnread;
+        break;
+      }
+    }
+
+    // Also check for get-inbox-stats results
+    const statsResult = retrieval.results.find(
+      (r) =>
+        r.status === "fulfilled" &&
+        r.operation === "get-inbox-stats",
+    );
+    if (statsResult && totalUnread === undefined) {
+      const statsData = statsResult.data as Record<string, unknown> | undefined;
+      if (statsData && typeof statsData.messagesUnread === "number") {
+        totalUnread = statsData.messagesUnread;
+      }
+    }
 
     // MCP tools return [{type: "text", text: "..."}] — extract and parse the text content
     const allData: unknown[] = [];
@@ -190,7 +214,7 @@ export class InboxSurfaceAgent extends BaseAgent {
         allData.push(result.data);
       }
     }
-    return allData;
+    return { data: allData, totalUnread };
   }
 
   /**

--- a/packages/connectors/src/gmail/gmail-connector.ts
+++ b/packages/connectors/src/gmail/gmail-connector.ts
@@ -81,7 +81,7 @@ export class GmailConnector extends BaseConnector {
       capabilities: {
         connectorId: "gmail",
         connectorType: "api",
-        actions: ["list-emails", "get-email", "search-emails", "create-draft", "send-email"],
+        actions: ["list-emails", "get-email", "search-emails", "get-inbox-stats", "create-draft", "send-email"],
         dataTypes: ["email"],
         trustLevel: "trusted",
       },
@@ -132,6 +132,8 @@ export class GmailConnector extends BaseConnector {
         return this.getEmail(request.params as unknown as GetEmailParams);
       case "search-emails":
         return this.searchEmails(request.params as unknown as SearchEmailsParams);
+      case "get-inbox-stats":
+        return this.getInboxStats();
       default:
         throw new Error(`Unknown fetch operation: ${request.operation}`);
     }
@@ -163,10 +165,11 @@ export class GmailConnector extends BaseConnector {
   // --- Fetch Operations (Class A) ---
 
   private async listEmails(params: ListEmailsParams): Promise<ConnectorResponse> {
+    const query = params.query ?? "is:unread";
     const res = await this.gmail!.users.messages.list({
       userId: "me",
-      maxResults: params.maxResults ?? 20,
-      q: params.query,
+      maxResults: params.maxResults ?? 10,
+      q: query,
       labelIds: params.labelIds,
     });
 
@@ -175,10 +178,23 @@ export class GmailConnector extends BaseConnector {
       messages.map((m) => this.fetchMessageSummary(m.id!)),
     );
 
+    // Fetch total unread count from INBOX label stats
+    let totalUnread: number | undefined;
+    try {
+      const labelRes = await this.gmail!.users.labels.get({
+        userId: "me",
+        id: "INBOX",
+      });
+      totalUnread = labelRes.data.messagesUnread ?? undefined;
+    } catch {
+      // Non-critical — continue without total unread count
+    }
+
     return {
       data: summaries,
       provenance: this.createProvenance(),
       raw: res.data,
+      metadata: { totalUnread },
     };
   }
 
@@ -204,6 +220,24 @@ export class GmailConnector extends BaseConnector {
       query: params.query,
       maxResults: params.maxResults,
     });
+  }
+
+  private async getInboxStats(): Promise<ConnectorResponse> {
+    const labelRes = await this.gmail!.users.labels.get({
+      userId: "me",
+      id: "INBOX",
+    });
+
+    return {
+      data: {
+        messagesTotal: labelRes.data.messagesTotal ?? 0,
+        messagesUnread: labelRes.data.messagesUnread ?? 0,
+        threadsTotal: labelRes.data.threadsTotal ?? 0,
+        threadsUnread: labelRes.data.threadsUnread ?? 0,
+      },
+      provenance: this.createProvenance(),
+      raw: labelRes.data,
+    };
   }
 
   // --- Execute Operations (Class C) ---

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -30,6 +30,7 @@ export interface ConnectorResponse {
   data: unknown;
   provenance: ProvenanceMetadata;
   raw?: unknown;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ConnectorAction {


### PR DESCRIPTION
## Summary
- **Wrong unread count**: Inbox surface counted unread emails from the fetched batch only (e.g. showing "0 unread" when account has 124). Now fetches actual total unread count from Gmail INBOX label stats via `users.labels.get` and passes it through the retrieval pipeline via a new `metadata` field on `ConnectorResponse`.
- **Only 1 email / stale emails**: The `list-emails` operation had no default query filter, so Gmail returned arbitrary messages. Now defaults `query` to `"is:unread"` and `maxResults` to 10. The context planner prompt now documents the `query` param with Gmail search syntax examples and instructs the LLM to default to `"is:unread newer_than:7d"` for inbox intents.
- **New `get-inbox-stats` operation**: Returns INBOX label statistics (total messages, unread count, thread counts) for accurate display without relying on batch counts.

### Files changed
- `packages/agents/src/context/context-planner.ts` — expanded gmail docs in system prompt
- `packages/connectors/src/gmail/gmail-connector.ts` — default query, totalUnread metadata, new get-inbox-stats
- `packages/connectors/src/types.ts` — added optional `metadata` to `ConnectorResponse`
- `packages/agents/src/context/data-retrieval.ts` — pass metadata through retrieval pipeline
- `packages/agents/src/ui/inbox-surface.ts` — use totalUnread from metadata for display count

## Test plan
- [ ] Verify `list-emails` with no params returns unread emails (not stale/random)
- [ ] Verify inbox surface shows correct total unread count from label stats
- [ ] Verify multiple emails display when available
- [ ] Verify `get-inbox-stats` returns accurate INBOX label statistics
- [ ] Run `bunx tsc --noEmit` — passes cleanly

Fixes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)