### PR TITLE
feat: truncation indicator for inbox email list

### DIFF
--- a/apps/frontend/src/blocks/components/domain/gmail/GmailInboxList.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailInboxList.tsx
@@ -6,10 +6,12 @@ interface GmailInboxListProps {
   totalCount: number;
   isScanned: boolean;
   error?: string;
+  isTruncated?: boolean;
+  fullCount?: number;
 }
 
 export function GmailInboxList({ block, children, onEvent }: BlockProps) {
-  const { unreadCount, isScanned, error } = block.props as GmailInboxListProps;
+  const { unreadCount, totalCount, isScanned, error, isTruncated, fullCount } = block.props as GmailInboxListProps;
   const [isScanning, setIsScanning] = useState(false);
 
   const handleScan = () => {
@@ -49,6 +51,11 @@ export function GmailInboxList({ block, children, onEvent }: BlockProps) {
         </div>
       ) : (
         <div className="gmail-inbox-list__cards">{children}</div>
+      )}
+      {isTruncated && fullCount && (
+        <p className="gmail-inbox-list__truncated">
+          Showing {totalCount} of {fullCount} emails
+        </p>
       )}
     </div>
   );

--- a/apps/frontend/src/blocks/transformers/inbox.ts
+++ b/apps/frontend/src/blocks/transformers/inbox.ts
@@ -112,6 +112,7 @@ export function inboxToBlocks(spec: SurfaceSpec): ComponentBlock[] {
         totalCount: data.totalCount,
         isScanned: false,
         ...(data.error ? { error: data.error } : {}),
+        ...(data.isTruncated ? { isTruncated: true, fullCount: data.fullCount } : {}),
       },
       children,
       meta: {

--- a/apps/frontend/src/styles/gmail-components.css
+++ b/apps/frontend/src/styles/gmail-components.css
@@ -239,6 +239,16 @@
   line-height: var(--leading-normal);
 }
 
+/* ---- GmailInboxList Truncation Footer ---- */
+
+.gmail-inbox-list__truncated {
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+  text-align: center;
+  margin: 0;
+  padding: var(--space-2) 0;
+}
+
 /* ---- GmailScanResult ---- */
 
 .gmail-scan-result {

--- a/packages/agents/src/ui/inbox-surface.ts
+++ b/packages/agents/src/ui/inbox-surface.ts
@@ -161,12 +161,14 @@ export class InboxSurfaceAgent extends BaseAgent {
     }
 
     // Truncate to 20 emails max
+    const originalCount = Array.isArray(gmailData) ? gmailData.length : 1;
     const truncatedData = this.truncateEmailData(gmailData);
 
     const rawEmails = (Array.isArray(truncatedData) ? truncatedData : [truncatedData]) as Record<string, unknown>[];
+    const isTruncated = originalCount > rawEmails.length;
 
     this.log("Building inbox surface from raw email data", {
-      rawEmailCount: Array.isArray(gmailData) ? gmailData.length : "non-array",
+      rawEmailCount: originalCount,
       truncatedEmailCount: rawEmails.length,
       totalUnreadFromMCP: gmailTotalUnread,
       isWaibScan,
@@ -201,11 +203,14 @@ export class InboxSurfaceAgent extends BaseAgent {
       emails,
       totalCount: emails.length,
       unreadCount,
+      ...(isTruncated && { isTruncated: true, fullCount: originalCount }),
     };
 
     const endMs = Date.now();
 
-    const summary = `${emails.length} emails, ${unreadCount} unread`;
+    const summary = isTruncated
+      ? `${emails.length} of ${originalCount} emails, ${unreadCount} unread`
+      : `${emails.length} emails, ${unreadCount} unread`;
 
     const provenance = {
       sourceType: "agent" as const,

--- a/packages/surfaces/src/surface-data.ts
+++ b/packages/surfaces/src/surface-data.ts
@@ -14,6 +14,10 @@ export interface InboxSurfaceData {
   }>;
   totalCount: number;
   unreadCount: number;
+  /** True when the email list was truncated to fit within limits */
+  isTruncated?: boolean;
+  /** Original email count before truncation */
+  fullCount?: number;
   /** Present when data retrieval failed (e.g. Gmail API timeout) */
   error?: string;
 }


### PR DESCRIPTION
## Summary
- Tracks original email count before truncation in the inbox surface agent
- Passes `isTruncated` and `fullCount` through the transformer to the GmailInboxList component
- Renders a "Showing X of Y emails" footer when the list is capped at 20

Closes #205

## Test plan
- [ ] Connect Gmail with >20 emails, verify footer shows "Showing 20 of N emails"
- [ ] Connect Gmail with ≤20 emails, verify no footer appears
- [ ] Verify `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)