### PR TITLE
fix: implement full Settings page with connections, preferences, and about tabs

### DIFF
--- a/apps/frontend/src/pages/SettingsPage.tsx
+++ b/apps/frontend/src/pages/SettingsPage.tsx
@@ -1,10 +1,152 @@
+import { useState } from "react";
 import { ConnectionManager } from "../components/ConnectionManager";
 
+type SettingsSection = "connections" | "preferences" | "about";
+
 export default function SettingsPage() {
+  const [activeSection, setActiveSection] = useState<SettingsSection>("connections");
+  const [theme, setTheme] = useState<"dark" | "light">("dark");
+  const [notifyErrors, setNotifyErrors] = useState(true);
+  const [notifyTaskComplete, setNotifyTaskComplete] = useState(true);
+
+  const sections: { id: SettingsSection; label: string }[] = [
+    { id: "connections", label: "Connections" },
+    { id: "preferences", label: "Preferences" },
+    { id: "about", label: "About" },
+  ];
+
   return (
     <div className="page settings-page">
       <h1>Settings</h1>
-      <ConnectionManager />
+
+      <nav className="settings-nav">
+        {sections.map((section) => (
+          <button
+            key={section.id}
+            className={`settings-nav__tab ${activeSection === section.id ? "settings-nav__tab--active" : ""}`}
+            onClick={() => setActiveSection(section.id)}
+          >
+            {section.label}
+          </button>
+        ))}
+      </nav>
+
+      <div className="settings-content">
+        {activeSection === "connections" && (
+          <section className="settings-section">
+            <ConnectionManager />
+          </section>
+        )}
+
+        {activeSection === "preferences" && (
+          <section className="settings-section">
+            <h3 className="settings-section__title">Appearance</h3>
+            <div className="settings-card">
+              <div className="settings-row">
+                <div className="settings-row__info">
+                  <span className="settings-row__label">Theme</span>
+                  <span className="settings-row__description">
+                    Choose between dark and light mode
+                  </span>
+                </div>
+                <div className="settings-toggle-group">
+                  <button
+                    className={`settings-toggle-group__btn ${theme === "dark" ? "settings-toggle-group__btn--active" : ""}`}
+                    onClick={() => setTheme("dark")}
+                  >
+                    Dark
+                  </button>
+                  <button
+                    className={`settings-toggle-group__btn ${theme === "light" ? "settings-toggle-group__btn--active" : ""}`}
+                    onClick={() => setTheme("light")}
+                  >
+                    Light
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <h3 className="settings-section__title">Notifications</h3>
+            <div className="settings-card">
+              <div className="settings-row">
+                <div className="settings-row__info">
+                  <span className="settings-row__label">Error alerts</span>
+                  <span className="settings-row__description">
+                    Show notifications when a task or connection fails
+                  </span>
+                </div>
+                <label className="settings-switch">
+                  <input
+                    type="checkbox"
+                    checked={notifyErrors}
+                    onChange={() => setNotifyErrors(!notifyErrors)}
+                  />
+                  <span className="settings-switch__slider" />
+                </label>
+              </div>
+
+              <div className="settings-row">
+                <div className="settings-row__info">
+                  <span className="settings-row__label">Task completion</span>
+                  <span className="settings-row__description">
+                    Notify when background tasks finish executing
+                  </span>
+                </div>
+                <label className="settings-switch">
+                  <input
+                    type="checkbox"
+                    checked={notifyTaskComplete}
+                    onChange={() => setNotifyTaskComplete(!notifyTaskComplete)}
+                  />
+                  <span className="settings-switch__slider" />
+                </label>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {activeSection === "about" && (
+          <section className="settings-section">
+            <div className="settings-card">
+              <div className="settings-about">
+                <h3 className="settings-about__name">WaibSpace</h3>
+                <span className="settings-about__version">v0.0.1</span>
+              </div>
+              <p className="settings-about__tagline">
+                AI-native personal assistant powered by MCP
+              </p>
+            </div>
+
+            <div className="settings-card">
+              <h3 className="settings-section__title settings-section__title--incard">
+                Resources
+              </h3>
+              <ul className="settings-links">
+                <li className="settings-links__item">
+                  <a
+                    href="https://github.com/crcnum4/WaibSpace"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="settings-links__anchor"
+                  >
+                    GitHub Repository
+                  </a>
+                </li>
+                <li className="settings-links__item">
+                  <a
+                    href="https://modelcontextprotocol.io"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="settings-links__anchor"
+                  >
+                    MCP Documentation
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </section>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -2192,6 +2192,221 @@ body {
   letter-spacing: -0.02em;
 }
 
+/* Settings Nav Tabs */
+.settings-nav {
+  display: flex;
+  gap: var(--space-1);
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0;
+}
+
+.settings-nav__tab {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -1px;
+}
+
+.settings-nav__tab:hover {
+  color: var(--color-text);
+}
+
+.settings-nav__tab--active {
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+}
+
+/* Settings Content */
+.settings-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.settings-section__title {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.settings-section__title--incard {
+  margin-bottom: var(--space-2);
+}
+
+/* Settings Card */
+.settings-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* Settings Row — label + control */
+.settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-2) 0;
+}
+
+.settings-row + .settings-row {
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.settings-row__info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.settings-row__label {
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+}
+
+.settings-row__description {
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+}
+
+/* Toggle Group (theme selector) */
+.settings-toggle-group {
+  display: flex;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.settings-toggle-group__btn {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.settings-toggle-group__btn:hover {
+  background: var(--color-surface-hover);
+}
+
+.settings-toggle-group__btn--active {
+  background: var(--color-accent-subtle);
+  color: var(--color-accent);
+}
+
+/* Toggle Switch */
+.settings-switch {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.settings-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.settings-switch__slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: var(--color-surface-active);
+  border-radius: var(--radius-full);
+  transition: background 0.2s;
+}
+
+.settings-switch__slider::before {
+  content: "";
+  position: absolute;
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background: var(--color-text-secondary);
+  border-radius: 50%;
+  transition: transform 0.2s, background 0.2s;
+}
+
+.settings-switch input:checked + .settings-switch__slider {
+  background: var(--color-accent-subtle);
+}
+
+.settings-switch input:checked + .settings-switch__slider::before {
+  transform: translateX(16px);
+  background: var(--color-accent);
+}
+
+/* About Section */
+.settings-about {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.settings-about__name {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-bold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.settings-about__version {
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+}
+
+.settings-about__tagline {
+  font-size: var(--text-md);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+/* Links List */
+.settings-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.settings-links__anchor {
+  font-size: var(--text-md);
+  color: var(--color-accent);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.settings-links__anchor:hover {
+  color: var(--color-accent-hover);
+  text-decoration: underline;
+}
+
 /* ================================ */
 /* Connection Manager               */
 /* ================================ */


### PR DESCRIPTION
## Summary
- Replaces the 10-line stub `SettingsPage` with a tabbed settings UI containing three sections: **Connections**, **Preferences**, and **About**
- Connections tab retains the existing `ConnectionManager` component unchanged
- Preferences tab adds theme toggle (dark/light) and notification switches as placeholders for future backend wiring
- About tab shows app version (v0.0.1) and links to the GitHub repo and MCP docs
- All new CSS uses BEM naming and existing CSS custom properties (`--color-*`, `--space-*`, `--text-*`, etc.)

## Test plan
- [ ] Navigate to `/settings` and verify all three tabs render correctly
- [ ] Verify Connections tab still shows the full ConnectionManager with add/connect/disconnect/delete functionality
- [ ] Verify Preferences tab toggles are interactive (state is local for now)
- [ ] Verify About section displays version and links open in new tabs
- [ ] Confirm no regressions on other pages

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)