### PR TITLE
fix: replace stub pages with functional redirects

### DIFF
--- a/apps/frontend/src/pages/ApprovalsPage.tsx
+++ b/apps/frontend/src/pages/ApprovalsPage.tsx
@@ -1,8 +1,15 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
 export default function ApprovalsPage() {
-  return (
-    <div className="page approvals-page">
-      <h1>Approvals</h1>
-      <p className="placeholder">Approvals content will be placed here.</p>
-    </div>
-  );
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    navigate("/", {
+      state: { pendingMessage: "Show my pending approvals" },
+      replace: true,
+    });
+  }, [navigate]);
+
+  return null;
 }

--- a/apps/frontend/src/pages/CalendarPage.tsx
+++ b/apps/frontend/src/pages/CalendarPage.tsx
@@ -1,8 +1,15 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
 export default function CalendarPage() {
-  return (
-    <div className="page calendar-page">
-      <h1>Calendar</h1>
-      <p className="placeholder">Calendar content will be placed here.</p>
-    </div>
-  );
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    navigate("/", {
+      state: { pendingMessage: "Show my upcoming calendar events" },
+      replace: true,
+    });
+  }, [navigate]);
+
+  return null;
 }

--- a/apps/frontend/src/pages/InboxPage.tsx
+++ b/apps/frontend/src/pages/InboxPage.tsx
@@ -1,8 +1,15 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
 export default function InboxPage() {
-  return (
-    <div className="page inbox-page">
-      <h1>Inbox</h1>
-      <p className="placeholder">Inbox content will be placed here.</p>
-    </div>
-  );
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    navigate("/", {
+      state: { pendingMessage: "Show my latest emails" },
+      replace: true,
+    });
+  }, [navigate]);
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- Inbox, Calendar, and Approvals pages now redirect to `/` with a `pendingMessage`
- HomePage already handles `pendingMessage` via `location.state` (line 101-108), sending it over WebSocket
- This means clicking "Inbox" in the nav auto-requests email data, "Calendar" requests events, etc.
- Zero duplication of WebSocket/rendering infrastructure

Closes #206

## Test plan
- [ ] Click Inbox nav link — redirects to home, loads inbox data
- [ ] Click Calendar nav link — redirects to home, loads calendar data
- [ ] Click Approvals nav link — redirects to home, loads approvals
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)