### PR TITLE
fix: improve inbox block renderer email styling

### DIFF
--- a/apps/frontend/src/blocks/transformers/inbox.ts
+++ b/apps/frontend/src/blocks/transformers/inbox.ts
@@ -9,13 +9,40 @@ import type { InboxSurfaceData } from "@waibspace/surfaces";
 function urgencyColor(urgency: string): string {
   switch (urgency) {
     case "high":
-      return "red";
+      return "var(--color-danger)";
     case "medium":
-      return "yellow";
+      return "var(--color-warning)";
     case "low":
-      return "blue";
+      return "var(--color-neutral)";
     default:
-      return "gray";
+      return "var(--color-neutral)";
+  }
+}
+
+function urgencyTextColor(urgency: string): string {
+  switch (urgency) {
+    case "medium":
+      return "#000";
+    default:
+      return "#fff";
+  }
+}
+
+function formatRelativeTime(dateStr: string): string {
+  try {
+    const d = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - d.getTime();
+    const diffMins = Math.round(diffMs / (1000 * 60));
+    if (diffMins < 1) return "now";
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHrs = Math.round(diffMins / 60);
+    if (diffHrs < 24) return `${diffHrs}h ago`;
+    const diffDays = Math.round(diffHrs / 24);
+    if (diffDays < 7) return `${diffDays}d ago`;
+    return d.toLocaleDateString();
+  } catch {
+    return dateStr;
   }
 }
 
@@ -52,51 +79,133 @@ export function inboxToBlocks(spec: SurfaceSpec): ComponentBlock[] {
 
   const children: ComponentBlock[] = [];
 
-  // Header
+  // Header row: title + unread count badge
+  const headerChildren: ComponentBlock[] = [
+    {
+      id: `${sid}-header`,
+      type: "Text",
+      props: { content: spec.title, variant: "h3", color: "var(--color-text)" },
+    },
+  ];
+  if (data.unreadCount > 0) {
+    headerChildren.push({
+      id: `${sid}-unread-count`,
+      type: "Badge",
+      props: {
+        content: `${data.unreadCount} unread`,
+        variant: "count",
+        color: "var(--color-accent)",
+      },
+    });
+  }
   children.push({
-    id: `${sid}-header`,
-    type: "Text",
-    props: { content: spec.title, variant: "h3", color: "var(--color-text)" },
+    id: `${sid}-header-row`,
+    type: "Row",
+    props: { gap: "12px", align: "center" },
+    children: headerChildren,
   });
 
   // Email list
   if (data.emails && data.emails.length > 0) {
     const emailItems: ComponentBlock[] = data.emails.map((email, i) => {
-      const rowChildren: ComponentBlock[] = [
-        {
-          id: `${sid}-email-badge-${i}`,
+      // Left side: unread dot
+      const rowChildren: ComponentBlock[] = [];
+
+      if (email.isUnread) {
+        rowChildren.push({
+          id: `${sid}-email-dot-${i}`,
           type: "Badge",
-          props: { label: email.urgency, color: urgencyColor(email.urgency) },
-        },
+          props: { variant: "dot", color: "var(--color-accent)" },
+        });
+      } else {
+        // Spacer to keep alignment consistent
+        rowChildren.push({
+          id: `${sid}-email-dot-spacer-${i}`,
+          type: "Container",
+          props: { className: "inbox-block-dot-spacer" },
+        });
+      }
+
+      // Content stack: sender+date row, subject, snippet
+      const contentChildren: ComponentBlock[] = [
+        // Top row: sender + date
         {
-          id: `${sid}-email-stack-${i}`,
-          type: "Stack",
-          props: { gap: "2px" },
+          id: `${sid}-email-top-${i}`,
+          type: "Row",
+          props: { gap: "8px", align: "center", justify: "space-between" },
           children: [
             {
               id: `${sid}-email-from-${i}`,
               type: "Text",
-              props: { content: email.from, variant: "body" },
+              props: {
+                content: email.from,
+                variant: "body",
+                weight: email.isUnread ? "var(--weight-semibold)" : undefined,
+              },
             },
             {
-              id: `${sid}-email-subject-${i}`,
+              id: `${sid}-email-date-${i}`,
               type: "Text",
-              props: { content: email.subject, variant: "bold" },
-            },
-            {
-              id: `${sid}-email-snippet-${i}`,
-              type: "Text",
-              props: { content: email.snippet, variant: "caption" },
+              props: {
+                content: formatRelativeTime(email.date),
+                variant: "caption",
+                color: "var(--color-muted)",
+              },
             },
           ],
         },
+        // Subject
+        {
+          id: `${sid}-email-subject-${i}`,
+          type: "Text",
+          props: {
+            content: email.subject,
+            variant: "label",
+            weight: email.isUnread ? "var(--weight-semibold)" : "var(--weight-medium)",
+          },
+        },
+        // Snippet
+        {
+          id: `${sid}-email-snippet-${i}`,
+          type: "Text",
+          props: {
+            content: email.snippet,
+            variant: "caption",
+            color: "var(--color-muted)",
+          },
+        },
       ];
+
+      rowChildren.push({
+        id: `${sid}-email-content-${i}`,
+        type: "Stack",
+        props: { gap: "2px" },
+        children: contentChildren,
+      });
+
+      // Urgency badge on the right
+      rowChildren.push({
+        id: `${sid}-email-urgency-${i}`,
+        type: "Container",
+        props: { className: `inbox-block-urgency inbox-block-urgency--${email.urgency}` },
+        children: [
+          {
+            id: `${sid}-email-urgency-text-${i}`,
+            type: "Text",
+            props: {
+              content: email.urgency,
+              variant: "caption",
+              color: urgencyTextColor(email.urgency),
+            },
+          },
+        ],
+      });
 
       const itemChildren: ComponentBlock[] = [
         {
           id: `${sid}-email-row-${i}`,
           type: "Row",
-          props: { gap: "12px", align: "center" },
+          props: { gap: "12px", align: "flex-start" },
           children: rowChildren,
         },
       ];
@@ -140,7 +249,9 @@ export function inboxToBlocks(spec: SurfaceSpec): ComponentBlock[] {
       return {
         id: `${sid}-email-item-${i}`,
         type: "ListItem",
-        props: {},
+        props: {
+          className: email.isUnread ? "inbox-block-item--unread" : "",
+        },
         children: itemChildren,
       } satisfies ComponentBlock;
     });
@@ -148,7 +259,7 @@ export function inboxToBlocks(spec: SurfaceSpec): ComponentBlock[] {
     children.push({
       id: `${sid}-email-list`,
       type: "List",
-      props: {},
+      props: { className: "inbox-block-list" },
       children: emailItems,
     });
   }

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -3121,6 +3121,73 @@ body {
 }
 
 /* ----------------------------- */
+/* Inbox Block Styling           */
+/* ----------------------------- */
+
+/* Unread item highlight */
+.inbox-block-item--unread {
+  background-color: var(--color-accent-muted);
+}
+
+.inbox-block-item--unread:hover {
+  background-color: var(--color-accent-subtle) !important;
+}
+
+/* Dot spacer keeps alignment when no unread dot is shown */
+.inbox-block-dot-spacer {
+  width: 8px;
+  height: 8px;
+  flex-shrink: 0;
+}
+
+/* Content stack should fill available space */
+.inbox-block-item--unread + .block-stack,
+.block-list-item .block-row > .block-stack {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Urgency badge pill */
+.inbox-block-urgency {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  margin-top: 2px;
+}
+
+.inbox-block-urgency--high {
+  background-color: var(--color-danger);
+}
+
+.inbox-block-urgency--medium {
+  background-color: var(--color-warning);
+}
+
+.inbox-block-urgency--low {
+  background-color: var(--color-neutral);
+}
+
+/* Truncate long snippets */
+.inbox-block-list .block-list-item .block-stack .block-text:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Ensure sender/date row spans full width */
+.inbox-block-list .block-list-item .block-stack > .block-row {
+  width: 100%;
+}
+
+/* ----------------------------- */
 /* Divider                       */
 /* ----------------------------- */
 .block-divider--line {


### PR DESCRIPTION
## Summary
- Add visual polish to the BlockSurfaceRenderer's inbox display to match the styling quality of the old SurfaceRenderer
- Unread indicators (blue accent dot), colored urgency badges (red/amber/gray), relative date formatting, sender+date row layout, snippet truncation, and unread item background highlighting
- Fix Badge component prop usage (`content` instead of incorrect `label`)

Closes #151

## Test plan
- [ ] Verify inbox surface renders with blue dot next to unread emails
- [ ] Verify urgency badges show correct colors: high=red, medium=amber, low=gray
- [ ] Verify dates display as relative time (e.g. "5m ago", "2h ago")
- [ ] Verify unread emails have highlighted background
- [ ] Verify long snippets truncate with ellipsis
- [ ] Verify suggested reply expandable still works correctly
- [ ] Verify `npx tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)