### PR TITLE
feat: ErrorSurface block for connector/API failures

### DIFF
--- a/apps/frontend/src/blocks/components/domain/ErrorSurface.tsx
+++ b/apps/frontend/src/blocks/components/domain/ErrorSurface.tsx
@@ -1,0 +1,46 @@
+import type { BlockProps } from "../../registry";
+
+interface ErrorSurfaceProps {
+  title: string;
+  message: string;
+  retryable: boolean;
+  errorCode?: string;
+}
+
+/**
+ * Error surface block displayed when a connector or API call fails.
+ * Shows a warning/error card with optional retry action.
+ */
+export function ErrorSurface({ block, onEvent }: BlockProps) {
+  const {
+    title,
+    message,
+    retryable,
+    errorCode,
+  } = block.props as ErrorSurfaceProps;
+
+  return (
+    <div className="error-surface">
+      <div className="error-surface__icon">{"\u26A0"}</div>
+
+      <div className="error-surface__body">
+        <div className="error-surface__title">{title}</div>
+        <div className="error-surface__message">{message}</div>
+
+        {errorCode && (
+          <div className="error-surface__code">Code: {errorCode}</div>
+        )}
+      </div>
+
+      {retryable && (
+        <button
+          className="error-surface__retry"
+          type="button"
+          onClick={() => onEvent?.("retry")}
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/blocks/components/domain/index.ts
+++ b/apps/frontend/src/blocks/components/domain/index.ts
@@ -1,5 +1,7 @@
+import { registerBlock } from "../../registry";
 import { registerGmailComponents } from "./gmail";
 import { registerCalendarComponents } from "./gcal";
+import { ErrorSurface } from "./ErrorSurface";
 
 /**
  * Register all domain-specific block components.
@@ -8,4 +10,12 @@ import { registerCalendarComponents } from "./gcal";
 export function registerDomainComponents(): void {
   registerGmailComponents();
   registerCalendarComponents();
+
+  registerBlock("ErrorSurface", ErrorSurface, {
+    type: "ErrorSurface",
+    category: "domain",
+    source: "builtin",
+    description:
+      "Error surface displayed when a connector or API call fails, with optional retry",
+  });
 }

--- a/apps/frontend/src/styles/error-surface.css
+++ b/apps/frontend/src/styles/error-surface.css
@@ -1,0 +1,73 @@
+/* ================================ */
+/* ErrorSurface Block               */
+/* ================================ */
+
+.error-surface {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  background: var(--color-danger-subtle);
+  border: var(--block-card-border);
+  border-left: 3px solid var(--color-warning);
+  border-radius: var(--block-card-radius);
+  box-shadow: var(--block-card-shadow);
+}
+
+.error-surface__icon {
+  flex-shrink: 0;
+  font-size: var(--text-2xl);
+  line-height: 1;
+  color: var(--color-warning-text);
+}
+
+.error-surface__body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.error-surface__title {
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  line-height: var(--leading-tight);
+}
+
+.error-surface__message {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+}
+
+.error-surface__code {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  margin-top: var(--space-1);
+}
+
+.error-surface__retry {
+  flex-shrink: 0;
+  align-self: center;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.error-surface__retry:hover {
+  background: var(--color-surface-active);
+  border-color: var(--color-warning);
+}
+
+.error-surface__retry:active {
+  background: var(--color-surface);
+}

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -1,4 +1,5 @@
 @import "./calendar-components.css";
+@import "./error-surface.css";
 
 /* ================================ */
 /* Design Tokens                    */


### PR DESCRIPTION
## Summary
- Adds `ErrorSurface` block component that renders when connectors or API calls fail
- Displays warning icon, bold title, muted message, optional error code, and a retry button (when `retryable: true`) that fires `onEvent("retry")`
- Styled with danger-subtle background tint and warning left border accent using existing design tokens
- Registered as `category: "domain"`, `source: "builtin"` in the block registry

## New files
- `apps/frontend/src/blocks/components/domain/ErrorSurface.tsx` -- component
- `apps/frontend/src/styles/error-surface.css` -- styles

## Modified files
- `apps/frontend/src/blocks/components/domain/index.ts` -- wired registration
- `apps/frontend/src/styles/global.css` -- CSS import

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Render an `ErrorSurface` block with `retryable: true` and confirm retry button appears and fires event
- [ ] Render with `retryable: false` and confirm no retry button
- [ ] Render with and without `errorCode` prop
- [ ] Verify styling matches dark theme (danger-subtle bg, warning border accent)

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)