### PR TITLE
fix: move block primitive inline styles to CSS classes

### DIFF
--- a/apps/frontend/src/blocks/components/primitives/Container.tsx
+++ b/apps/frontend/src/blocks/components/primitives/Container.tsx
@@ -2,9 +2,9 @@ import type { BlockProps } from "../../registry";
 
 export function Container({ block, children }: BlockProps) {
   const {
-    direction = "column",
-    gap = "0",
-    padding = "0",
+    direction,
+    gap,
+    padding,
     className = "",
   } = block.props as {
     direction?: "row" | "column";
@@ -13,15 +13,15 @@ export function Container({ block, children }: BlockProps) {
     className?: string;
   };
 
+  const style: React.CSSProperties = {};
+  if (direction === "row") style.flexDirection = "row";
+  if (gap) style.gap = gap;
+  if (padding) style.padding = padding;
+
   return (
     <div
       className={`block-container ${className}`.trim()}
-      style={{
-        display: "flex",
-        flexDirection: direction,
-        gap,
-        padding,
-      }}
+      style={Object.keys(style).length > 0 ? style : undefined}
     >
       {children}
     </div>

--- a/apps/frontend/src/blocks/components/primitives/List.tsx
+++ b/apps/frontend/src/blocks/components/primitives/List.tsx
@@ -1,7 +1,7 @@
 import type { BlockProps } from "../../registry";
 
 export function List({ block, children }: BlockProps) {
-  const { gap = "4px", className = "" } = block.props as {
+  const { gap, className = "" } = block.props as {
     gap?: string;
     className?: string;
   };
@@ -9,11 +9,7 @@ export function List({ block, children }: BlockProps) {
   return (
     <div
       className={`block-list ${className}`.trim()}
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap,
-      }}
+      style={gap ? { gap } : undefined}
     >
       {children}
     </div>

--- a/apps/frontend/src/blocks/components/primitives/ListItem.tsx
+++ b/apps/frontend/src/blocks/components/primitives/ListItem.tsx
@@ -10,18 +10,6 @@ export function ListItem({ block, children }: BlockProps) {
     <div
       className={`block-list-item ${className}`.trim()}
       data-swipeable={swipeable || undefined}
-      style={{
-        padding: "8px 12px",
-        cursor: "pointer",
-        borderRadius: "var(--radius-sm, 4px)",
-        transition: "background-color 0.15s ease",
-      }}
-      onMouseEnter={(e) => {
-        e.currentTarget.style.backgroundColor = "var(--color-surface-hover)";
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.backgroundColor = "transparent";
-      }}
     >
       {children}
     </div>

--- a/apps/frontend/src/blocks/components/primitives/Row.tsx
+++ b/apps/frontend/src/blocks/components/primitives/Row.tsx
@@ -1,23 +1,23 @@
 import type { BlockProps } from "../../registry";
 
 export function Row({ block, children }: BlockProps) {
-  const { align = "center", justify = "flex-start", gap = "0" } =
-    block.props as {
-      align?: string;
-      justify?: string;
-      gap?: string;
-    };
+  const { align, justify, gap, className = "" } = block.props as {
+    align?: string;
+    justify?: string;
+    gap?: string;
+    className?: string;
+  };
+
+  // Only set inline styles for non-default prop values
+  const style: React.CSSProperties = {};
+  if (align) style.alignItems = align;
+  if (justify) style.justifyContent = justify;
+  if (gap) style.gap = gap;
 
   return (
     <div
-      className="block-row"
-      style={{
-        display: "flex",
-        flexDirection: "row",
-        alignItems: align,
-        justifyContent: justify,
-        gap,
-      }}
+      className={`block-row ${className}`.trim()}
+      style={Object.keys(style).length > 0 ? style : undefined}
     >
       {children}
     </div>

--- a/apps/frontend/src/blocks/components/primitives/Stack.tsx
+++ b/apps/frontend/src/blocks/components/primitives/Stack.tsx
@@ -1,20 +1,20 @@
 import type { BlockProps } from "../../registry";
 
 export function Stack({ block, children }: BlockProps) {
-  const { align = "stretch", gap = "0" } = block.props as {
+  const { align, gap, className = "" } = block.props as {
     align?: string;
     gap?: string;
+    className?: string;
   };
+
+  const style: React.CSSProperties = {};
+  if (align) style.alignItems = align;
+  if (gap) style.gap = gap;
 
   return (
     <div
-      className="block-stack"
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: align,
-        gap,
-      }}
+      className={`block-stack ${className}`.trim()}
+      style={Object.keys(style).length > 0 ? style : undefined}
     >
       {children}
     </div>

--- a/apps/frontend/src/blocks/components/primitives/Text.tsx
+++ b/apps/frontend/src/blocks/components/primitives/Text.tsx
@@ -1,35 +1,37 @@
 import type { BlockProps } from "../../registry";
 
-const variantConfig: Record<string, { tag: string; fontSize: string; fontWeight: string }> = {
-  h1: { tag: "h1", fontSize: "var(--text-4xl)", fontWeight: "var(--weight-bold)" },
-  h2: { tag: "h2", fontSize: "var(--text-3xl)", fontWeight: "var(--weight-semibold)" },
-  h3: { tag: "h3", fontSize: "var(--text-2xl)", fontWeight: "var(--weight-semibold)" },
-  body: { tag: "p", fontSize: "var(--text-base)", fontWeight: "var(--weight-normal)" },
-  caption: { tag: "span", fontSize: "var(--text-sm)", fontWeight: "var(--weight-normal)" },
-  label: { tag: "span", fontSize: "var(--text-sm)", fontWeight: "var(--weight-medium)" },
+const variantConfig: Record<string, { tag: string; className: string }> = {
+  h1: { tag: "h1", className: "block-text--h1" },
+  h2: { tag: "h2", className: "block-text--h2" },
+  h3: { tag: "h3", className: "block-text--h3" },
+  body: { tag: "p", className: "block-text--body" },
+  caption: { tag: "span", className: "block-text--caption" },
+  label: { tag: "span", className: "block-text--label" },
+  bold: { tag: "span", className: "block-text--bold" },
+  heading: { tag: "h3", className: "block-text--heading" },
 };
 
 export function Text({ block }: BlockProps) {
-  const { content = "", variant = "body", color, weight } = block.props as {
+  const { content = "", variant = "body", color, weight, className = "" } = block.props as {
     content: string;
-    variant?: "h1" | "h2" | "h3" | "body" | "caption" | "label";
+    variant?: string;
     color?: string;
     weight?: string;
+    className?: string;
   };
 
   const config = variantConfig[variant] ?? variantConfig.body;
   const Tag = config.tag as keyof JSX.IntrinsicElements;
 
+  // Only use inline styles for dynamic overrides from props
+  const style: React.CSSProperties = {};
+  if (color) style.color = color;
+  if (weight) style.fontWeight = weight;
+
   return (
     <Tag
-      className="block-text"
-      style={{
-        margin: 0,
-        fontSize: config.fontSize,
-        fontWeight: weight ?? config.fontWeight,
-        color: color ?? "var(--color-text)",
-        lineHeight: "var(--leading-normal)",
-      }}
+      className={`block-text ${config.className} ${className}`.trim()}
+      style={Object.keys(style).length > 0 ? style : undefined}
     >
       {content}
     </Tag>

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -2881,6 +2881,8 @@ body {
 /* Container                     */
 /* ----------------------------- */
 .block-container {
+  display: flex;
+  flex-direction: column;
   border-radius: var(--radius-md);
   font-family: var(--font-sans);
   line-height: var(--leading-normal);
@@ -2890,6 +2892,9 @@ body {
 /* Row                           */
 /* ----------------------------- */
 .block-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   font-family: var(--font-sans);
   line-height: var(--leading-normal);
   flex-wrap: wrap;
@@ -2899,6 +2904,9 @@ body {
 /* Stack                         */
 /* ----------------------------- */
 .block-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   font-family: var(--font-sans);
   line-height: var(--leading-normal);
 }
@@ -2930,9 +2938,48 @@ body {
 /* Text                          */
 /* ----------------------------- */
 .block-text {
+  margin: 0;
   font-family: var(--font-sans);
+  color: var(--color-text);
+  line-height: var(--leading-normal);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+.block-text--h1 {
+  font-size: var(--text-4xl);
+  font-weight: var(--weight-bold);
+}
+
+.block-text--h2 {
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-semibold);
+}
+
+.block-text--h3,
+.block-text--heading {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-semibold);
+}
+
+.block-text--body {
+  font-size: var(--text-base);
+  font-weight: var(--weight-normal);
+}
+
+.block-text--caption {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-normal);
+}
+
+.block-text--label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+}
+
+.block-text--bold {
+  font-size: var(--text-base);
+  font-weight: var(--weight-bold);
 }
 
 /* ----------------------------- */
@@ -3011,6 +3058,9 @@ body {
 /* List                          */
 /* ----------------------------- */
 .block-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 4px);
   font-family: var(--font-sans);
 }
 
@@ -3018,6 +3068,9 @@ body {
 /* ListItem                      */
 /* ----------------------------- */
 .block-list-item {
+  padding: var(--block-item-padding, 8px 12px);
+  cursor: pointer;
+  border-radius: var(--radius-sm, 4px);
   font-family: var(--font-sans);
   border: 1px solid transparent;
   transition:


### PR DESCRIPTION
## Summary
- Block primitives used inline styles for all layout properties, making CSS class overrides impossible
- Moved base styles to CSS classes so `.inbox-block-*` and future overrides actually work
- Primitives only use inline styles for dynamic prop overrides now

## Changes
- **ListItem.tsx** — Removed inline padding, borderRadius, cursor, hover handlers → CSS
- **List.tsx** — Removed inline display/flexDirection/gap → CSS (gap still overridable via prop)
- **Row.tsx** — Removed inline display/flexDirection/alignItems → CSS
- **Stack.tsx** — Removed inline display/flexDirection/alignItems → CSS
- **Text.tsx** — Moved variant font-size/weight to CSS classes (`.block-text--h1`, etc.), only color/weight overrides use inline
- **Container.tsx** — Removed inline display/flexDirection → CSS
- **global.css** — Added base layout styles for all block primitives, text variant classes

## Why this matters
The previous PR (#157) added card shadows, left borders, dividers via CSS classes — but none of them were visible because inline styles always beat class selectors. This fix makes CSS theming actually work.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)