### PR TITLE
fix: handle empty subject/from in inbox email mapping

### DIFF
--- a/apps/frontend/src/blocks/components/domain/gmail/GmailEmailCard.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailEmailCard.tsx
@@ -67,7 +67,7 @@ export function GmailEmailCard({ block }: BlockProps) {
       </div>
 
       <div className="gmail-email-card__content">
-        <div className="gmail-email-card__subject">{subject}</div>
+        <div className="gmail-email-card__subject">{subject || "No Subject"}</div>
         <div className="gmail-email-card__meta">
           <span className="gmail-email-card__from">{from}</span>
           <span className="gmail-email-card__date">{date}</span>

--- a/packages/agents/src/ui/inbox-surface.ts
+++ b/packages/agents/src/ui/inbox-surface.ts
@@ -129,8 +129,8 @@ export class InboxSurfaceAgent extends BaseAgent {
     // Default path: map raw email fields directly — no LLM involved
     const emails: InboxSurfaceData["emails"] = rawEmails.map((email, i) => ({
       id: String(email.id ?? email.messageId ?? `email-${i}`),
-      from: String(email.from ?? email.sender ?? "Unknown"),
-      subject: String(email.subject ?? "No subject"),
+      from: String(email.from || email.sender || "Unknown"),
+      subject: String(email.subject || "No Subject"),
       snippet: String(email.snippet ?? email.text ?? email.body ?? "").slice(0, 200),
       date: String(email.date ?? email.receivedAt ?? ""),
       isUnread: Boolean(email.isUnread ?? email.unread ?? true),
@@ -301,8 +301,8 @@ export class InboxSurfaceAgent extends BaseAgent {
       return {
         emails: rawEmails.map((email, i) => ({
           id: String(email.id ?? email.messageId ?? `email-${i}`),
-          from: String(email.from ?? email.sender ?? "Unknown"),
-          subject: String(email.subject ?? "No subject"),
+          from: String(email.from || email.sender || "Unknown"),
+          subject: String(email.subject || "No Subject"),
           snippet: String(email.snippet ?? email.text ?? email.body ?? "").slice(0, 200),
           date: String(email.date ?? email.receivedAt ?? ""),
           isUnread: Boolean(email.isUnread ?? email.unread ?? true),


### PR DESCRIPTION
## Summary

- Change `??` to `||` for `subject` and `from` fields in inbox-surface.ts so empty strings (returned by Gmail API when headers are missing) trigger the fallback instead of passing through as blank
- Add display fallback in GmailEmailCard (`subject || "No Subject"`)

The Gmail API returns `""` for missing headers. The nullish coalescing operator (`??`) only catches `null`/`undefined`, not empty strings. The logical OR (`||`) catches all falsy values including `""`.

## Test plan

- [ ] Load inbox — emails with subjects should show their actual subject
- [ ] Emails genuinely missing subjects show "No Subject" fallback
- [ ] From field shows sender name or "Unknown" for empty senders

🤖 Generated with [Claude Code](https://claude.com/claude-code)