### PR TITLE
fix: correct Row alignment in inbox transformer

### DIFF
--- a/apps/frontend/src/blocks/transformers/inbox.ts
+++ b/apps/frontend/src/blocks/transformers/inbox.ts
@@ -205,7 +205,7 @@ export function inboxToBlocks(spec: SurfaceSpec): ComponentBlock[] {
         {
           id: `${sid}-email-row-${i}`,
           type: "Row",
-          props: { gap: "12px", align: "flex-start" },
+          props: { gap: "12px", align: "center" },
           children: rowChildren,
         },
       ];


### PR DESCRIPTION
## Summary
- Changes the outer email Row's `align` prop from `"flex-start"` to `"center"` in the inbox transformer, fixing vertical misalignment of the dot indicator, content, and urgency badge within each email row.

Closes #164

## Test plan
- [ ] Verify inbox emails render with vertically centered dot, content, and urgency badge
- [ ] Confirm no visual regressions in inbox surface across different email lengths
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)