### PR TITLE
feat: add WebSocket reconnection with pending message queue

### DIFF
--- a/apps/frontend/src/hooks/useWebSocket.ts
+++ b/apps/frontend/src/hooks/useWebSocket.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 
-export type ConnectionStatus = "connecting" | "connected" | "disconnected";
+export type ConnectionStatus =
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "disconnected";
 
 export interface WebSocketMessage {
   type: string;
@@ -11,31 +15,84 @@ export interface UseWebSocketReturn {
   send: (type: string, payload?: unknown) => void;
   lastMessage: WebSocketMessage | null;
   status: ConnectionStatus;
+  /** Number of queued messages waiting to be sent on reconnect. */
+  pendingCount: number;
+}
+
+/** Maximum reconnection attempts before giving up. */
+const MAX_RETRIES = 10;
+
+/** Maximum number of messages to buffer while disconnected. */
+const MAX_QUEUE_SIZE = 50;
+
+interface QueuedMessage {
+  type: string;
+  payload: unknown;
 }
 
 /**
  * Connect to a backend WebSocket on mount.
- * Auto-reconnects on disconnect with exponential backoff.
+ * Auto-reconnects on disconnect with exponential backoff (up to MAX_RETRIES).
+ * Messages sent while disconnected are queued and flushed on reconnect.
  */
 export function useWebSocket(url: string): UseWebSocketReturn {
   const [status, setStatus] = useState<ConnectionStatus>("disconnected");
   const [lastMessage, setLastMessage] = useState<WebSocketMessage | null>(null);
+  const [pendingCount, setPendingCount] = useState(0);
 
   const wsRef = useRef<WebSocket | null>(null);
   const retriesRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const urlRef = useRef(url);
+  const queueRef = useRef<QueuedMessage[]>([]);
+  const hasConnectedRef = useRef(false);
+  /** Guard against scheduling multiple reconnects from concurrent close/error. */
+  const reconnectScheduledRef = useRef(false);
+
   urlRef.current = url;
 
+  const flushQueue = useCallback((ws: WebSocket) => {
+    const pending = queueRef.current.splice(0);
+    setPendingCount(0);
+    for (const msg of pending) {
+      try {
+        ws.send(JSON.stringify(msg));
+      } catch {
+        // If send fails mid-flush, re-queue remaining messages
+        queueRef.current.unshift(msg);
+        setPendingCount(queueRef.current.length);
+        break;
+      }
+    }
+  }, []);
+
   const connect = useCallback(() => {
-    setStatus("connecting");
+    // Prevent duplicate connections
+    const existing = wsRef.current;
+    if (
+      existing &&
+      (existing.readyState === WebSocket.CONNECTING ||
+        existing.readyState === WebSocket.OPEN)
+    ) {
+      return;
+    }
+
+    reconnectScheduledRef.current = false;
+
+    setStatus(hasConnectedRef.current ? "reconnecting" : "connecting");
 
     const ws = new WebSocket(urlRef.current);
     wsRef.current = ws;
 
     ws.addEventListener("open", () => {
       retriesRef.current = 0;
+      hasConnectedRef.current = true;
       setStatus("connected");
+
+      // Flush any messages that were queued while disconnected
+      if (queueRef.current.length > 0) {
+        flushQueue(ws);
+      }
     });
 
     ws.addEventListener("message", (event) => {
@@ -55,9 +112,20 @@ export function useWebSocket(url: string): UseWebSocketReturn {
     ws.addEventListener("error", () => {
       ws.close();
     });
-  }, []);
+  }, [flushQueue]);
 
   function scheduleReconnect() {
+    if (reconnectScheduledRef.current) return;
+
+    if (retriesRef.current >= MAX_RETRIES) {
+      console.warn(
+        `[useWebSocket] Max retries (${MAX_RETRIES}) reached. Giving up.`,
+      );
+      setStatus("disconnected");
+      return;
+    }
+
+    reconnectScheduledRef.current = true;
     const delay = Math.min(1000 * 2 ** retriesRef.current, 30_000);
     retriesRef.current += 1;
     timerRef.current = setTimeout(connect, delay);
@@ -72,10 +140,24 @@ export function useWebSocket(url: string): UseWebSocketReturn {
   }, [connect]);
 
   const send = useCallback((type: string, payload?: unknown) => {
+    const msg: QueuedMessage = { type, payload };
+
     if (wsRef.current?.readyState === WebSocket.OPEN) {
-      wsRef.current.send(JSON.stringify({ type, payload }));
+      wsRef.current.send(JSON.stringify(msg));
+      return;
+    }
+
+    // Queue the message for later delivery
+    if (queueRef.current.length < MAX_QUEUE_SIZE) {
+      queueRef.current.push(msg);
+      setPendingCount(queueRef.current.length);
+    } else {
+      console.warn(
+        `[useWebSocket] Message queue full (${MAX_QUEUE_SIZE}). Dropping message:`,
+        type,
+      );
     }
   }, []);
 
-  return { send, lastMessage, status };
+  return { send, lastMessage, status, pendingCount };
 }

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -29,7 +29,7 @@ interface FailedService {
 }
 
 export default function HomePage() {
-  const { send, lastMessage, status } = useWebSocket(WS_URL);
+  const { send, lastMessage, status, pendingCount } = useWebSocket(WS_URL);
   const location = useLocation();
   const [layout, setLayout] = useState<ComposedLayout | null>(null);
   const [agents, setAgents] = useState<AgentStatusType[]>([]);
@@ -211,24 +211,28 @@ export default function HomePage() {
   return (
     <div className="page home-page">
       {status !== "connected" && (
-        <div className={`connection-banner ${status}`}>
+        <div className={`connection-banner ${status === "reconnecting" ? "connecting" : status}`}>
           <span className="connection-banner-icon">!</span>
           {status === "connecting"
-            ? "Reconnecting to server..."
-            : "Connection lost. Attempting to reconnect..."}
+            ? "Connecting to server..."
+            : status === "reconnecting"
+              ? `Reconnecting to server...${pendingCount > 0 ? ` (${pendingCount} pending)` : ""}`
+              : "Connection lost. Retries exhausted."}
         </div>
       )}
 
       <div className="home-status-bar">
         <span
-          className={`connection-dot ${status === "connected" ? "connected" : status === "connecting" ? "connecting" : "disconnected"}`}
+          className={`connection-dot ${status === "connected" ? "connected" : status === "reconnecting" || status === "connecting" ? "connecting" : "disconnected"}`}
         />
         <span className="connection-label">
           {status === "connected"
             ? "Connected"
             : status === "connecting"
               ? "Connecting..."
-              : "Disconnected"}
+              : status === "reconnecting"
+                ? "Reconnecting..."
+                : "Disconnected"}
         </span>
         <AgentStatus agents={agents} />
       </div>

--- a/apps/frontend/src/pages/IntentResolutionPage.tsx
+++ b/apps/frontend/src/pages/IntentResolutionPage.tsx
@@ -118,7 +118,7 @@ export default function IntentResolutionPage() {
         </div>
         <div className="intent-status-bar">
           <span
-            className={`connection-dot ${status === "connected" ? "connected" : status === "connecting" ? "connecting" : "disconnected"}`}
+            className={`connection-dot ${status === "connected" ? "connected" : status === "reconnecting" || status === "connecting" ? "connecting" : "disconnected"}`}
           />
           <AgentStatus agents={agents} />
         </div>
@@ -142,9 +142,9 @@ export default function IntentResolutionPage() {
               Agents working on your request
             </p>
           )}
-          {status === "connecting" && (
+          {(status === "connecting" || status === "reconnecting") && (
             <p className="intent-loading-agents">
-              Connecting to backend...
+              {status === "reconnecting" ? "Reconnecting to backend..." : "Connecting to backend..."}
             </p>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Adds exponential backoff reconnection to `useWebSocket` with a max retry limit of 10 attempts before giving up
- Queues messages sent while disconnected (up to 50) and flushes them on reconnect so user actions are not lost
- Introduces a `reconnecting` connection status distinct from the initial `connecting` state, with a UI banner showing pending message count

## Changes
- `apps/frontend/src/hooks/useWebSocket.ts` — core reconnection logic, message queue, max retries, duplicate connection guard
- `apps/frontend/src/pages/HomePage.tsx` — updated banner and status dot to handle `reconnecting` status and display `pendingCount`
- `apps/frontend/src/pages/IntentResolutionPage.tsx` — updated status dot and loading text for `reconnecting` status

## Test plan
- [ ] Verify initial connection works as before (status goes connecting -> connected)
- [ ] Kill the backend server and confirm the banner shows "Reconnecting to server..."
- [ ] Send a message while disconnected, restart backend, confirm the queued message is delivered
- [ ] Verify reconnection stops after 10 failed attempts with "Connection lost. Retries exhausted."
- [ ] Confirm the pending count badge appears when messages are queued during disconnect

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)