### PR TITLE
fix: approval denial has no user feedback

### DIFF
--- a/apps/frontend/src/blocks/transformers/approval.ts
+++ b/apps/frontend/src/blocks/transformers/approval.ts
@@ -1,7 +1,7 @@
 import type {
   ComponentBlock,
   SurfaceSpec,
-  EmitAction,
+  SequenceAction,
 } from "@waibspace/types";
 import type { ApprovalSurfaceData } from "@waibspace/surfaces";
 
@@ -61,13 +61,23 @@ export function approvalToBlocks(spec: SurfaceSpec): ComponentBlock[] {
         props: { label: "Approve", variant: "primary" },
         events: {
           onClick: {
-            action: "emit",
-            event: "approval",
-            payload: {
-              approvalId: data.approvalId,
-              approved: true,
-            },
-          } satisfies EmitAction,
+            action: "sequence",
+            steps: [
+              {
+                action: "setState",
+                key: `${sid}-status`,
+                value: "approved",
+              },
+              {
+                action: "emit",
+                event: "approval",
+                payload: {
+                  approvalId: data.approvalId,
+                  approved: true,
+                },
+              },
+            ],
+          } satisfies SequenceAction,
         },
       },
       {
@@ -76,13 +86,23 @@ export function approvalToBlocks(spec: SurfaceSpec): ComponentBlock[] {
         props: { label: "Deny", variant: "secondary" },
         events: {
           onClick: {
-            action: "emit",
-            event: "approval",
-            payload: {
-              approvalId: data.approvalId,
-              approved: false,
-            },
-          } satisfies EmitAction,
+            action: "sequence",
+            steps: [
+              {
+                action: "setState",
+                key: `${sid}-status`,
+                value: "denied",
+              },
+              {
+                action: "emit",
+                event: "approval",
+                payload: {
+                  approvalId: data.approvalId,
+                  approved: false,
+                },
+              },
+            ],
+          } satisfies SequenceAction,
         },
       },
     ],
@@ -94,6 +114,9 @@ export function approvalToBlocks(spec: SurfaceSpec): ComponentBlock[] {
       type: "Container",
       props: { direction: "column", gap: "12px", padding: "var(--space-5)" },
       children,
+      state: {
+        [`${sid}-status`]: { type: "string", default: "pending" },
+      },
       meta: {
         surfaceId: spec.surfaceId,
         surfaceType: "approval",

--- a/apps/frontend/src/components/surfaces/ApprovalSurface.tsx
+++ b/apps/frontend/src/components/surfaces/ApprovalSurface.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { SurfaceProps } from "./registry";
 import type { ApprovalSurfaceData } from "@waibspace/surfaces";
 
@@ -13,23 +14,43 @@ const riskLabels: Record<string, string> = {
   C: "High Risk",
 };
 
+type ApprovalStatus = "pending" | "approved" | "denied";
+
 export function ApprovalSurface({
   spec,
   onAction,
   onInteraction,
 }: SurfaceProps) {
   const data = spec.data as ApprovalSurfaceData;
+  const [status, setStatus] = useState<ApprovalStatus>("pending");
 
   const handleApprove = () => {
-    // Emit approval.response via the onInteraction callback
-    // The HomePage will detect the "approve" interaction on an approval surface
-    // and send an approval.response message
+    setStatus("approved");
     onInteraction("approve", data.approvalId, { approved: true });
   };
 
   const handleDeny = () => {
+    setStatus("denied");
     onInteraction("deny", data.approvalId, { approved: false });
   };
+
+  if (status !== "pending") {
+    return (
+      <div className="approval-overlay">
+        <div className="approval-backdrop approval-backdrop--fading" />
+        <div className={`approval-modal approval-modal--${status}`}>
+          <div className="approval-response-message">
+            <span className="approval-response-icon">
+              {status === "approved" ? "\u2713" : "\u2717"}
+            </span>
+            <p className="approval-response-text">
+              {status === "approved" ? "Action approved" : "Action denied"}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="approval-overlay">

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -1558,6 +1558,69 @@ body {
   box-shadow: var(--shadow-glow-danger), var(--shadow-md);
 }
 
+/* Approval response feedback */
+.approval-backdrop--fading {
+  animation: approval-fade-out 1.8s ease-out forwards;
+}
+
+.approval-modal--approved,
+.approval-modal--denied {
+  animation: approval-response-pop 0.3s ease-out, approval-slide-out 0.5s ease-in 1.3s forwards;
+  text-align: center;
+  padding: var(--space-8) var(--space-10);
+}
+
+.approval-modal--denied {
+  border-color: var(--color-danger);
+}
+
+.approval-modal--approved {
+  border-color: var(--color-accent);
+}
+
+.approval-response-message {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.approval-response-icon {
+  font-size: 2.5rem;
+  line-height: 1;
+}
+
+.approval-modal--approved .approval-response-icon {
+  color: var(--color-accent);
+}
+
+.approval-modal--denied .approval-response-icon {
+  color: var(--color-danger);
+}
+
+.approval-response-text {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+@keyframes approval-response-pop {
+  0% { transform: scale(0.95); opacity: 0.5; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+@keyframes approval-slide-out {
+  0% { transform: scale(1); opacity: 1; }
+  100% { transform: scale(0.9) translateY(-12px); opacity: 0; }
+}
+
+@keyframes approval-fade-out {
+  0% { opacity: 1; }
+  70% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
 /* ================================ */
 /* Tasks Page                       */
 /* ================================ */


### PR DESCRIPTION
## Summary
- When clicking "Deny" (or "Approve") on an approval surface, the modal now shows an animated confirmation message before fading out
- Updated both the legacy `ApprovalSurface.tsx` component (React state) and the block-based `approval.ts` transformer (sequence action with setState + emit)
- Added CSS animations for the response feedback (pop-in, slide-out, backdrop fade)

## Test plan
- [ ] Trigger an approval surface (e.g. via a risky action that requires approval)
- [ ] Click "Deny" and verify a confirmation message appears ("Action denied" with a cross icon)
- [ ] Click "Approve" and verify a confirmation message appears ("Action approved" with a checkmark)
- [ ] Verify the modal animates out after the confirmation is shown
- [ ] Run `npx tsc --noEmit` to confirm no type errors

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)