### PR TITLE
feat: mobile responsive layout for surfaces and gmail cards

### DIFF
--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -1777,6 +1777,34 @@ body {
   }
 }
 
+/* ================================ */
+/* Responsive — Mobile (<480px)     */
+/* ================================ */
+@media (max-width: 480px) {
+  .layout-main {
+    padding: var(--space-3) var(--space-2);
+  }
+
+  .surface {
+    padding: var(--space-3);
+    border-radius: var(--radius-md);
+  }
+
+  .surface-cell.half,
+  .surface-cell.third,
+  .surface-cell.full {
+    grid-column: span 12;
+  }
+
+  .chat-input {
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .chat-input__field {
+    font-size: var(--text-base);
+  }
+}
+
 /* ===================== */
 /* Loading States          */
 /* ===================== */

--- a/apps/frontend/src/styles/gmail-components.css
+++ b/apps/frontend/src/styles/gmail-components.css
@@ -354,3 +354,35 @@
 .gmail-email-card--skeleton .skel-bar--snippet {
   width: 80%;
 }
+
+/* ================================ */
+/* Gmail — Mobile Responsive        */
+/* ================================ */
+@media (max-width: 640px) {
+  .gmail-email-card {
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .gmail-email-card__avatar {
+    width: 28px;
+    height: 28px;
+    font-size: var(--text-xs);
+  }
+
+  .gmail-email-card__snippet {
+    display: none;
+  }
+
+  .gmail-email-card__actions {
+    display: none;
+  }
+
+  .gmail-inbox-list__header {
+    padding: 0;
+  }
+
+  .gmail-inbox-list__title {
+    font-size: var(--text-lg);
+  }
+}


### PR DESCRIPTION
## Summary
- Add 480px mobile breakpoint to global.css (tighter padding, full-width cells)
- Gmail cards on mobile: hide snippets/urgency badges, compact avatars, reduced padding
- Existing 768px tablet breakpoint already handles grid column stacking

Closes #208

## Test plan
- [ ] Desktop — no visual changes
- [ ] Tablet (768px) — grid collapses to single column
- [ ] Mobile (480px) — tighter padding, gmail cards compact
- [ ] No JS changes, CSS-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)