### PR TITLE
fix: ActionExecutor executes approved actions via connectors

### DIFF
--- a/packages/agents/src/execution/action-executor.ts
+++ b/packages/agents/src/execution/action-executor.ts
@@ -1,15 +1,16 @@
-import type { AgentOutput, PolicyDecision } from "@waibspace/types";
-import type { ConnectorRegistry } from "@waibspace/connectors";
+import type { AgentOutput } from "@waibspace/types";
+import type { ConnectorRegistry, ConnectorAction } from "@waibspace/connectors";
 import { SurfaceFactory } from "@waibspace/surfaces";
 import { BaseAgent } from "../base-agent";
 import type { AgentInput, AgentContext } from "../types";
+import { pendingActionStore } from "./pending-action-store";
 
 /**
  * Executes approved actions by invoking the appropriate connector.
  *
  * Handles `policy.approval.response` events. When the user approves an action,
- * this agent retrieves the pending action context from the event payload and
- * executes it through the relevant connector.
+ * this agent retrieves the pending action from the store (keyed by approvalId)
+ * and executes it through the relevant connector.
  */
 export class ActionExecutorAgent extends BaseAgent {
   constructor() {
@@ -37,6 +38,9 @@ export class ActionExecutorAgent extends BaseAgent {
 
     if (!approved) {
       this.log("Action denied by user", { approvalId });
+
+      // Clean up the pending action
+      pendingActionStore.remove(approvalId);
 
       // Build a confirmation surface showing the action was denied
       const confirmSurface = SurfaceFactory.generic(
@@ -84,36 +88,191 @@ export class ActionExecutorAgent extends BaseAgent {
       );
     }
 
-    // For the MVP, we build a confirmation surface
-    // In a full implementation, we'd retrieve the pending action details
-    // from a store keyed by approvalId and execute via the connector
-    const confirmSurface = SurfaceFactory.generic(
-      "Action Executed",
-      {
-        message: "The approved action has been executed successfully.",
+    // Look up the pending action stored when the approval surface was created
+    const pendingAction = pendingActionStore.get(approvalId);
+
+    if (!pendingAction) {
+      this.log("No pending action found for approvalId", { approvalId });
+      return this.buildResult(
+        `No pending action found for approval "${approvalId}". It may have expired.`,
+        false,
+        startMs,
+      );
+    }
+
+    // Remove from store now that we're executing (prevents duplicate execution)
+    pendingActionStore.remove(approvalId);
+
+    // Look up the connector
+    const connector = registry.get(pendingAction.connectorId);
+
+    if (!connector) {
+      this.log("Connector not found", {
+        connectorId: pendingAction.connectorId,
         approvalId,
-        status: "executed",
-      },
-      {
-        sourceType: "system",
-        sourceId: this.id,
-        trustLevel: "trusted",
-        timestamp: startMs,
-        freshness: "realtime",
-        dataState: "raw",
-      },
-    );
+      });
+      return this.buildResult(
+        `Connector "${pendingAction.connectorId}" not found in registry`,
+        false,
+        startMs,
+      );
+    }
 
-    const endMs = Date.now();
-
-    return {
-      ...this.createOutput(
-        { surfaceSpec: confirmSurface, status: "executed", approvalId },
-        1.0,
-        { sourceType: "system", dataState: "raw", timestamp: startMs },
-      ),
-      timing: { startMs, endMs, durationMs: endMs - startMs },
+    // Build the ConnectorAction with an approved policy decision
+    const connectorAction: ConnectorAction = {
+      operation: pendingAction.operation,
+      params: pendingAction.params,
+      policyDecision: {
+        action: pendingAction.actionType,
+        riskClass: "C",
+        verdict: "approved",
+        reason: `User approved action (approvalId: ${approvalId})`,
+      },
+      traceId: context.traceId,
     };
+
+    this.log("Executing action via connector", {
+      connectorId: pendingAction.connectorId,
+      operation: pendingAction.operation,
+      approvalId,
+    });
+
+    try {
+      const result = await connector.execute(connectorAction);
+
+      if (!result.success) {
+        this.log("Connector execution failed", {
+          approvalId,
+          error: result.error,
+        });
+
+        const errorSurface = SurfaceFactory.generic(
+          "Action Failed",
+          {
+            message: result.error ?? "The action could not be completed.",
+            approvalId,
+            status: "error",
+            operation: pendingAction.operation,
+            connectorId: pendingAction.connectorId,
+          },
+          {
+            sourceType: "system",
+            sourceId: this.id,
+            trustLevel: "trusted",
+            timestamp: startMs,
+            freshness: "realtime",
+            dataState: "raw",
+          },
+        );
+
+        const endMs = Date.now();
+        return {
+          ...this.createOutput(
+            { surfaceSpec: errorSurface, status: "error", approvalId, error: result.error },
+            0.5,
+            { sourceType: "system", dataState: "raw", timestamp: startMs },
+          ),
+          timing: { startMs, endMs, durationMs: endMs - startMs },
+        };
+      }
+
+      this.log("Action executed successfully", {
+        approvalId,
+        result: result.result,
+      });
+
+      const successSurface = SurfaceFactory.generic(
+        "Action Executed",
+        {
+          message: this.describeSuccess(pendingAction.operation, result.result),
+          approvalId,
+          status: "executed",
+          operation: pendingAction.operation,
+          connectorId: pendingAction.connectorId,
+          result: result.result,
+        },
+        {
+          sourceType: "system",
+          sourceId: this.id,
+          trustLevel: "trusted",
+          timestamp: startMs,
+          freshness: "realtime",
+          dataState: "raw",
+        },
+      );
+
+      const endMs = Date.now();
+      return {
+        ...this.createOutput(
+          { surfaceSpec: successSurface, status: "executed", approvalId },
+          1.0,
+          { sourceType: "system", dataState: "raw", timestamp: startMs },
+        ),
+        timing: { startMs, endMs, durationMs: endMs - startMs },
+      };
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      this.log("Connector execution threw an error", {
+        approvalId,
+        error: errorMsg,
+      });
+
+      const errorSurface = SurfaceFactory.generic(
+        "Action Failed",
+        {
+          message: `An unexpected error occurred: ${errorMsg}`,
+          approvalId,
+          status: "error",
+          operation: pendingAction.operation,
+          connectorId: pendingAction.connectorId,
+        },
+        {
+          sourceType: "system",
+          sourceId: this.id,
+          trustLevel: "trusted",
+          timestamp: startMs,
+          freshness: "realtime",
+          dataState: "raw",
+        },
+      );
+
+      const endMs = Date.now();
+      return {
+        ...this.createOutput(
+          { surfaceSpec: errorSurface, status: "error", approvalId, error: errorMsg },
+          0.5,
+          { sourceType: "system", dataState: "raw", timestamp: startMs },
+        ),
+        timing: { startMs, endMs, durationMs: endMs - startMs },
+      };
+    }
+  }
+
+  /**
+   * Generate a human-readable success message based on the operation.
+   */
+  private describeSuccess(operation: string, result: unknown): string {
+    const r = result as Record<string, unknown> | undefined;
+
+    switch (operation) {
+      case "send-email": {
+        const messageId = r?.messageId ?? "unknown";
+        return `Email sent successfully (message ID: ${messageId}).`;
+      }
+      case "create-draft": {
+        const draftId = r?.draftId ?? "unknown";
+        return `Draft created successfully (draft ID: ${draftId}).`;
+      }
+      case "create-event": {
+        const summary = r?.summary ?? (r as Record<string, unknown>)?.summary ?? "event";
+        return `Calendar event "${summary}" created successfully.`;
+      }
+      case "update-event": {
+        return "Calendar event updated successfully.";
+      }
+      default:
+        return "The approved action has been executed successfully.";
+    }
   }
 
   private buildResult(

--- a/packages/agents/src/execution/index.ts
+++ b/packages/agents/src/execution/index.ts
@@ -1,1 +1,3 @@
 export { ActionExecutorAgent } from "./action-executor";
+export { pendingActionStore } from "./pending-action-store";
+export type { PendingAction } from "./pending-action-store";

--- a/packages/agents/src/execution/pending-action-store.ts
+++ b/packages/agents/src/execution/pending-action-store.ts
@@ -1,0 +1,60 @@
+/**
+ * In-memory store for pending actions awaiting user approval.
+ *
+ * When a PolicyGateAgent decision requires approval, the ApprovalSurfaceAgent
+ * stores the action details here keyed by approvalId. When the user approves,
+ * the ActionExecutorAgent retrieves and executes the action via the connector.
+ *
+ * Entries expire after a configurable TTL (default 30 minutes) to avoid
+ * unbounded memory growth.
+ */
+
+export interface PendingAction {
+  approvalId: string;
+  connectorId: string;
+  operation: string;
+  params: Record<string, unknown>;
+  actionType: string;
+  createdAt: number;
+}
+
+const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+class PendingActionStoreImpl {
+  private store = new Map<string, PendingAction>();
+  private ttlMs: number;
+
+  constructor(ttlMs = DEFAULT_TTL_MS) {
+    this.ttlMs = ttlMs;
+  }
+
+  set(action: PendingAction): void {
+    this.evictExpired();
+    this.store.set(action.approvalId, action);
+  }
+
+  get(approvalId: string): PendingAction | undefined {
+    this.evictExpired();
+    return this.store.get(approvalId);
+  }
+
+  remove(approvalId: string): boolean {
+    return this.store.delete(approvalId);
+  }
+
+  /** Remove all expired entries. */
+  private evictExpired(): void {
+    const now = Date.now();
+    for (const [id, action] of this.store) {
+      if (now - action.createdAt > this.ttlMs) {
+        this.store.delete(id);
+      }
+    }
+  }
+}
+
+/**
+ * Singleton pending-action store shared between ApprovalSurfaceAgent
+ * and ActionExecutorAgent.
+ */
+export const pendingActionStore = new PendingActionStoreImpl();

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -43,4 +43,5 @@ export {
   LayoutComposerAgent,
   extractSurfaces,
 } from "./ui";
-export { ActionExecutorAgent } from "./execution";
+export { ActionExecutorAgent, pendingActionStore } from "./execution";
+export type { PendingAction } from "./execution";

--- a/packages/agents/src/ui/approval-surface.ts
+++ b/packages/agents/src/ui/approval-surface.ts
@@ -5,6 +5,74 @@ import {
 } from "@waibspace/surfaces";
 import { BaseAgent } from "../base-agent";
 import type { AgentInput, AgentContext } from "../types";
+import { pendingActionStore } from "../execution/pending-action-store";
+
+/**
+ * Map action types (from PolicyGateAgent) to connector IDs and operations.
+ *
+ * Action types use a "service.verb" convention (e.g. "email.send",
+ * "calendar.create"). This mapping translates them to the connector ID
+ * and operation name that the connector understands.
+ */
+function resolveConnectorAction(
+  actionType: string,
+  context: Record<string, unknown>,
+): { connectorId: string; operation: string; params: Record<string, unknown> } | undefined {
+  if (actionType === "email.send") {
+    return {
+      connectorId: "gmail",
+      operation: "send-email",
+      params: {
+        to: context.to ?? context.from,
+        subject: context.subject,
+        body: context.body ?? context.replyBody ?? context.draftBody,
+        draftId: context.draftId,
+        inReplyTo: context.inReplyTo ?? context.messageId,
+      },
+    };
+  }
+
+  if (actionType === "email.draft") {
+    return {
+      connectorId: "gmail",
+      operation: "create-draft",
+      params: {
+        to: context.to ?? context.from,
+        subject: context.subject,
+        body: context.body ?? context.draftBody,
+        inReplyTo: context.inReplyTo ?? context.messageId,
+      },
+    };
+  }
+
+  if (actionType === "calendar.create") {
+    return {
+      connectorId: "google-calendar",
+      operation: "create-event",
+      params: {
+        summary: context.summary ?? context.title,
+        start: context.start ?? context.startTime,
+        end: context.end ?? context.endTime,
+        description: context.description,
+        attendees: context.attendees,
+        location: context.location,
+      },
+    };
+  }
+
+  if (actionType === "calendar.update") {
+    return {
+      connectorId: "google-calendar",
+      operation: "update-event",
+      params: {
+        eventId: context.eventId,
+        updates: context.updates ?? context,
+      },
+    };
+  }
+
+  return undefined;
+}
 
 export class ApprovalSurfaceAgent extends BaseAgent {
   constructor() {
@@ -50,6 +118,32 @@ export class ApprovalSurfaceAgent extends BaseAgent {
       },
       consequences,
     };
+
+    // Store the pending action so the ActionExecutorAgent can execute it
+    // when the user approves.
+    const actionContext = (policyDecision.requiredApproval?.context ?? {}) as Record<string, unknown>;
+    const resolved = resolveConnectorAction(policyDecision.action, actionContext);
+
+    if (resolved) {
+      pendingActionStore.set({
+        approvalId,
+        connectorId: resolved.connectorId,
+        operation: resolved.operation,
+        params: resolved.params,
+        actionType: policyDecision.action,
+        createdAt: Date.now(),
+      });
+      this.log("Stored pending action for approval", {
+        approvalId,
+        connectorId: resolved.connectorId,
+        operation: resolved.operation,
+      });
+    } else {
+      this.log("Could not resolve connector action for action type", {
+        actionType: policyDecision.action,
+        approvalId,
+      });
+    }
 
     const surfaceSpec = SurfaceFactory.approval(surfaceData);
 


### PR DESCRIPTION
## Summary
- **Added `PendingActionStore`**: an in-memory store with TTL expiry that maps `approvalId` to action details (connector ID, operation, params). Shared between `ApprovalSurfaceAgent` and `ActionExecutorAgent` as a singleton.
- **Updated `ApprovalSurfaceAgent`** to store pending actions when creating approval surfaces. Maps policy action types (`email.send`, `email.draft`, `calendar.create`, `calendar.update`) to their corresponding connector operations via `resolveConnectorAction()`.
- **Updated `ActionExecutorAgent`** to look up pending actions by `approvalId`, execute them through the connector registry, and return meaningful result surfaces (success, failure, or error). Removes the pending action before execution to prevent duplicates.

Closes #187

## Test plan
- [x] Existing e2e tests pass (26/27 — the 1 pre-existing failure is unrelated to this change)
- [x] No new TypeScript errors introduced (verified with `tsc --noEmit`)
- [ ] Manual test: trigger an email send approval flow and verify the email is actually sent via the Gmail connector
- [ ] Manual test: trigger a calendar create approval flow and verify the event is created
- [ ] Verify denied actions clean up from the pending store and show denial surface
- [ ] Verify expired pending actions (>30 min) return a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)