### PR TITLE
fix: add loading state to WaibScan button

### DIFF
--- a/apps/frontend/src/blocks/components/domain/gmail/GmailInboxList.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailInboxList.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { BlockProps } from "../../../registry";
 
 interface GmailInboxListProps {
@@ -8,6 +9,12 @@ interface GmailInboxListProps {
 
 export function GmailInboxList({ block, children, onEvent }: BlockProps) {
   const { unreadCount, isScanned } = block.props as GmailInboxListProps;
+  const [isScanning, setIsScanning] = useState(false);
+
+  const handleScan = () => {
+    setIsScanning(true);
+    onEvent?.("waib-scan", { scope: "all" });
+  };
 
   return (
     <div className="gmail-inbox-list">
@@ -20,10 +27,18 @@ export function GmailInboxList({ block, children, onEvent }: BlockProps) {
         </div>
         {!isScanned && (
           <button
-            className="gmail-inbox-list__scan-btn"
-            onClick={() => onEvent?.("waib-scan", { scope: "all" })}
+            className={`gmail-inbox-list__scan-btn${isScanning ? " gmail-inbox-list__scan-btn--loading" : ""}`}
+            onClick={handleScan}
+            disabled={isScanning}
           >
-            WaibScan
+            {isScanning ? (
+              <>
+                <span className="gmail-inbox-list__scan-spinner" />
+                Scanning…
+              </>
+            ) : (
+              "WaibScan"
+            )}
           </button>
         )}
       </div>

--- a/apps/frontend/src/styles/gmail-components.css
+++ b/apps/frontend/src/styles/gmail-components.css
@@ -187,9 +187,34 @@
   transition: background var(--transition-fast), color var(--transition-fast);
 }
 
-.gmail-inbox-list__scan-btn:hover {
+.gmail-inbox-list__scan-btn:hover:not(:disabled) {
   background: var(--color-accent);
   color: #fff;
+}
+
+.gmail-inbox-list__scan-btn--loading {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  opacity: 0.7;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.gmail-inbox-list__scan-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: var(--radius-full);
+  animation: gmail-scan-spin 0.6s linear infinite;
+}
+
+@keyframes gmail-scan-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .gmail-inbox-list__cards {


### PR DESCRIPTION
## Summary
- Adds a local `isScanning` state to `GmailInboxList` so the WaibScan button shows a spinner and becomes disabled while a scan is in progress
- Prevents users from clicking the button multiple times before results arrive
- State naturally resets when the surface re-renders with scan results (component re-mounts with `isScanning=false`)

Closes #190

## Test plan
- [ ] Click WaibScan — button should show spinner and "Scanning..." text, and be disabled
- [ ] Verify button cannot be clicked again while scanning
- [ ] When scan completes and surface re-renders, confirm the button either disappears (if `isScanned` becomes true) or resets to its default state

🤖 Generated with [Claude Code](https://claude.com/claude-code)