### PR TITLE
feat: add error boundary for graceful block failure recovery

### DIFF
--- a/apps/frontend/src/blocks/WaibRenderer.tsx
+++ b/apps/frontend/src/blocks/WaibRenderer.tsx
@@ -22,6 +22,7 @@ import { BlockStateProvider, BlockStateContext } from "./BlockStateStore";
 import { ObservationWrapper } from "./ObservationWrapper";
 import { getBlockComponent } from "./registry";
 import { registerPrimitiveBlocks, registerDomainComponents, FallbackBlock } from "./components";
+import { BlockErrorBoundary } from "../components/BlockErrorBoundary";
 
 // ---------------------------------------------------------------------------
 // WaibRenderer — top-level entry point
@@ -142,8 +143,10 @@ function BlockNode({ block, send }: BlockNodeProps) {
   }
 
   return (
-    <ObservationWrapper block={block} onExecuteAction={handleExecuteAction}>
-      <Component block={block} onEvent={handleEvent}>{childNodes}</Component>
-    </ObservationWrapper>
+    <BlockErrorBoundary blockId={block.id}>
+      <ObservationWrapper block={block} onExecuteAction={handleExecuteAction}>
+        <Component block={block} onEvent={handleEvent}>{childNodes}</Component>
+      </ObservationWrapper>
+    </BlockErrorBoundary>
   );
 }

--- a/apps/frontend/src/components/BlockErrorBoundary.tsx
+++ b/apps/frontend/src/components/BlockErrorBoundary.tsx
@@ -1,0 +1,87 @@
+/**
+ * BlockErrorBoundary — Catches render errors in individual blocks
+ *
+ * Wraps each block in an error boundary so that a single broken block
+ * does not tear down the entire surface grid. Shows a compact fallback
+ * card with the error message and a retry button that resets the boundary.
+ */
+
+import { Component, type ReactNode } from "react";
+
+// ---------------------------------------------------------------------------
+// Props & State
+// ---------------------------------------------------------------------------
+
+interface BlockErrorBoundaryProps {
+  /** Unique key for the block being wrapped (used in error reporting). */
+  blockId?: string;
+  children: ReactNode;
+}
+
+interface BlockErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export class BlockErrorBoundary extends Component<
+  BlockErrorBoundaryProps,
+  BlockErrorBoundaryState
+> {
+  constructor(props: BlockErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): BlockErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    if (import.meta.env.DEV) {
+      console.error(
+        `[BlockErrorBoundary] Block "${this.props.blockId ?? "unknown"}" crashed:`,
+        error,
+        info.componentStack,
+      );
+    }
+  }
+
+  private handleRetry = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      const message =
+        this.state.error?.message ?? "An unexpected error occurred.";
+
+      return (
+        <div className="block-error" role="alert">
+          <div className="block-error__icon" aria-hidden="true">
+            !
+          </div>
+          <div className="block-error__body">
+            <p className="block-error__title">Block failed to render</p>
+            <p className="block-error__message">{message}</p>
+            {this.props.blockId && (
+              <p className="block-error__code">{this.props.blockId}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            className="block-error__retry"
+            onClick={this.handleRetry}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/frontend/src/styles/block-error.css
+++ b/apps/frontend/src/styles/block-error.css
@@ -1,0 +1,84 @@
+/* ================================ */
+/* BlockErrorBoundary Fallback      */
+/* ================================ */
+
+.block-error {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  background: var(--color-danger-subtle);
+  border: var(--block-card-border);
+  border-left: 3px solid var(--color-danger);
+  border-radius: var(--block-card-radius);
+  box-shadow: var(--block-card-shadow);
+}
+
+.block-error__icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  color: var(--color-danger-text);
+  background: var(--color-danger-subtle);
+  border: 1px solid var(--color-danger);
+  border-radius: 50%;
+  line-height: 1;
+}
+
+.block-error__body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.block-error__title {
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  line-height: var(--leading-tight);
+  margin: 0;
+}
+
+.block-error__message {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+  margin: 0;
+}
+
+.block-error__code {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  margin: var(--space-1) 0 0;
+}
+
+.block-error__retry {
+  flex-shrink: 0;
+  align-self: center;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.block-error__retry:hover {
+  background: var(--color-surface-active);
+  border-color: var(--color-danger);
+}
+
+.block-error__retry:active {
+  background: var(--color-surface);
+}

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -1,3 +1,4 @@
+@import "./block-error.css";
 @import "./calendar-components.css";
 @import "./error-surface.css";
 


### PR DESCRIPTION
## Summary
- Adds a `BlockErrorBoundary` React class component that catches render errors in individual blocks
- Shows a compact fallback card with error message, block ID, and a retry button that resets the boundary
- Wraps each `BlockNode` in `WaibRenderer` so a single broken block does not tear down the entire surface grid
- CSS follows existing BEM naming and custom property patterns (modeled after `error-surface.css`)

Closes #223

## Test plan
- [ ] Verify normal blocks render unchanged
- [ ] Simulate a render error in a block component and confirm the fallback card appears
- [ ] Click the retry button and confirm the block attempts to re-render
- [ ] Confirm other blocks on the page remain functional when one block crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)