### PR TITLE
feat: wire WaibScan action to trigger inbox LLM analysis

### DIFF
--- a/apps/frontend/src/blocks/WaibRenderer.tsx
+++ b/apps/frontend/src/blocks/WaibRenderer.tsx
@@ -113,6 +113,23 @@ function BlockNode({ block, send }: BlockNodeProps) {
     [executeAction],
   );
 
+  /**
+   * onEvent callback for domain components (e.g. GmailInboxList's WaibScan button).
+   * Bridges the BlockProps.onEvent API to the WebSocket event bus so domain
+   * components can emit named events without needing to define emit actions.
+   */
+  const handleEvent = useCallback(
+    (eventName: string, payload?: unknown) => {
+      send("user.interaction", {
+        interaction: eventName,
+        blockId: block.id,
+        blockType: block.type,
+        ...((payload != null && typeof payload === "object") ? payload as Record<string, unknown> : {}),
+      });
+    },
+    [send, block.id, block.type],
+  );
+
   // Resolve registered component or fall back
   const Component = getBlockComponent(block.type) ?? FallbackBlock;
 
@@ -126,7 +143,7 @@ function BlockNode({ block, send }: BlockNodeProps) {
 
   return (
     <ObservationWrapper block={block} onExecuteAction={handleExecuteAction}>
-      <Component block={block}>{childNodes}</Component>
+      <Component block={block} onEvent={handleEvent}>{childNodes}</Component>
     </ObservationWrapper>
   );
 }

--- a/packages/agents/src/ui/inbox-surface.ts
+++ b/packages/agents/src/ui/inbox-surface.ts
@@ -76,9 +76,12 @@ export class InboxSurfaceAgent extends BaseAgent {
 
   async execute(
     input: AgentInput,
-    _context: AgentContext,
+    context: AgentContext,
   ): Promise<AgentOutput> {
     const startMs = Date.now();
+
+    // Detect WaibScan action — triggered when user clicks the WaibScan button
+    const isWaibScan = this.isWaibScanAction(input);
 
     const retrievalOutput = this.findDataRetrieval(input);
     if (!retrievalOutput) {
@@ -108,9 +111,22 @@ export class InboxSurfaceAgent extends BaseAgent {
       rawEmailCount: Array.isArray(gmailData) ? gmailData.length : "non-array",
       truncatedEmailCount: rawEmails.length,
       totalUnreadFromMCP: gmailTotalUnread,
+      isWaibScan,
     });
 
-    // Map raw email fields directly — no LLM involved
+    // If WaibScan was triggered, run LLM analysis for urgency classification
+    if (isWaibScan) {
+      return this.executeWithLLMAnalysis(
+        gmailData,
+        rawEmails,
+        gmailTotalUnread,
+        input,
+        context,
+        startMs,
+      );
+    }
+
+    // Default path: map raw email fields directly — no LLM involved
     const emails: InboxSurfaceData["emails"] = rawEmails.map((email, i) => ({
       id: String(email.id ?? email.messageId ?? `email-${i}`),
       from: String(email.from ?? email.sender ?? "Unknown"),
@@ -157,6 +173,93 @@ export class InboxSurfaceAgent extends BaseAgent {
       ...this.createOutput(
         { surfaceSpec, summary },
         0.85,
+        provenance,
+      ),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+
+  /**
+   * Check if the current event is a WaibScan action trigger.
+   * This matches when the user clicks the WaibScan button, which emits
+   * an interaction event with actionType "agent.invoke" and actionId "waib-scan".
+   */
+  private isWaibScanAction(input: AgentInput): boolean {
+    const payload = input.event.payload as Record<string, unknown> | undefined;
+    if (!payload) return false;
+
+    // Match the emit action payload from the WaibScan button
+    return (
+      payload.actionId === "waib-scan" ||
+      (payload.actionType === "agent.invoke" &&
+        payload.interaction === "waib-scan")
+    );
+  }
+
+  /**
+   * Execute the LLM analysis path: classify urgency, generate suggested replies,
+   * and produce an enriched inbox surface with a GmailScanResult summary.
+   */
+  private async executeWithLLMAnalysis(
+    gmailData: unknown,
+    rawEmails: Record<string, unknown>[],
+    gmailTotalUnread: number | undefined,
+    input: AgentInput,
+    context: AgentContext,
+    startMs: number,
+  ): Promise<AgentOutput> {
+    this.log("WaibScan triggered — running LLM analysis on inbox");
+
+    const calendarData = this.extractCalendarData(input);
+    const analysis = await this.analyzeWithLLM(gmailData, calendarData, context);
+
+    // Build enriched email list with urgency and suggested replies from LLM
+    const emails: InboxSurfaceData["emails"] = analysis.emails.map((email) => ({
+      id: email.id,
+      from: email.from,
+      subject: email.subject,
+      snippet: email.snippet,
+      date: email.date,
+      isUnread: email.isUnread,
+      urgency: email.urgency,
+      suggestedReply: email.suggestedReply,
+    }));
+
+    const batchUnreadCount = emails.filter((e) => e.isUnread).length;
+    const unreadCount = gmailTotalUnread ?? batchUnreadCount;
+
+    const surfaceData: InboxSurfaceData = {
+      emails,
+      totalCount: emails.length,
+      unreadCount,
+    };
+
+    const endMs = Date.now();
+
+    const summary = analysis.overallSummary;
+
+    const provenance = {
+      sourceType: "agent" as const,
+      sourceId: this.id,
+      trustLevel: "trusted" as const,
+      timestamp: startMs,
+      freshness: "realtime" as const,
+      dataState: "transformed" as const,
+    };
+
+    const surfaceSpec = SurfaceFactory.inbox(surfaceData, provenance);
+
+    // No WaibScan action — already scanned. The inbox transformer will
+    // detect urgency data and render appropriately.
+
+    return {
+      ...this.createOutput(
+        { surfaceSpec, summary },
+        0.9,
         provenance,
       ),
       timing: {

--- a/packages/orchestrator/src/execution-planner.ts
+++ b/packages/orchestrator/src/execution-planner.ts
@@ -103,7 +103,10 @@ export function buildExecutionPlan(
   registry: AgentRegistry,
 ): ExecutionPlan {
   const categories = getPipelineForEvent(eventType);
-  const orderings = AGENT_ORDERINGS[eventType];
+  // Look up exact match first, then fall back to pattern-based orderings
+  // (e.g. user.interaction.* events reuse the user.message.received ordering)
+  const orderings = AGENT_ORDERINGS[eventType]
+    ?? (eventType.startsWith("user.interaction.") ? AGENT_ORDERINGS["user.message.received"] : undefined);
 
   const phases: ExecutionPhase[] = [];
 


### PR DESCRIPTION
## Summary
- **InboxSurfaceAgent**: Detects WaibScan action events (`actionId: "waib-scan"` or `interaction: "waib-scan"`) and branches to LLM analysis path via `analyzeWithLLM()`. The enriched surface includes urgency classification, suggested replies, and omits the WaibScan button (already scanned). Provenance is marked as `dataState: "transformed"`.
- **Execution planner**: `user.interaction.*` events now fall back to the `user.message.received` agent ordering, ensuring context agents run sequentially (planner → connector-selection → data-retrieval) instead of in parallel. This is critical for the WaibScan flow since the inbox agent needs data-retrieval output.
- **WaibRenderer**: Wires `BlockProps.onEvent` to the WebSocket event bus via a new `handleEvent` callback passed to every block component. Domain components like `GmailInboxList` can now emit named events (e.g., `"waib-scan"`) that flow through to the orchestrator.

## How it works
1. User clicks WaibScan button → emits `user.interaction` with `actionId: "waib-scan"` / `actionType: "agent.invoke"`
2. Backend WS handler routes to orchestrator as `user.interaction.user.interaction` event
3. Execution planner uses `user.message.received` ordering → context agents fetch email data sequentially
4. InboxSurfaceAgent detects WaibScan flag → calls `analyzeWithLLM()` → returns enriched surface with urgency badges and suggested replies
5. `surface.composed` event broadcasts updated layout to frontend

## Test plan
- [ ] Verify `npx tsc --noEmit` compiles clean
- [ ] Click WaibScan button on inbox surface → should trigger LLM analysis and re-render with urgency badges
- [ ] Verify raw inbox still renders without urgency on initial load (no regression)
- [ ] Verify the WaibScan button disappears after scanning (already analyzed)
- [ ] Verify `GmailInboxList` domain component's WaibScan button also triggers the flow via `onEvent`

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)