### PR TITLE
feat: add accessibility attributes to block primitives

### DIFF
--- a/apps/frontend/src/blocks/components/domain/gmail/GmailEmailCard.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailEmailCard.tsx
@@ -58,10 +58,11 @@ export function GmailEmailCard({ block }: BlockProps) {
     .join(" ");
 
   return (
-    <div className={cardClass}>
+    <div className={cardClass} role="listitem" aria-label={`${isUnread ? "Unread: " : ""}${subject || "No Subject"} from ${from}`}>
       <div
         className="gmail-email-card__avatar"
         style={{ backgroundColor: avatarBg }}
+        aria-hidden="true"
       >
         {initials}
       </div>

--- a/apps/frontend/src/blocks/components/domain/gmail/GmailInboxList.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailInboxList.tsx
@@ -20,12 +20,12 @@ export function GmailInboxList({ block, children, onEvent }: BlockProps) {
   };
 
   return (
-    <div className="gmail-inbox-list">
+    <div className="gmail-inbox-list" role="region" aria-label="Gmail Inbox">
       <div className="gmail-inbox-list__header">
         <div className="gmail-inbox-list__title-row">
           <h3 className="gmail-inbox-list__title">Inbox</h3>
           {!error && unreadCount > 0 && (
-            <span className="gmail-inbox-list__badge">{unreadCount}</span>
+            <span className="gmail-inbox-list__badge" aria-label={`${unreadCount} unread`}>{unreadCount}</span>
           )}
         </div>
         {!isScanned && !error && (
@@ -46,11 +46,11 @@ export function GmailInboxList({ block, children, onEvent }: BlockProps) {
         )}
       </div>
       {error ? (
-        <div className="gmail-inbox-list__error">
+        <div className="gmail-inbox-list__error" role="alert">
           <p className="gmail-inbox-list__error-text">{error}</p>
         </div>
       ) : (
-        <div className="gmail-inbox-list__cards">{children}</div>
+        <div className="gmail-inbox-list__cards" role="list" aria-label="Email messages">{children}</div>
       )}
       {isTruncated && fullCount && (
         <p className="gmail-inbox-list__truncated">

--- a/apps/frontend/src/blocks/components/primitives/Expandable.tsx
+++ b/apps/frontend/src/blocks/components/primitives/Expandable.tsx
@@ -13,6 +13,7 @@ export function Expandable({ block, children }: BlockProps) {
     <div className="block-expandable">
       <button
         className="block-expandable__header"
+        aria-expanded={open}
         onClick={() => setOpen((prev) => !prev)}
         style={{
           display: "flex",

--- a/apps/frontend/src/blocks/components/primitives/List.tsx
+++ b/apps/frontend/src/blocks/components/primitives/List.tsx
@@ -8,6 +8,7 @@ export function List({ block, children }: BlockProps) {
 
   return (
     <div
+      role="list"
       className={`block-list ${className}`.trim()}
       style={gap ? { gap } : undefined}
     >

--- a/apps/frontend/src/blocks/components/primitives/ListItem.tsx
+++ b/apps/frontend/src/blocks/components/primitives/ListItem.tsx
@@ -8,6 +8,7 @@ export function ListItem({ block, children }: BlockProps) {
 
   return (
     <div
+      role="listitem"
       className={`block-list-item ${className}`.trim()}
       data-swipeable={swipeable || undefined}
     >

--- a/apps/frontend/src/blocks/components/primitives/TextInput.tsx
+++ b/apps/frontend/src/blocks/components/primitives/TextInput.tsx
@@ -31,6 +31,7 @@ export function TextInput({ block, onEvent }: BlockProps) {
       <textarea
         className="block-text-input"
         placeholder={placeholder}
+        aria-label={placeholder || "Text input"}
         defaultValue={value}
         rows={rows}
         onChange={handleChange}
@@ -44,6 +45,7 @@ export function TextInput({ block, onEvent }: BlockProps) {
       type="text"
       className="block-text-input"
       placeholder={placeholder}
+      aria-label={placeholder || "Text input"}
       defaultValue={value}
       onChange={handleChange}
       style={{ ...sharedStyle, resize: undefined }}


### PR DESCRIPTION
## Summary
- **List/ListItem**: `role="list"` and `role="listitem"` for screen readers
- **Expandable**: `aria-expanded` on toggle button
- **TextInput**: `aria-label` from placeholder prop
- **GmailInboxList**: `role="region"`, `role="list"` on cards, `role="alert"` on error
- **GmailEmailCard**: `role="listitem"`, `aria-label` with subject/sender, `aria-hidden` on decorative avatar

Closes #207

## Test plan
- [ ] Screen reader announces list items correctly
- [ ] Expandable sections report expanded/collapsed state
- [ ] Email cards are announced with subject and sender
- [ ] Error states announced as alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)