### PR TITLE
fix: handle WebSocket send failures in broadcast loop

### DIFF
--- a/apps/backend/src/ws.ts
+++ b/apps/backend/src/ws.ts
@@ -22,7 +22,15 @@ export function getClients(): Set<ServerWebSocket<WebSocketData>> {
 export function broadcast(message: ServerMessage): void {
   const raw = JSON.stringify(message);
   for (const ws of clients) {
-    ws.send(raw);
+    try {
+      ws.send(raw);
+    } catch (err) {
+      console.error(
+        `[ws] broadcast send failed for ${ws.data.connectionId}:`,
+        err,
+      );
+      clients.delete(ws);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Wraps each `ws.send()` call in the `broadcast()` function with try-catch so a single client in a bad state cannot break the loop and prevent remaining clients from receiving the message.
- On failure, logs the error with the client's connection ID and removes the client from the active set.

Closes #191

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Confirm broadcast continues to remaining clients when one client's socket is in a bad state

🤖 Generated with [Claude Code](https://claude.com/claude-code)