### PR TITLE
fix: BlockRenderer CSS polish for professional card styling

### DIFF
--- a/apps/frontend/src/blocks/components/primitives/List.tsx
+++ b/apps/frontend/src/blocks/components/primitives/List.tsx
@@ -1,11 +1,14 @@
 import type { BlockProps } from "../../registry";
 
 export function List({ block, children }: BlockProps) {
-  const { gap = "4px" } = block.props as { gap?: string };
+  const { gap = "4px", className = "" } = block.props as {
+    gap?: string;
+    className?: string;
+  };
 
   return (
     <div
-      className="block-list"
+      className={`block-list ${className}`.trim()}
       style={{
         display: "flex",
         flexDirection: "column",

--- a/apps/frontend/src/blocks/components/primitives/ListItem.tsx
+++ b/apps/frontend/src/blocks/components/primitives/ListItem.tsx
@@ -1,11 +1,14 @@
 import type { BlockProps } from "../../registry";
 
 export function ListItem({ block, children }: BlockProps) {
-  const { swipeable = false } = block.props as { swipeable?: boolean };
+  const { swipeable = false, className = "" } = block.props as {
+    swipeable?: boolean;
+    className?: string;
+  };
 
   return (
     <div
-      className="block-list-item"
+      className={`block-list-item ${className}`.trim()}
       data-swipeable={swipeable || undefined}
       style={{
         padding: "8px 12px",

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -97,6 +97,16 @@
   --shadow-glow-success: 0 0 20px rgba(34, 197, 94, 0.12);
   --shadow-glow-danger: 0 0 20px rgba(239, 68, 68, 0.12);
 
+  /* Block card theming */
+  --block-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.24);
+  --block-card-border: 1px solid rgba(255, 255, 255, 0.08);
+  --block-card-radius: var(--radius-lg);
+  --block-item-border-left: 3px solid var(--color-accent);
+  --block-item-divider: 1px solid rgba(255, 255, 255, 0.06);
+  --block-item-padding: 10px 14px;
+  --block-item-gap: 0px;
+  --block-snippet-lines: 1;
+
   /* Transitions */
   --transition-fast: 150ms ease;
   --transition-base: 200ms ease;
@@ -2069,6 +2079,10 @@ body {
 .surface-wrapper {
   display: flex;
   flex-direction: column;
+  border-radius: var(--block-card-radius);
+  border: var(--block-card-border);
+  box-shadow: var(--block-card-shadow);
+  overflow: hidden;
 }
 
 /* ================================ */
@@ -3024,6 +3038,23 @@ body {
 /* Inbox Block Styling           */
 /* ----------------------------- */
 
+/* Inbox list: remove gap between items, use dividers instead */
+.inbox-block-list {
+  gap: var(--block-item-gap) !important;
+}
+
+/* Email list items: left accent border + bottom divider */
+.inbox-block-list > .block-list-item {
+  border-left: var(--block-item-border-left);
+  border-radius: 0;
+  padding: var(--block-item-padding);
+  border-bottom: var(--block-item-divider);
+}
+
+.inbox-block-list > .block-list-item:last-child {
+  border-bottom: none;
+}
+
 /* Unread item highlight */
 .inbox-block-item--unread {
   background-color: var(--color-accent-muted);
@@ -3061,6 +3092,7 @@ body {
   align-items: center;
   align-self: flex-start;
   margin-top: 2px;
+  margin-left: auto;
 }
 
 .inbox-block-urgency--high {
@@ -3075,16 +3107,24 @@ body {
   background-color: var(--color-neutral);
 }
 
-/* Truncate long snippets */
+/* Truncate long snippets to single line */
 .inbox-block-list .block-list-item .block-stack .block-text:last-child {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  display: block;
 }
 
-/* Ensure sender/date row spans full width */
+/* Ensure sender/date row spans full width and right-aligns date */
 .inbox-block-list .block-list-item .block-stack > .block-row {
   width: 100%;
+  justify-content: space-between;
+}
+
+/* Date text: always push to the right */
+.inbox-block-list .block-list-item .block-stack > .block-row > .block-text:last-child {
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 /* ----------------------------- */


### PR DESCRIPTION
## Summary
- Add `--block-*` CSS custom properties for card shadow, border, accent border, dividers, item padding, and gap — all themeable without touching CSS
- Apply left accent border (blue) and subtle bottom dividers between inbox email items
- Ensure date + urgency badge are consistently right-aligned via `justify-content: space-between` and `margin-left: auto`
- Force single-line snippet truncation with `text-overflow: ellipsis`
- Add subtle card shadow and border to `.surface-wrapper` for a polished, lifted appearance
- Pass `className` prop through `List` and `ListItem` primitives so transformer classNames (e.g. `inbox-block-list`) actually reach the DOM

Closes #156

## Test plan
- [ ] Verify inbox surface cards show left accent border on each email item
- [ ] Verify subtle bottom dividers separate email items (none on last item)
- [ ] Verify date and urgency badge are right-aligned on the sender row
- [ ] Verify long snippets truncate to one line with ellipsis
- [ ] Verify surface-wrapper has subtle shadow/border giving a card feel
- [ ] Verify `--block-*` custom properties can be overridden in dev tools for theming
- [ ] Run `npx tsc --noEmit` — clean compile confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)