### PR TITLE
feat: add Gmail domain components

### DIFF
--- a/apps/frontend/src/blocks/WaibRenderer.tsx
+++ b/apps/frontend/src/blocks/WaibRenderer.tsx
@@ -21,7 +21,7 @@ import { ObservationCollectorProvider } from "./ObservationCollector";
 import { BlockStateProvider, BlockStateContext } from "./BlockStateStore";
 import { ObservationWrapper } from "./ObservationWrapper";
 import { getBlockComponent } from "./registry";
-import { registerPrimitiveBlocks, FallbackBlock } from "./components";
+import { registerPrimitiveBlocks, registerDomainComponents, FallbackBlock } from "./components";
 
 // ---------------------------------------------------------------------------
 // WaibRenderer — top-level entry point
@@ -35,6 +35,7 @@ export interface WaibRendererProps {
 export function WaibRenderer({ blocks, send }: WaibRendererProps) {
   useEffect(() => {
     registerPrimitiveBlocks();
+    registerDomainComponents();
   }, []);
 
   return (

--- a/apps/frontend/src/blocks/components/domain/gmail/GmailEmailCard.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailEmailCard.tsx
@@ -1,0 +1,94 @@
+import type { BlockProps } from "../../../registry";
+
+interface GmailEmailCardProps {
+  emailId: string;
+  from: string;
+  subject: string;
+  snippet: string;
+  date: string;
+  isUnread: boolean;
+  labels?: string[];
+  urgency?: "high" | "medium" | "low";
+  suggestedReply?: string;
+}
+
+/**
+ * Derive a hue from a string using a simple hash so the same sender
+ * always gets the same avatar colour.
+ */
+function senderHue(name: string): number {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return Math.abs(hash) % 360;
+}
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  }
+  return name.slice(0, 2).toUpperCase();
+}
+
+export function GmailEmailCard({ block }: BlockProps) {
+  const {
+    from,
+    subject,
+    snippet,
+    date,
+    isUnread,
+    labels = [],
+    urgency,
+  } = block.props as GmailEmailCardProps;
+
+  const initials = getInitials(from);
+  const hue = senderHue(from);
+  const avatarBg = `hsl(${hue}, 55%, 45%)`;
+
+  const hasImportant = labels.includes("IMPORTANT");
+  const hasStarred = labels.includes("STARRED");
+
+  const cardClass = [
+    "gmail-email-card",
+    isUnread ? "gmail-email-card--unread" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={cardClass}>
+      <div
+        className="gmail-email-card__avatar"
+        style={{ backgroundColor: avatarBg }}
+      >
+        {initials}
+      </div>
+
+      <div className="gmail-email-card__content">
+        <div className="gmail-email-card__subject">{subject}</div>
+        <div className="gmail-email-card__meta">
+          <span className="gmail-email-card__from">{from}</span>
+          <span className="gmail-email-card__date">{date}</span>
+        </div>
+        <div className="gmail-email-card__snippet">{snippet}</div>
+      </div>
+
+      <div className="gmail-email-card__actions">
+        {urgency && (
+          <span
+            className={`gmail-email-card__urgency gmail-email-card__urgency--${urgency}`}
+          >
+            {urgency}
+          </span>
+        )}
+        {(hasImportant || hasStarred) && (
+          <span className="gmail-email-card__star">
+            {hasStarred ? "\u2605" : "\u2606"}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/blocks/components/domain/gmail/GmailInboxList.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailInboxList.tsx
@@ -1,0 +1,33 @@
+import type { BlockProps } from "../../../registry";
+
+interface GmailInboxListProps {
+  unreadCount: number;
+  totalCount: number;
+  isScanned: boolean;
+}
+
+export function GmailInboxList({ block, children, onEvent }: BlockProps) {
+  const { unreadCount, isScanned } = block.props as GmailInboxListProps;
+
+  return (
+    <div className="gmail-inbox-list">
+      <div className="gmail-inbox-list__header">
+        <div className="gmail-inbox-list__title-row">
+          <h3 className="gmail-inbox-list__title">Inbox</h3>
+          {unreadCount > 0 && (
+            <span className="gmail-inbox-list__badge">{unreadCount}</span>
+          )}
+        </div>
+        {!isScanned && (
+          <button
+            className="gmail-inbox-list__scan-btn"
+            onClick={() => onEvent?.("waib-scan", { scope: "all" })}
+          >
+            WaibScan
+          </button>
+        )}
+      </div>
+      <div className="gmail-inbox-list__cards">{children}</div>
+    </div>
+  );
+}

--- a/apps/frontend/src/blocks/components/domain/gmail/GmailScanResult.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailScanResult.tsx
@@ -1,0 +1,35 @@
+import type { BlockProps } from "../../../registry";
+
+interface GmailScanResultProps {
+  summary: string;
+  highUrgencyCount: number;
+  recommendations: string[];
+}
+
+export function GmailScanResult({ block }: BlockProps) {
+  const { summary, highUrgencyCount, recommendations } =
+    block.props as GmailScanResultProps;
+
+  return (
+    <div className="gmail-scan-result">
+      <p className="gmail-scan-result__summary">{summary}</p>
+      {highUrgencyCount > 0 && (
+        <div className="gmail-scan-result__urgency">
+          <span className="gmail-scan-result__urgency-count">
+            {highUrgencyCount}
+          </span>{" "}
+          high-urgency email{highUrgencyCount !== 1 ? "s" : ""}
+        </div>
+      )}
+      {recommendations.length > 0 && (
+        <ul className="gmail-scan-result__recommendations">
+          {recommendations.map((rec, i) => (
+            <li key={i} className="gmail-scan-result__recommendation">
+              {rec}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/blocks/components/domain/gmail/index.ts
+++ b/apps/frontend/src/blocks/components/domain/gmail/index.ts
@@ -1,0 +1,43 @@
+import { registerBlocks } from "../../../registry";
+import { GmailEmailCard } from "./GmailEmailCard";
+import { GmailInboxList } from "./GmailInboxList";
+import { GmailScanResult } from "./GmailScanResult";
+
+/**
+ * Register all Gmail domain block components.
+ * Call once at application startup alongside primitive block registration.
+ */
+export function registerGmailComponents(): void {
+  registerBlocks([
+    {
+      type: "GmailEmailCard",
+      component: GmailEmailCard,
+      registration: {
+        type: "GmailEmailCard",
+        category: "domain",
+        source: "gmail.waib",
+        description: "Individual email card with sender avatar, subject, snippet, and urgency",
+      },
+    },
+    {
+      type: "GmailInboxList",
+      component: GmailInboxList,
+      registration: {
+        type: "GmailInboxList",
+        category: "domain",
+        source: "gmail.waib",
+        description: "Inbox list wrapper with header, unread badge, and WaibScan trigger",
+      },
+    },
+    {
+      type: "GmailScanResult",
+      component: GmailScanResult,
+      registration: {
+        type: "GmailScanResult",
+        category: "domain",
+        source: "gmail.waib",
+        description: "Summary card displayed after WaibScan analysis",
+      },
+    },
+  ]);
+}

--- a/apps/frontend/src/blocks/components/domain/index.ts
+++ b/apps/frontend/src/blocks/components/domain/index.ts
@@ -1,0 +1,9 @@
+import { registerGmailComponents } from "./gmail";
+
+/**
+ * Register all domain-specific block components.
+ * Call once at application startup alongside primitive block registration.
+ */
+export function registerDomainComponents(): void {
+  registerGmailComponents();
+}

--- a/apps/frontend/src/blocks/components/index.ts
+++ b/apps/frontend/src/blocks/components/index.ts
@@ -15,6 +15,7 @@ import { TextInput } from "./primitives/TextInput";
 import { Divider } from "./primitives/Divider";
 
 export { FallbackBlock } from "./FallbackBlock";
+export { registerDomainComponents } from "./domain";
 
 /**
  * Register all 13 built-in primitive block components.

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/global.css";
+import "./styles/gmail-components.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/apps/frontend/src/styles/gmail-components.css
+++ b/apps/frontend/src/styles/gmail-components.css
@@ -1,0 +1,243 @@
+/* ======================================== */
+/* Gmail Domain Components                  */
+/* ======================================== */
+
+/* ---- GmailEmailCard ---- */
+
+.gmail-email-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--block-item-padding);
+  border: 1px solid var(--color-border);
+  border-radius: var(--block-card-radius);
+  background: var(--color-surface);
+  transition: background var(--transition-fast);
+  cursor: pointer;
+}
+
+.gmail-email-card:hover {
+  background: var(--color-surface-hover);
+}
+
+.gmail-email-card--unread {
+  border-left: 3px solid var(--color-accent);
+  box-shadow: var(--shadow-sm);
+}
+
+.gmail-email-card__avatar {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  font-family: var(--font-sans);
+  line-height: 1;
+  user-select: none;
+}
+
+.gmail-email-card__content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.gmail-email-card__subject {
+  font-size: var(--text-base);
+  font-weight: var(--weight-normal);
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gmail-email-card--unread .gmail-email-card__subject {
+  font-weight: var(--weight-bold);
+}
+
+.gmail-email-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.gmail-email-card__from {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gmail-email-card__date {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.gmail-email-card__snippet {
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gmail-email-card__actions {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-1);
+}
+
+.gmail-email-card__urgency {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  text-transform: capitalize;
+}
+
+.gmail-email-card__urgency--high {
+  background: var(--color-danger-subtle);
+  color: var(--color-danger-text);
+}
+
+.gmail-email-card__urgency--medium {
+  background: var(--color-warning-subtle);
+  color: var(--color-warning-text);
+}
+
+.gmail-email-card__urgency--low {
+  background: var(--color-success-subtle);
+  color: var(--color-success-text);
+}
+
+.gmail-email-card__star {
+  font-size: var(--text-md);
+  color: var(--color-warning-text);
+  line-height: 1;
+}
+
+/* ---- GmailInboxList ---- */
+
+.gmail-inbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.gmail-inbox-list__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 var(--space-1);
+}
+
+.gmail-inbox-list__title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.gmail-inbox-list__title {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.gmail-inbox-list__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  color: #fff;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  line-height: 1;
+}
+
+.gmail-inbox-list__scan-btn {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-md);
+  background: var(--color-accent-subtle);
+  color: var(--color-accent-hover);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.gmail-inbox-list__scan-btn:hover {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.gmail-inbox-list__cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ---- GmailScanResult ---- */
+
+.gmail-scan-result {
+  padding: var(--space-4);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--block-card-radius);
+  background: var(--color-accent-muted);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.gmail-scan-result__summary {
+  font-size: var(--text-md);
+  color: var(--color-text);
+  line-height: var(--leading-normal);
+  margin: 0;
+}
+
+.gmail-scan-result__urgency {
+  font-size: var(--text-sm);
+  color: var(--color-danger-text);
+}
+
+.gmail-scan-result__urgency-count {
+  font-weight: var(--weight-bold);
+  font-size: var(--text-lg);
+}
+
+.gmail-scan-result__recommendations {
+  list-style: disc;
+  padding-left: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+}
+
+.gmail-scan-result__recommendation {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+}


### PR DESCRIPTION
## Summary
- Adds three Gmail domain block components: `GmailEmailCard`, `GmailInboxList`, and `GmailScanResult`
- Registers them via `registerDomainComponents()` called alongside `registerPrimitiveBlocks()` in WaibRenderer
- Includes dedicated `gmail-components.css` using existing design tokens and BEM naming

## Details

**GmailEmailCard** — Email card with sender-initial avatar (hue derived from name hash), subject/from/snippet layout, urgency pill (high/medium/low), and star indicator for IMPORTANT/STARRED labels. Unread state shows accent left border and bold subject.

**GmailInboxList** — Wrapper with "Inbox" header, unread count badge, WaibScan button that fires `onEvent("waib-scan", { scope: "all" })`, and 8px card gap.

**GmailScanResult** — Summary card with accent border showing scan summary, high-urgency count, and recommendation bullet list.

**Registration** — New `domain/` directory structure under `blocks/components/` with `registerGmailComponents()` → `registerDomainComponents()` pattern for future domain expansions (e.g. calendar).

Closes #167
Closes #171

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Render a `GmailInboxList` block with child `GmailEmailCard` blocks and confirm layout
- [ ] Confirm unread vs read visual distinction
- [ ] Confirm urgency pills display correct colors (high=red, medium=yellow, low=green)
- [ ] Click WaibScan button and verify event emission
- [ ] Render `GmailScanResult` and verify recommendations list

🤖 Generated with [Claude Code](https://claude.com/claude-code)