### PR TITLE
fix: differentiate Gmail API failures from empty inbox

### DIFF
--- a/apps/frontend/src/blocks/components/domain/gmail/GmailInboxList.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailInboxList.tsx
@@ -5,10 +5,11 @@ interface GmailInboxListProps {
   unreadCount: number;
   totalCount: number;
   isScanned: boolean;
+  error?: string;
 }
 
 export function GmailInboxList({ block, children, onEvent }: BlockProps) {
-  const { unreadCount, isScanned } = block.props as GmailInboxListProps;
+  const { unreadCount, isScanned, error } = block.props as GmailInboxListProps;
   const [isScanning, setIsScanning] = useState(false);
 
   const handleScan = () => {
@@ -21,11 +22,11 @@ export function GmailInboxList({ block, children, onEvent }: BlockProps) {
       <div className="gmail-inbox-list__header">
         <div className="gmail-inbox-list__title-row">
           <h3 className="gmail-inbox-list__title">Inbox</h3>
-          {unreadCount > 0 && (
+          {!error && unreadCount > 0 && (
             <span className="gmail-inbox-list__badge">{unreadCount}</span>
           )}
         </div>
-        {!isScanned && (
+        {!isScanned && !error && (
           <button
             className={`gmail-inbox-list__scan-btn${isScanning ? " gmail-inbox-list__scan-btn--loading" : ""}`}
             onClick={handleScan}
@@ -42,7 +43,13 @@ export function GmailInboxList({ block, children, onEvent }: BlockProps) {
           </button>
         )}
       </div>
-      <div className="gmail-inbox-list__cards">{children}</div>
+      {error ? (
+        <div className="gmail-inbox-list__error">
+          <p className="gmail-inbox-list__error-text">{error}</p>
+        </div>
+      ) : (
+        <div className="gmail-inbox-list__cards">{children}</div>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/blocks/transformers/inbox.ts
+++ b/apps/frontend/src/blocks/transformers/inbox.ts
@@ -57,6 +57,18 @@ export function inboxToBlocks(spec: SurfaceSpec): ComponentBlock[] {
 
   const children: ComponentBlock[] = [];
 
+  // Error banner when data retrieval failed
+  if (data.error) {
+    children.push({
+      id: `${sid}-error`,
+      type: "Text",
+      props: {
+        text: data.error,
+        variant: "error",
+      },
+    });
+  }
+
   // Email cards
   if (data.emails && data.emails.length > 0) {
     for (let i = 0; i < data.emails.length; i++) {
@@ -99,6 +111,7 @@ export function inboxToBlocks(spec: SurfaceSpec): ComponentBlock[] {
         unreadCount: data.unreadCount,
         totalCount: data.totalCount,
         isScanned: false,
+        ...(data.error ? { error: data.error } : {}),
       },
       children,
       meta: {

--- a/apps/frontend/src/styles/gmail-components.css
+++ b/apps/frontend/src/styles/gmail-components.css
@@ -223,6 +223,22 @@
   gap: 8px;
 }
 
+/* ---- GmailInboxList Error State ---- */
+
+.gmail-inbox-list__error {
+  padding: var(--space-4);
+  border: 1px solid var(--color-danger-subtle);
+  border-radius: var(--block-card-radius);
+  background: var(--color-danger-subtle);
+}
+
+.gmail-inbox-list__error-text {
+  font-size: var(--text-sm);
+  color: var(--color-danger-text);
+  margin: 0;
+  line-height: var(--leading-normal);
+}
+
 /* ---- GmailScanResult ---- */
 
 .gmail-scan-result {

--- a/packages/agents/src/ui/inbox-surface.ts
+++ b/packages/agents/src/ui/inbox-surface.ts
@@ -91,7 +91,39 @@ export class InboxSurfaceAgent extends BaseAgent {
       });
     }
 
-    const { data: gmailData, totalUnread: gmailTotalUnread } = this.extractGmailData(retrievalOutput);
+    const { data: gmailData, totalUnread: gmailTotalUnread, error: gmailError } = this.extractGmailData(retrievalOutput);
+
+    // If data retrieval failed, return an error-state inbox surface
+    if (gmailError) {
+      this.log("Email retrieval failed, returning error surface", { error: gmailError });
+      const surfaceData: InboxSurfaceData = {
+        emails: [],
+        totalCount: 0,
+        unreadCount: 0,
+        error: gmailError,
+      };
+      const provenance = {
+        sourceType: "agent" as const,
+        sourceId: this.id,
+        trustLevel: "trusted" as const,
+        timestamp: startMs,
+        freshness: "realtime" as const,
+        dataState: "raw" as const,
+      };
+      const surfaceSpec = SurfaceFactory.inbox(surfaceData, provenance);
+      return {
+        ...this.createOutput(
+          { surfaceSpec, summary: gmailError },
+          0.3,
+          provenance,
+        ),
+        timing: {
+          startMs,
+          endMs: Date.now(),
+          durationMs: Date.now() - startMs,
+        },
+      };
+    }
 
     // If no email data found, return an empty inbox surface (not null)
     if (!gmailData || (Array.isArray(gmailData) && gmailData.length === 0)) {
@@ -353,21 +385,37 @@ export class InboxSurfaceAgent extends BaseAgent {
     return undefined;
   }
 
-  private extractGmailData(retrieval: DataRetrievalOutput): { data: unknown; totalUnread: number | undefined } {
-    // Find email-related results from any connector (gmail, catalog-gmail, MCP mail, etc.)
-    const emailResults = retrieval.results.filter(
-      (r) =>
-        r.status === "fulfilled" &&
-        (r.connectorId.includes("gmail") ||
-          r.connectorId.includes("mail") ||
-          r.operation.includes("email") ||
-          r.operation.includes("message") ||
-          r.operation.includes("inbox") ||
-          r.operation.includes("unseen") ||
-          r.operation.includes("recent")),
-    );
+  private extractGmailData(retrieval: DataRetrievalOutput): { data: unknown; totalUnread: number | undefined; error?: string } {
+    const isEmailRelated = (r: { connectorId: string; operation: string }) =>
+      r.connectorId.includes("gmail") ||
+      r.connectorId.includes("mail") ||
+      r.operation.includes("email") ||
+      r.operation.includes("message") ||
+      r.operation.includes("inbox") ||
+      r.operation.includes("unseen") ||
+      r.operation.includes("recent");
 
-    if (emailResults.length === 0) return { data: [], totalUnread: undefined };
+    // Find ALL email-related results (both fulfilled and rejected)
+    const allEmailResults = retrieval.results.filter((r) => isEmailRelated(r));
+
+    // If no email-related results at all, this isn't an email retrieval
+    if (allEmailResults.length === 0) return { data: [], totalUnread: undefined };
+
+    const rejectedEmailResults = allEmailResults.filter((r) => r.status === "rejected");
+    const emailResults = allEmailResults.filter((r) => r.status === "fulfilled");
+
+    // If ALL email results failed, signal an error instead of returning empty
+    if (emailResults.length === 0 && rejectedEmailResults.length > 0) {
+      const errors = rejectedEmailResults.map(
+        (r) => `${r.connectorId}/${r.operation}: ${r.error ?? "unknown error"}`,
+      );
+      this.log("All email retrievals failed", { errors });
+      return {
+        data: [],
+        totalUnread: undefined,
+        error: `Gmail service unavailable (${rejectedEmailResults.length} request${rejectedEmailResults.length > 1 ? "s" : ""} failed)`,
+      };
+    }
 
     this.log("Found email results", {
       count: emailResults.length,

--- a/packages/surfaces/src/surface-data.ts
+++ b/packages/surfaces/src/surface-data.ts
@@ -14,6 +14,8 @@ export interface InboxSurfaceData {
   }>;
   totalCount: number;
   unreadCount: number;
+  /** Present when data retrieval failed (e.g. Gmail API timeout) */
+  error?: string;
 }
 
 export interface CalendarSurfaceData {


### PR DESCRIPTION
## Summary
- **InboxSurfaceAgent.extractGmailData** now checks for `status === "rejected"` entries alongside fulfilled ones. When ALL email-related results are rejected, it returns `{ data: [], totalUnread: undefined, error: "Gmail service unavailable (...)" }` instead of silently returning empty data.
- **InboxSurfaceAgent.execute** detects the `error` field and builds an error-state inbox surface (low confidence, with the error message as summary) rather than treating it as "no emails found".
- **InboxSurfaceData** gains an optional `error?: string` field that flows through the block transformer into `GmailInboxList`, which renders an error banner instead of the empty card list.
- Happy path is completely unchanged — fulfilled results follow the same code path as before.

Closes #189

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Simulate Gmail connector timeout/rejection and confirm the inbox surface shows the error banner
- [ ] Confirm normal Gmail responses still render the inbox card list as before
- [ ] Confirm WaibScan button does not appear on the error surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)