### PR TITLE
feat: mock Calendar connector with fixture data

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -35,6 +35,7 @@ import {
   MCPServerRegistry,
   GmailConnector,
   MockGmailConnector,
+  MockCalendarConnector,
 } from "@waibspace/connectors";
 import { PolicyEngine, DEFAULT_POLICY_RULES } from "@waibspace/policy";
 import {
@@ -79,6 +80,11 @@ if (process.env.MOCK_CONNECTORS === "true") {
   await mockGmail.connect();
   connectorRegistry.register(mockGmail);
   console.log("[backend] MockGmailConnector registered (MOCK_CONNECTORS=true)");
+
+  const mockCalendar = new MockCalendarConnector();
+  await mockCalendar.connect();
+  connectorRegistry.register(mockCalendar);
+  console.log("[backend] MockCalendarConnector registered (MOCK_CONNECTORS=true)");
 } else {
   const gmailConnector = new GmailConnector();
   await gmailConnector.connect();

--- a/packages/connectors/src/google-calendar/fixtures.ts
+++ b/packages/connectors/src/google-calendar/fixtures.ts
@@ -1,0 +1,118 @@
+import type { CalendarEvent, FreeSlot } from "./types";
+
+/**
+ * Generate fixture events relative to "today" so they always look fresh.
+ */
+function today(hour: number, minute = 0): string {
+  const d = new Date();
+  d.setHours(hour, minute, 0, 0);
+  return d.toISOString();
+}
+
+function tomorrow(hour: number, minute = 0): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  d.setHours(hour, minute, 0, 0);
+  return d.toISOString();
+}
+
+export const FIXTURE_EVENTS: CalendarEvent[] = [
+  {
+    id: "cal-evt-1",
+    summary: "Standup",
+    start: today(9, 0),
+    end: today(9, 15),
+    location: "Zoom",
+    attendees: ["alice@example.com", "bob@example.com"],
+    status: "confirmed",
+  },
+  {
+    id: "cal-evt-2",
+    summary: "Product Review",
+    start: today(10, 30),
+    end: today(11, 30),
+    location: "Conference Room B",
+    attendees: ["carol@example.com", "dave@example.com", "eve@example.com"],
+    status: "confirmed",
+  },
+  {
+    id: "cal-evt-3",
+    summary: "Lunch with Investors",
+    start: today(12, 0),
+    end: today(13, 0),
+    location: "Downtown Grill",
+    description: "Q1 review discussion",
+    status: "confirmed",
+  },
+  {
+    id: "cal-evt-4",
+    summary: "Sprint Planning",
+    start: today(14, 0),
+    end: today(15, 0),
+    location: "Zoom",
+    attendees: ["alice@example.com", "frank@example.com"],
+    status: "confirmed",
+  },
+  {
+    id: "cal-evt-5",
+    summary: "1:1 with Manager",
+    start: today(16, 0),
+    end: today(16, 30),
+    status: "confirmed",
+  },
+  {
+    id: "cal-evt-6",
+    summary: "Team Retro",
+    start: tomorrow(10, 0),
+    end: tomorrow(11, 0),
+    location: "Zoom",
+    attendees: ["alice@example.com", "bob@example.com", "carol@example.com"],
+    status: "confirmed",
+  },
+  {
+    id: "cal-evt-7",
+    summary: "Design Review",
+    start: tomorrow(14, 0),
+    end: tomorrow(15, 0),
+    location: "Conference Room A",
+    status: "confirmed",
+  },
+];
+
+/**
+ * Compute free slots between events for a given time range.
+ */
+export function computeFreeSlots(
+  events: CalendarEvent[],
+  rangeStart: string,
+  rangeEnd: string,
+): FreeSlot[] {
+  const sorted = [...events].sort(
+    (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+  );
+
+  const slots: FreeSlot[] = [];
+  let cursor = new Date(rangeStart).getTime();
+  const end = new Date(rangeEnd).getTime();
+
+  for (const evt of sorted) {
+    const evtStart = new Date(evt.start).getTime();
+    const evtEnd = new Date(evt.end).getTime();
+    if (evtStart > cursor && evtStart <= end) {
+      slots.push({
+        start: new Date(cursor).toISOString(),
+        end: new Date(evtStart).toISOString(),
+      });
+    }
+    if (evtEnd > cursor) cursor = evtEnd;
+  }
+
+  if (cursor < end) {
+    slots.push({
+      start: new Date(cursor).toISOString(),
+      end: new Date(end).toISOString(),
+    });
+  }
+
+  return slots;
+}

--- a/packages/connectors/src/google-calendar/index.ts
+++ b/packages/connectors/src/google-calendar/index.ts
@@ -1,3 +1,4 @@
 export { GoogleCalendarConnector } from "./calendar-connector";
 export type { GoogleCalendarConnectorConfig } from "./calendar-connector";
+export { MockCalendarConnector } from "./mock-calendar-connector";
 export type { CalendarEvent, FreeSlot } from "./types";

--- a/packages/connectors/src/google-calendar/mock-calendar-connector.ts
+++ b/packages/connectors/src/google-calendar/mock-calendar-connector.ts
@@ -1,0 +1,170 @@
+import { BaseConnector } from "../base-connector";
+import type {
+  ConnectorRequest,
+  ConnectorResponse,
+  ConnectorAction,
+  ConnectorResult,
+} from "../types";
+import type { CalendarEvent } from "./types";
+import { FIXTURE_EVENTS, computeFreeSlots } from "./fixtures";
+
+/**
+ * Mock Google Calendar connector that returns fixture data.
+ * Activated when `MOCK_CONNECTORS=true` is set in the environment.
+ */
+export class MockCalendarConnector extends BaseConnector {
+  private events: CalendarEvent[] = [];
+
+  constructor() {
+    super({
+      id: "google-calendar",
+      name: "Google Calendar",
+      type: "api",
+      trustLevel: "trusted",
+      capabilities: {
+        connectorId: "google-calendar",
+        connectorType: "api",
+        actions: [
+          "list-events",
+          "check-availability",
+          "get-event",
+          "create-event",
+          "update-event",
+        ],
+        dataTypes: ["calendar-event", "free-slot"],
+        trustLevel: "trusted",
+      },
+    });
+  }
+
+  async connect(): Promise<void> {
+    this.events = [...FIXTURE_EVENTS];
+    this.connected = true;
+    this.log("Connected (mock mode — using fixture data)");
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    this.log("Disconnected (mock)");
+  }
+
+  protected override createProvenance() {
+    return {
+      sourceType: "google-calendar",
+      sourceId: this.id,
+      trustLevel: this.trustLevel,
+      timestamp: Date.now(),
+      freshness: "realtime" as const,
+      dataState: "raw" as const,
+    };
+  }
+
+  protected async doFetch(
+    request: ConnectorRequest,
+  ): Promise<ConnectorResponse> {
+    switch (request.operation) {
+      case "list-events":
+        return this.listEvents(request.params);
+      case "check-availability":
+        return this.checkAvailability(request.params);
+      case "get-event":
+        return this.getEvent(request.params);
+      default:
+        throw new Error(`Unknown fetch operation: ${request.operation}`);
+    }
+  }
+
+  protected async doExecute(
+    action: ConnectorAction,
+  ): Promise<ConnectorResult> {
+    switch (action.operation) {
+      case "create-event":
+        return {
+          success: true,
+          result: {
+            id: `mock-evt-${Date.now()}`,
+            ...(action.params as Record<string, unknown>),
+            status: "confirmed",
+          },
+        };
+      case "update-event":
+        return {
+          success: true,
+          result: { eventId: action.params.eventId, updated: true },
+        };
+      default:
+        return {
+          success: false,
+          error: `Unknown execute operation: ${action.operation}`,
+        };
+    }
+  }
+
+  private async listEvents(
+    params: Record<string, unknown>,
+  ): Promise<ConnectorResponse> {
+    const { timeMin, timeMax, maxResults } = params as {
+      timeMin?: string;
+      timeMax?: string;
+      maxResults?: number;
+    };
+
+    let results = [...this.events];
+
+    if (timeMin) {
+      const min = new Date(timeMin).getTime();
+      results = results.filter(
+        (e) => new Date(e.end).getTime() >= min,
+      );
+    }
+    if (timeMax) {
+      const max = new Date(timeMax).getTime();
+      results = results.filter(
+        (e) => new Date(e.start).getTime() <= max,
+      );
+    }
+
+    results.sort(
+      (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+    );
+
+    if (maxResults) {
+      results = results.slice(0, maxResults);
+    }
+
+    return {
+      data: results,
+      provenance: this.createProvenance(),
+    };
+  }
+
+  private async checkAvailability(
+    params: Record<string, unknown>,
+  ): Promise<ConnectorResponse> {
+    const { timeMin, timeMax } = params as {
+      timeMin: string;
+      timeMax: string;
+    };
+
+    const slots = computeFreeSlots(this.events, timeMin, timeMax);
+
+    return {
+      data: slots,
+      provenance: this.createProvenance(),
+    };
+  }
+
+  private async getEvent(
+    params: Record<string, unknown>,
+  ): Promise<ConnectorResponse> {
+    const { eventId } = params as { eventId: string };
+    const event = this.events.find((e) => e.id === eventId);
+    if (!event) {
+      throw new Error(`Event not found: ${eventId}`);
+    }
+    return {
+      data: event,
+      provenance: this.createProvenance(),
+    };
+  }
+}

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -20,6 +20,7 @@ export type {
 } from "./gmail";
 export {
   GoogleCalendarConnector,
+  MockCalendarConnector,
   type GoogleCalendarConnectorConfig,
   type CalendarEvent,
   type FreeSlot,


### PR DESCRIPTION
## Summary
- New `MockCalendarConnector` class following the MockGmailConnector pattern
- 7 fixture events (5 today, 2 tomorrow) with locations, attendees, descriptions
- Free slot computation via `computeFreeSlots()` utility
- Supports list-events, check-availability, get-event, create-event, update-event
- Wired into backend when `MOCK_CONNECTORS=true`

Closes #200

## Test plan
- [ ] Start backend with `MOCK_CONNECTORS=true`, verify calendar connector registers
- [ ] Request "Show my calendar events" — should return fixture events
- [ ] Request availability check — should return computed free slots
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)