### PR TITLE
fix: prevent scroll-view observations from triggering full pipeline reload

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -175,8 +175,21 @@ const USER_EVENT_PATTERNS = [
   "policy.approval.*",
 ];
 
+/**
+ * Passive observation event types that should NOT trigger the orchestration
+ * pipeline. These are telemetry events processed by the ObservationProcessor
+ * only (e.g. scroll-view fired by IntersectionObserver as the user scrolls).
+ */
+const PASSIVE_OBSERVATION_TYPES = new Set([
+  "user.interaction.scroll-view",
+]);
+
 for (const pattern of USER_EVENT_PATTERNS) {
   bus.on(pattern, async (event: WaibEvent) => {
+    // Skip passive observation events — they are handled by the
+    // ObservationProcessor and should not re-trigger the full pipeline.
+    if (PASSIVE_OBSERVATION_TYPES.has(event.type)) return;
+
     const traceId = event.traceId;
     console.log(
       `[backend] [trace:${traceId}] Routing event "${event.type}" to orchestrator`,

--- a/apps/frontend/src/components/BlockSurfaceRenderer.tsx
+++ b/apps/frontend/src/components/BlockSurfaceRenderer.tsx
@@ -154,10 +154,15 @@ export function BlockSurfaceRenderer({
 
       const data = payload as Record<string, unknown>;
 
-      // Observation batches from ObservationCollector — forward as-is
+      // Observation batches from ObservationCollector — these go directly
+      // over the WebSocket for telemetry; do not forward to onInteraction.
       if (data.batch) return;
 
       const interaction = (data.interaction as string) ?? "";
+
+      // Passive observation events (e.g. scroll-view from IntersectionObserver)
+      // are telemetry-only and should not be forwarded as user interactions.
+      if (interaction === "scroll-view") return;
 
       // Try to resolve surfaceId/surfaceType from the payload context
       const surfaceId = (data.surfaceId as string) ?? "";


### PR DESCRIPTION
## Summary
- **Root cause**: `user.interaction.scroll-view` events from the `IntersectionObserver` (fired as the user scrolls through surfaces) matched the `user.*` wildcard pattern in the backend event router, triggering a full orchestration pipeline re-run for each observation. This produced new `surface.update` messages that reset the UI layout on first visit.
- **Backend fix**: Added a `PASSIVE_OBSERVATION_TYPES` set in `apps/backend/src/index.ts` that filters out `scroll-view` events before they reach `orchestrator.processEvent()`. The `ObservationProcessor` continues to handle these events for telemetry/pattern detection.
- **Frontend fix**: Added an early return in `BlockSurfaceRenderer`'s `send` bridge to skip forwarding `scroll-view` interactions to `onInteraction`, preventing unnecessary upstream processing.

Fixes #152

## Test plan
- [ ] Load the home page with connected services — surfaces should render via `BlockSurfaceRenderer`
- [ ] Scroll through the inbox results — no page reload or surface reset should occur
- [ ] Verify the old `SurfaceRenderer` (with "Surfaces" toggle button) does not appear
- [ ] Confirm `ObservationProcessor` still receives and processes scroll-view telemetry (check backend logs for observation batch processing)
- [ ] Manual page refresh should continue to load `BlockSurfaceRenderer` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)