### PR TITLE
feat: wire calendar transformer to Calendar domain components

### DIFF
--- a/apps/frontend/src/blocks/transformers/calendar.ts
+++ b/apps/frontend/src/blocks/transformers/calendar.ts
@@ -1,118 +1,172 @@
-import type { ComponentBlock, SurfaceSpec } from "@waibspace/types";
+import type {
+  ComponentBlock,
+  SurfaceSpec,
+  SurfaceAction,
+  EmitAction,
+} from "@waibspace/types";
 import type { CalendarSurfaceData } from "@waibspace/surfaces";
+
+/**
+ * Deterministic color from a string hash — produces an HSL hue,
+ * matching the approach used in CalendarEventCard / Gmail avatar logic.
+ */
+function colorFromTitle(title: string): string {
+  let hash = 0;
+  for (let i = 0; i < title.length; i++) {
+    hash = title.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue = ((hash % 360) + 360) % 360;
+  return `hsl(${hue}, 65%, 55%)`;
+}
+
+/**
+ * Detect whether an event is "all-day" by checking if its start/end are
+ * date-only strings (no "T") or span exactly 24 hours.
+ */
+function isAllDayEvent(start: string, end: string): boolean {
+  // Date-only strings like "2026-03-09" have no "T"
+  if (!start.includes("T") || !end.includes("T")) return true;
+
+  const diffMs = new Date(end).getTime() - new Date(start).getTime();
+  const twentyFourHours = 24 * 60 * 60 * 1000;
+  return diffMs >= twentyFourHours;
+}
+
+/**
+ * Check whether an ISO date string falls on today's date.
+ */
+function isToday(iso: string): boolean {
+  const d = new Date(iso);
+  const now = new Date();
+  return (
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  );
+}
+
+function actionToButton(
+  action: SurfaceAction,
+  surfaceId: string,
+  index: number,
+): ComponentBlock {
+  return {
+    id: `${surfaceId}-action-${index}`,
+    type: "Button",
+    props: {
+      label: action.label,
+      variant: "secondary",
+    },
+    events: {
+      onClick: {
+        action: "emit",
+        event: "user.interaction",
+        payload: {
+          actionId: action.id,
+          actionType: action.actionType,
+          riskClass: action.riskClass,
+          payload: action.payload,
+        },
+      } satisfies EmitAction,
+    },
+  };
+}
 
 export function calendarToBlocks(spec: SurfaceSpec): ComponentBlock[] {
   const data = spec.data as CalendarSurfaceData;
   const sid = spec.surfaceId;
+  const events = data.events ?? [];
+  const freeSlots = data.freeSlots ?? [];
 
   const children: ComponentBlock[] = [];
 
-  // Header
+  // ── 1. CalendarSummary ──────────────────────────────────────────────
+  const conflictCount = events.filter((e) => e.conflictWith).length;
+  const now = new Date();
+
+  // Find the next upcoming event (starts in the future)
+  const upcomingEvents = events
+    .filter((e) => new Date(e.start).getTime() > now.getTime())
+    .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+
+  const nextEvent = upcomingEvents[0];
+  const nextEventProp = nextEvent
+    ? {
+        title: nextEvent.title,
+        start: nextEvent.start,
+        minutesUntil: Math.round(
+          (new Date(nextEvent.start).getTime() - now.getTime()) / (1000 * 60),
+        ),
+      }
+    : undefined;
+
+  // Use dateRange.start as the summary date
+  const summaryDate = data.dateRange?.start ?? new Date().toISOString();
+
   children.push({
-    id: `${sid}-header`,
-    type: "Text",
-    props: { content: spec.title, variant: "h3", color: "var(--color-text)" },
+    id: `${sid}-summary`,
+    type: "CalendarSummary",
+    props: {
+      date: summaryDate,
+      eventCount: events.length,
+      nextEvent: nextEventProp,
+      freeSlotCount: freeSlots.length,
+      conflicts: conflictCount,
+    },
   });
 
-  // Events list
-  if (data.events && data.events.length > 0) {
-    const eventItems: ComponentBlock[] = data.events.map((event, i) => {
-      const rowChildren: ComponentBlock[] = [
-        {
-          id: `${sid}-event-time-${i}`,
-          type: "Text",
-          props: {
-            content: `${event.start} – ${event.end}`,
-            variant: "body",
-          },
-        },
-        {
-          id: `${sid}-event-stack-${i}`,
-          type: "Stack",
-          props: { gap: "2px" },
-          children: [
-            {
-              id: `${sid}-event-title-${i}`,
-              type: "Text",
-              props: { content: event.title, variant: "body" },
-            },
-            ...(event.location
-              ? [
-                  {
-                    id: `${sid}-event-location-${i}`,
-                    type: "Text",
-                    props: {
-                      content: event.location,
-                      variant: "caption",
-                    },
-                  } satisfies ComponentBlock,
-                ]
-              : []),
-          ],
-        },
-      ];
+  // ── 2. CalendarDayTimeline (today's events) ─────────────────────────
+  const todayEvents = events.filter((e) => isToday(e.start));
+  const todayFreeSlots = freeSlots.filter((s) => isToday(s.start));
 
-      // Conflict badge
-      if (event.conflictWith) {
-        rowChildren.push({
-          id: `${sid}-event-conflict-${i}`,
-          type: "Badge",
-          props: { label: "Conflict", color: "red" },
-        });
-      }
+  const timelineEvents = todayEvents.map((e) => ({
+    eventId: e.id,
+    title: e.title,
+    start: e.start,
+    end: e.end,
+    color: colorFromTitle(e.title),
+  }));
 
-      return {
-        id: `${sid}-event-item-${i}`,
-        type: "ListItem",
-        props: {},
-        children: [
-          {
-            id: `${sid}-event-row-${i}`,
-            type: "Row",
-            props: { gap: "12px", align: "center" },
-            children: rowChildren,
-          },
-        ],
-      } satisfies ComponentBlock;
-    });
+  children.push({
+    id: `${sid}-timeline`,
+    type: "CalendarDayTimeline",
+    props: {
+      date: summaryDate,
+      events: timelineEvents,
+      freeSlots: todayFreeSlots.map((s) => ({ start: s.start, end: s.end })),
+      dayStart: "08:00",
+      dayEnd: "20:00",
+    },
+  });
 
+  // ── 3. CalendarEventCard × N (upcoming events beyond today) ─────────
+  const futureEvents = events.filter((e) => !isToday(e.start));
+  for (let i = 0; i < futureEvents.length; i++) {
+    const evt = futureEvents[i];
     children.push({
-      id: `${sid}-event-list`,
-      type: "List",
-      props: {},
-      children: eventItems,
+      id: `${sid}-event-${i}`,
+      type: "CalendarEventCard",
+      props: {
+        eventId: evt.id,
+        title: evt.title,
+        start: evt.start,
+        end: evt.end,
+        location: evt.location,
+        attendees: evt.attendees,
+        status: "confirmed",
+        conflictWith: evt.conflictWith,
+        isAllDay: isAllDayEvent(evt.start, evt.end),
+      },
     });
   }
 
-  // Free slots
-  if (data.freeSlots && data.freeSlots.length > 0) {
+  // ── 4. Actions row ──────────────────────────────────────────────────
+  if (spec.actions.length > 0) {
     children.push({
-      id: `${sid}-freeslots-label`,
-      type: "Text",
-      props: { content: "Available Slots", variant: "h3" },
-    });
-
-    const slotItems: ComponentBlock[] = data.freeSlots.map((slot, i) => ({
-      id: `${sid}-freeslot-item-${i}`,
-      type: "ListItem",
-      props: {},
-      children: [
-        {
-          id: `${sid}-freeslot-time-${i}`,
-          type: "Text",
-          props: {
-            content: `${slot.start} – ${slot.end}`,
-            variant: "body",
-          },
-        },
-      ],
-    }));
-
-    children.push({
-      id: `${sid}-freeslot-list`,
-      type: "List",
-      props: {},
-      children: slotItems,
+      id: `${sid}-actions-row`,
+      type: "Row",
+      props: { gap: "8px" },
+      children: spec.actions.map((action, i) => actionToButton(action, sid, i)),
     });
   }
 
@@ -120,7 +174,7 @@ export function calendarToBlocks(spec: SurfaceSpec): ComponentBlock[] {
     {
       id: `${sid}-root`,
       type: "Container",
-      props: { direction: "column", gap: "12px", padding: "var(--space-5)" },
+      props: { direction: "column", gap: "16px", padding: "var(--space-5)" },
       children,
       meta: {
         surfaceId: spec.surfaceId,


### PR DESCRIPTION
## Summary
- Rewrote `calendarToBlocks()` to emit `CalendarSummary`, `CalendarDayTimeline`, and `CalendarEventCard` domain components instead of generic primitives (Text, List, Badge)
- CalendarSummary computes stats (event count, free slots, conflicts, next event with minutesUntil)
- CalendarDayTimeline filters today's events and maps them with deterministic hash-based colors
- CalendarEventCard renders each future event with all-day detection and conflict metadata
- Preserved root container meta for provenance and the actions row

## Test plan
- [ ] Verify calendar surface renders with CalendarSummary showing correct stats
- [ ] Verify CalendarDayTimeline shows today's events positioned on the timeline
- [ ] Verify CalendarEventCard renders for future events with correct props
- [ ] Verify all-day events are detected (date-only strings or 24h spans)
- [ ] Verify conflict badges appear on events with conflictWith set
- [ ] Verify actions row still renders when spec has actions

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)