### PR TITLE
fix: empty inbox returns proper surface instead of null

### DIFF
--- a/packages/agents/src/ui/inbox-surface.ts
+++ b/packages/agents/src/ui/inbox-surface.ts
@@ -93,13 +93,39 @@ export class InboxSurfaceAgent extends BaseAgent {
 
     const { data: gmailData, totalUnread: gmailTotalUnread } = this.extractGmailData(retrievalOutput);
 
-    // If no email data found, return empty
+    // If no email data found, return an empty inbox surface (not null)
     if (!gmailData || (Array.isArray(gmailData) && gmailData.length === 0)) {
-      this.log("No email data found, skipping inbox surface");
-      return this.createOutput(null, 0, {
-        dataState: "raw",
+      this.log("No email data found, returning empty inbox surface");
+
+      const emptySurfaceData: InboxSurfaceData = {
+        emails: [],
+        totalCount: 0,
+        unreadCount: 0,
+      };
+
+      const provenance = {
+        sourceType: "agent" as const,
+        sourceId: this.id,
+        trustLevel: "trusted" as const,
         timestamp: startMs,
-      });
+        freshness: "realtime" as const,
+        dataState: "raw" as const,
+      };
+
+      const surfaceSpec = SurfaceFactory.inbox(emptySurfaceData, provenance);
+
+      return {
+        ...this.createOutput(
+          { surfaceSpec, summary: "Your inbox is empty" },
+          0.85,
+          provenance,
+        ),
+        timing: {
+          startMs,
+          endMs: Date.now(),
+          durationMs: Date.now() - startMs,
+        },
+      };
     }
 
     // Truncate to 20 emails max


### PR DESCRIPTION
## Summary
- When inbox retrieval returns 0 emails, the `InboxSurfaceAgent` was returning `null` output, causing the frontend to render a blank page
- Now returns a proper `InboxSurfaceData` surface with an empty emails array, `totalCount: 0`, and `unreadCount: 0`, so the UI can render an empty-state message
- The `retrievalOutput === null` case (line 87-92) is left unchanged — that indicates connectors were never called, which is a different error condition

Closes #188

## Test plan
- [ ] Trigger inbox surface with a Gmail account that has 0 emails in the query window — verify the UI shows an empty inbox state instead of a blank page
- [ ] Verify normal inbox with emails still renders correctly
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)