### PR TITLE
fix: surface MCP connection errors to users

### DIFF
--- a/apps/frontend/src/components/ConnectionManager.tsx
+++ b/apps/frontend/src/components/ConnectionManager.tsx
@@ -68,7 +68,17 @@ export function ConnectionManager() {
   const connectServer = async (id: string) => {
     setActionLoading(id);
     try {
-      await fetch(`/api/mcp/servers/${id}/connect`, { method: "POST" });
+      const res = await fetch(`/api/mcp/servers/${id}/connect`, { method: "POST" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        const errMsg = body?.error ?? `Connection failed (HTTP ${res.status})`;
+        // Update local state immediately so the error shows
+        setServers((prev) =>
+          prev.map((s) =>
+            s.config.id === id ? { ...s, error: errMsg } : s,
+          ),
+        );
+      }
       await fetchServers();
     } finally {
       setActionLoading(null);
@@ -136,11 +146,13 @@ export function ConnectionManager() {
 
   const getStatusClass = (server: MCPServer) => {
     if (server.connected) return "connected";
+    if (server.error) return "error";
     return "disconnected";
   };
 
   const getStatusLabel = (server: MCPServer) => {
     if (server.connected) return "Connected";
+    if (server.error) return "Error";
     return "Disconnected";
   };
 
@@ -327,6 +339,15 @@ export function ConnectionManager() {
               </div>
             </div>
 
+            {server.error && !server.connected && (
+              <div className="conn-error">
+                <span className="conn-error-icon">!</span>
+                <span className="conn-error-message">
+                  {friendlyConnectionError(server.error, server.config)}
+                </span>
+              </div>
+            )}
+
             {server.connected && (
               <button
                 className="conn-expand-btn"
@@ -367,4 +388,42 @@ export function ConnectionManager() {
       </div>
     </div>
   );
+}
+
+/** Convert raw MCP connection errors into actionable user-facing messages. */
+function friendlyConnectionError(
+  error: string,
+  config: MCPServer["config"],
+): string {
+  // stdio: command not found
+  if (error.includes("ENOENT") || error.includes("not found")) {
+    return `Command "${config.command ?? "unknown"}" not found. Is the MCP server installed?`;
+  }
+  // SSE/HTTP: connection refused
+  if (error.includes("ECONNREFUSED")) {
+    const port = config.url ? new URL(config.url).port : null;
+    return port
+      ? `Connection refused on port ${port}. Is the server running?`
+      : `Connection refused. Is the ${config.name} server running?`;
+  }
+  // Process exited / crashed
+  if (error.includes("exited") || error.includes("spawn")) {
+    return `${config.name} server process failed to start. Check the command and arguments.`;
+  }
+  // Timeout
+  if (error.includes("timed out") || error.includes("timeout")) {
+    return `Connection to ${config.name} timed out. The server may be unresponsive.`;
+  }
+  // DNS / network
+  if (error.includes("ENOTFOUND")) {
+    return `Could not resolve host for ${config.name}. Check the server URL.`;
+  }
+  // Auth
+  if (error.includes("401") || error.includes("403") || error.includes("Unauthorized")) {
+    return `Authentication failed for ${config.name}. Check your credentials.`;
+  }
+  // Fallback: show the raw error but truncated
+  const maxLen = 150;
+  const cleaned = error.replace(/^Failed to connect to MCP server "[^"]+": /, "");
+  return cleaned.length > maxLen ? cleaned.slice(0, maxLen) + "..." : cleaned;
 }

--- a/apps/frontend/src/components/ErrorSurface.tsx
+++ b/apps/frontend/src/components/ErrorSurface.tsx
@@ -50,17 +50,28 @@ function friendlyAgentName(agentId: string): string {
 
 /** Convert error messages to user-friendly text */
 function friendlyErrorMessage(message: string): string {
-  if (message.includes("timed out")) {
+  if (message.includes("timed out") || message.includes("timeout")) {
     return "Request timed out - please try again";
   }
-  if (message.includes("ECONNREFUSED") || message.includes("ENOTFOUND")) {
-    return "Service temporarily unavailable";
+  if (message.includes("ECONNREFUSED")) {
+    return "Server not running - connection refused";
   }
-  if (message.includes("401") || message.includes("403")) {
+  if (message.includes("ENOTFOUND")) {
+    return "Server not found - check configuration";
+  }
+  if (message.includes("ENOENT") || message.includes("not found")) {
+    return "Server command not found - is it installed?";
+  }
+  if (message.includes("401") || message.includes("403") || message.includes("Unauthorized")) {
     return "Authentication required - please reconnect";
   }
+  if (message.includes("Failed to connect to MCP server")) {
+    // Extract the actionable part after the server name
+    const match = message.match(/MCP server "[^"]+": (.+)/);
+    if (match) return match[1];
+  }
   // Don't expose raw error messages to users
-  if (message.length > 100 || message.includes("Error:")) {
+  if (message.length > 120 || message.includes("Error:")) {
     return "An unexpected error occurred";
   }
   return message;

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -22,6 +22,12 @@ interface ConnectedService {
   name: string;
 }
 
+interface FailedService {
+  id: string;
+  name: string;
+  error: string;
+}
+
 export default function HomePage() {
   const { send, lastMessage, status } = useWebSocket(WS_URL);
   const location = useLocation();
@@ -29,6 +35,7 @@ export default function HomePage() {
   const [agents, setAgents] = useState<AgentStatusType[]>([]);
   const [hasCheckedConnections, setHasCheckedConnections] = useState(false);
   const [connectedServices, setConnectedServices] = useState<ConnectedService[]>([]);
+  const [failedServices, setFailedServices] = useState<FailedService[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [pipelinePhase, setPipelinePhase] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -51,12 +58,17 @@ export default function HomePage() {
 
     fetch(`${API_BASE}/api/mcp/servers`)
       .then((res) => res.json())
-      .then((servers: Array<{ config: { id: string; name: string }; connected: boolean }>) => {
+      .then((servers: Array<{ config: { id: string; name: string }; connected: boolean; error: string | null }>) => {
         const connected = servers
           .filter((s) => s.connected)
           .map((s) => ({ id: s.config.id, name: s.config.name }));
 
+        const failed = servers
+          .filter((s) => !s.connected && s.error)
+          .map((s) => ({ id: s.config.id, name: s.config.name, error: s.error! }));
+
         setConnectedServices(connected);
+        setFailedServices(failed);
 
         if (connected.length === 0) return; // Stay on WelcomeState
 
@@ -222,6 +234,15 @@ export default function HomePage() {
       </div>
 
       <div className="home-content">
+        {failedServices.length > 0 && (
+          <ErrorSurface
+            errors={failedServices.map((svc) => ({
+              agentId: svc.name,
+              message: svc.error,
+              phase: "connection",
+            }))}
+          />
+        )}
         {errorMessage && (
           <ErrorSurface
             errors={[

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -710,6 +710,11 @@ body {
   background: var(--color-danger);
 }
 
+.connection-dot.error {
+  background: var(--color-warning);
+  box-shadow: 0 0 6px var(--color-warning);
+}
+
 .connection-label {
   font-size: var(--text-sm);
   color: var(--color-muted);
@@ -2473,6 +2478,29 @@ body {
   gap: var(--space-1);
   font-size: var(--text-sm);
   color: var(--color-danger);
+}
+
+/* Connection Error */
+.conn-error {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: color-mix(in srgb, var(--color-warning) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 30%, transparent);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  color: var(--color-warning);
+  line-height: 1.4;
+}
+
+.conn-error-icon {
+  flex-shrink: 0;
+  font-weight: var(--weight-bold);
+}
+
+.conn-error-message {
+  color: var(--color-text-secondary, var(--color-muted));
 }
 
 /* Expand / Tools */

--- a/apps/frontend/src/types/mcp.ts
+++ b/apps/frontend/src/types/mcp.ts
@@ -9,6 +9,7 @@ export interface MCPServer {
   };
   connected: boolean;
   toolCount: number;
+  error: string | null;
 }
 
 export interface MCPTool {

--- a/packages/connectors/src/mcp/registry.ts
+++ b/packages/connectors/src/mcp/registry.ts
@@ -31,6 +31,7 @@ function classifyTool(toolName: string): { riskClass: "A" | "B" | "C"; autoAppro
 
 export class MCPServerRegistry {
   private servers = new Map<string, { config: MCPServerConfig; connector: MCPConnector }>();
+  private connectionErrors = new Map<string, string>();
   private policyEngine: PolicyEngine | undefined;
   private db?: WaibDatabase;
 
@@ -57,6 +58,7 @@ export class MCPServerRegistry {
     if (entry.connector.isConnected()) {
       await this.disconnectServer(id);
     }
+    this.connectionErrors.delete(id);
     this.servers.delete(id);
   }
 
@@ -66,8 +68,16 @@ export class MCPServerRegistry {
     if (!entry) {
       throw new Error(`MCP server "${id}" not found`);
     }
-    await entry.connector.connect();
-    this.generatePolicyRules(id, entry.connector.getDiscoveredTools());
+    try {
+      await entry.connector.connect();
+      // Clear any previous connection error on success
+      this.connectionErrors.delete(id);
+      this.generatePolicyRules(id, entry.connector.getDiscoveredTools());
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.connectionErrors.set(id, message);
+      throw error;
+    }
   }
 
   /** Disconnect from a specific server and remove its policy rules. */
@@ -77,15 +87,17 @@ export class MCPServerRegistry {
       throw new Error(`MCP server "${id}" not found`);
     }
     this.removePolicyRules(id);
+    this.connectionErrors.delete(id);
     await entry.connector.disconnect();
   }
 
   /** Get status of all servers. */
-  getServers(): Array<{ config: MCPServerConfig; connected: boolean; toolCount: number }> {
+  getServers(): Array<{ config: MCPServerConfig; connected: boolean; toolCount: number; error: string | null }> {
     return Array.from(this.servers.values()).map(({ config, connector }) => ({
       config,
       connected: connector.isConnected(),
       toolCount: connector.getDiscoveredTools().length,
+      error: this.connectionErrors.get(config.id) ?? null,
     }));
   }
 


### PR DESCRIPTION
## Summary
- **Tracks connection errors** per server in `MCPServerRegistry` (clears on successful connect/disconnect/remove)
- **Returns error details** in the `GET /api/mcp/servers` response (`error: string | null` field)
- **Shows actionable error messages** in the ConnectionManager settings page with warning styling
- **Displays failed-service errors** on the HomePage via the existing `ErrorSurface` component
- **Improves error-to-message mapping** for common failures: `ECONNREFUSED` (server not running), `ENOENT` (command not found), timeouts, DNS failures, auth errors

## What was happening
When MCP server connections failed (e.g., server not installed, port not listening), the error was caught in the backend startup loop and logged to `console.warn` only. The frontend received `connected: false` with no explanation. Users saw broken/disconnected services with no way to diagnose or fix the issue.

## Test plan
- [ ] Configure an MCP server with an invalid command (e.g., `nonexistent-binary`) and verify the Settings page shows "Command not found" error
- [ ] Configure an SSE server pointing to a closed port and verify "Connection refused on port X" message
- [ ] Verify the HomePage shows an ErrorSurface banner when servers fail at startup
- [ ] Successfully connect a server and verify the error clears
- [ ] Disconnect and reconnect - verify error state resets properly

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)