### PR TITLE
feat: add validation for MCP tool response schemas

### DIFF
--- a/packages/connectors/src/mcp/index.ts
+++ b/packages/connectors/src/mcp/index.ts
@@ -3,3 +3,9 @@ export { MCPServerRegistry } from "./registry";
 export type { MCPServerConfig, MCPToolInfo } from "./types";
 export { MCP_SERVER_CATALOG, findTemplate, searchCatalog } from "./catalog";
 export type { MCPServerTemplate, MCPCredentialSpec } from "./catalog";
+export {
+  validateResponse,
+  extractPayload,
+  KNOWN_SCHEMAS,
+} from "./validation";
+export type { ResponseSchema, ValidationResult } from "./validation";

--- a/packages/connectors/src/mcp/mcp-connector.ts
+++ b/packages/connectors/src/mcp/mcp-connector.ts
@@ -9,6 +9,11 @@ import type {
   ConnectorResult,
 } from "../types";
 import type { MCPServerConfig, MCPToolInfo } from "./types";
+import {
+  KNOWN_SCHEMAS,
+  extractPayload,
+  validateResponse,
+} from "./validation";
 
 export class MCPConnector extends BaseConnector {
   private client: Client | null = null;
@@ -188,7 +193,31 @@ export class MCPConnector extends BaseConnector {
         name: toolName,
         arguments: args,
       });
-      return result.content;
+
+      const content = result.content;
+
+      // Validate response against known schema (if one exists)
+      const schema = KNOWN_SCHEMAS[toolName];
+      if (schema) {
+        try {
+          const payload = extractPayload(content);
+          const validation = validateResponse(payload, schema);
+          if (!validation.valid) {
+            this.log(
+              `Validation warnings for "${toolName}": ${validation.warnings.join("; ")}`,
+            );
+          }
+        } catch (validationError) {
+          // Never let validation itself crash the pipeline
+          const msg =
+            validationError instanceof Error
+              ? validationError.message
+              : String(validationError);
+          this.log(`Validation error for "${toolName}": ${msg}`);
+        }
+      }
+
+      return content;
     } catch (error) {
       // If the server process crashed, mark as disconnected
       this.connected = false;

--- a/packages/connectors/src/mcp/validation.test.ts
+++ b/packages/connectors/src/mcp/validation.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateResponse,
+  extractPayload,
+  KNOWN_SCHEMAS,
+  type ResponseSchema,
+} from "./validation";
+
+// ---------------------------------------------------------------------------
+// extractPayload
+// ---------------------------------------------------------------------------
+describe("extractPayload", () => {
+  it("parses JSON from an MCP text content block", () => {
+    const content = [{ type: "text", text: '{"id":"1","subject":"Hello"}' }];
+    expect(extractPayload(content)).toEqual({ id: "1", subject: "Hello" });
+  });
+
+  it("returns raw text when JSON parsing fails", () => {
+    const content = [{ type: "text", text: "not json" }];
+    expect(extractPayload(content)).toBe("not json");
+  });
+
+  it("returns non-array content as-is", () => {
+    expect(extractPayload("hello")).toBe("hello");
+    expect(extractPayload(42)).toBe(42);
+  });
+
+  it("returns content as-is when no text block found", () => {
+    const content = [{ type: "image", data: "..." }];
+    expect(extractPayload(content)).toEqual(content);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateResponse — generic
+// ---------------------------------------------------------------------------
+describe("validateResponse", () => {
+  const emailListSchema: ResponseSchema = {
+    description: "test email list",
+    isArray: true,
+    fields: {
+      id: { type: "string", required: true },
+      from: { type: "string", required: true },
+      subject: { type: "string", required: true },
+      snippet: { type: "string", required: false },
+    },
+  };
+
+  it("returns valid for a correct array response", () => {
+    const data = [
+      { id: "1", from: "a@b.com", subject: "Hi", snippet: "..." },
+      { id: "2", from: "c@d.com", subject: "Re: Hi" },
+    ];
+    const result = validateResponse(data, emailListSchema);
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("warns when required field is missing", () => {
+    const data = [{ id: "1", from: "a@b.com" }]; // missing subject
+    const result = validateResponse(data, emailListSchema);
+    expect(result.valid).toBe(false);
+    expect(result.warnings).toContainEqual(
+      expect.stringContaining("subject"),
+    );
+  });
+
+  it("warns when field has wrong type", () => {
+    const data = [{ id: 123, from: "a@b.com", subject: "Hi" }];
+    const result = validateResponse(data, emailListSchema);
+    expect(result.valid).toBe(false);
+    expect(result.warnings).toContainEqual(
+      expect.stringContaining("expected string"),
+    );
+  });
+
+  it("warns when expected array but got object", () => {
+    const result = validateResponse({ id: "1" }, emailListSchema);
+    expect(result.valid).toBe(false);
+    expect(result.warnings[0]).toContain("Expected array");
+  });
+
+  it("handles null response", () => {
+    const result = validateResponse(null, emailListSchema);
+    expect(result.valid).toBe(false);
+    expect(result.warnings[0]).toContain("null");
+  });
+
+  it("handles undefined response", () => {
+    const result = validateResponse(undefined, emailListSchema);
+    expect(result.valid).toBe(false);
+    expect(result.warnings[0]).toContain("undefined");
+  });
+
+  it("validates a single-object schema", () => {
+    const schema: ResponseSchema = {
+      description: "single email",
+      isArray: false,
+      fields: {
+        id: { type: "string", required: true },
+        body: { type: "string", required: false },
+      },
+    };
+    const result = validateResponse({ id: "abc" }, schema);
+    expect(result.valid).toBe(true);
+  });
+
+  it("limits array validation to first 5 items", () => {
+    // Create 10 items where items 6-10 are invalid
+    const data = Array.from({ length: 10 }, (_, i) => ({
+      id: i < 5 ? String(i) : 999, // items 5-9 have wrong type
+      from: "a@b.com",
+      subject: "Test",
+    }));
+    const result = validateResponse(data, emailListSchema);
+    // Should only have checked first 5 items (all valid)
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// KNOWN_SCHEMAS sanity check
+// ---------------------------------------------------------------------------
+describe("KNOWN_SCHEMAS", () => {
+  it("has schemas for core Gmail operations", () => {
+    expect(KNOWN_SCHEMAS.listEmails).toBeDefined();
+    expect(KNOWN_SCHEMAS.getEmail).toBeDefined();
+    expect(KNOWN_SCHEMAS.searchEmails).toBeDefined();
+    expect(KNOWN_SCHEMAS.sendEmail).toBeDefined();
+  });
+
+  it("has schemas for core Calendar operations", () => {
+    expect(KNOWN_SCHEMAS.listEvents).toBeDefined();
+    expect(KNOWN_SCHEMAS.getEvent).toBeDefined();
+    expect(KNOWN_SCHEMAS.createEvent).toBeDefined();
+    expect(KNOWN_SCHEMAS.freeSlots).toBeDefined();
+  });
+
+  it("Gmail listEmails schema validates realistic data", () => {
+    const data = [
+      {
+        id: "msg-1",
+        from: "sender@example.com",
+        subject: "Meeting tomorrow",
+        snippet: "Don't forget about...",
+        date: "2026-03-09T10:00:00Z",
+      },
+    ];
+    const result = validateResponse(data, KNOWN_SCHEMAS.listEmails);
+    expect(result.valid).toBe(true);
+  });
+
+  it("Calendar listEvents schema validates realistic data", () => {
+    const data = [
+      {
+        id: "evt-1",
+        summary: "Team standup",
+        start: "2026-03-09T09:00:00Z",
+        end: "2026-03-09T09:15:00Z",
+        status: "confirmed",
+      },
+    ];
+    const result = validateResponse(data, KNOWN_SCHEMAS.listEvents);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/connectors/src/mcp/validation.ts
+++ b/packages/connectors/src/mcp/validation.ts
@@ -1,0 +1,261 @@
+/**
+ * MCP tool response validation.
+ *
+ * Validates that MCP tool responses conform to expected shapes so that
+ * downstream agents (e.g. InboxSurfaceAgent) don't silently fail on
+ * malformed data. Validation is best-effort: warnings are logged but
+ * data is still passed through to avoid hard failures.
+ */
+
+// ---------------------------------------------------------------------------
+// Core validation helpers
+// ---------------------------------------------------------------------------
+
+export interface ValidationResult {
+  valid: boolean;
+  warnings: string[];
+}
+
+type FieldSpec =
+  | "string"
+  | "number"
+  | "boolean"
+  | "object"
+  | "array"
+  | "any";
+
+interface SchemaField {
+  type: FieldSpec;
+  required: boolean;
+}
+
+export interface ResponseSchema {
+  /** Human-readable description for log messages. */
+  description: string;
+  /**
+   * If true, the response is expected to be an array of objects that each
+   * match `fields`. If false, the response itself is a single object.
+   */
+  isArray: boolean;
+  /** Expected fields on each object (or the single object). */
+  fields: Record<string, SchemaField>;
+}
+
+function checkType(value: unknown, expected: FieldSpec): boolean {
+  if (expected === "any") return true;
+  if (expected === "array") return Array.isArray(value);
+  if (expected === "object")
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  return typeof value === expected;
+}
+
+/**
+ * Validate a single object against a set of field specs.
+ */
+function validateObject(
+  obj: unknown,
+  fields: Record<string, SchemaField>,
+  path: string,
+): string[] {
+  const warnings: string[] = [];
+
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+    warnings.push(`${path}: expected object, got ${typeof obj}`);
+    return warnings;
+  }
+
+  const record = obj as Record<string, unknown>;
+
+  for (const [key, spec] of Object.entries(fields)) {
+    const value = record[key];
+
+    if (value === undefined || value === null) {
+      if (spec.required) {
+        warnings.push(`${path}.${key}: required field is missing`);
+      }
+      continue;
+    }
+
+    if (!checkType(value, spec.type)) {
+      warnings.push(
+        `${path}.${key}: expected ${spec.type}, got ${Array.isArray(value) ? "array" : typeof value}`,
+      );
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Validate an MCP tool response against a schema.
+ *
+ * Returns a ValidationResult. The `valid` flag is false when any warning
+ * is present, but the caller should still forward the data — validation
+ * is advisory, not blocking.
+ */
+export function validateResponse(
+  data: unknown,
+  schema: ResponseSchema,
+): ValidationResult {
+  const warnings: string[] = [];
+
+  if (data === undefined || data === null) {
+    warnings.push(`Response is ${data === null ? "null" : "undefined"}`);
+    return { valid: false, warnings };
+  }
+
+  if (schema.isArray) {
+    if (!Array.isArray(data)) {
+      warnings.push(
+        `Expected array for "${schema.description}", got ${typeof data}`,
+      );
+      return { valid: false, warnings };
+    }
+
+    // Validate up to the first 5 items to keep logs reasonable
+    const limit = Math.min(data.length, 5);
+    for (let i = 0; i < limit; i++) {
+      warnings.push(
+        ...validateObject(data[i], schema.fields, `[${i}]`),
+      );
+    }
+  } else {
+    warnings.push(...validateObject(data, schema.fields, "root"));
+  }
+
+  return { valid: warnings.length === 0, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Known response schemas for common MCP tools (Gmail, Google Calendar)
+// ---------------------------------------------------------------------------
+
+const field = (type: FieldSpec, required = true): SchemaField => ({
+  type,
+  required,
+});
+
+export const KNOWN_SCHEMAS: Record<string, ResponseSchema> = {
+  // Gmail -------------------------------------------------------------------
+  listEmails: {
+    description: "Gmail listEmails",
+    isArray: true,
+    fields: {
+      id: field("string"),
+      from: field("string"),
+      subject: field("string"),
+      snippet: field("string", false),
+      date: field("string"),
+    },
+  },
+  getEmail: {
+    description: "Gmail getEmail",
+    isArray: false,
+    fields: {
+      id: field("string"),
+      from: field("string"),
+      to: field("string"),
+      subject: field("string"),
+      body: field("string", false),
+      date: field("string"),
+    },
+  },
+  searchEmails: {
+    description: "Gmail searchEmails",
+    isArray: true,
+    fields: {
+      id: field("string"),
+      from: field("string"),
+      subject: field("string"),
+      snippet: field("string", false),
+      date: field("string"),
+    },
+  },
+  sendEmail: {
+    description: "Gmail sendEmail",
+    isArray: false,
+    fields: {
+      success: field("boolean", false),
+      messageId: field("string", false),
+    },
+  },
+
+  // Google Calendar ---------------------------------------------------------
+  listEvents: {
+    description: "Calendar listEvents",
+    isArray: true,
+    fields: {
+      id: field("string"),
+      summary: field("string"),
+      start: field("string"),
+      end: field("string"),
+      status: field("string", false),
+    },
+  },
+  getEvent: {
+    description: "Calendar getEvent",
+    isArray: false,
+    fields: {
+      id: field("string"),
+      summary: field("string"),
+      start: field("string"),
+      end: field("string"),
+      location: field("string", false),
+      description: field("string", false),
+      status: field("string", false),
+    },
+  },
+  createEvent: {
+    description: "Calendar createEvent",
+    isArray: false,
+    fields: {
+      id: field("string", false),
+      summary: field("string", false),
+      start: field("string", false),
+      end: field("string", false),
+    },
+  },
+  freeSlots: {
+    description: "Calendar freeSlots",
+    isArray: true,
+    fields: {
+      start: field("string"),
+      end: field("string"),
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Convenience: extract a JSON value from MCP content blocks
+// ---------------------------------------------------------------------------
+
+/**
+ * MCP tool results come back as an array of content blocks. This helper
+ * extracts the first text block and attempts to JSON.parse it so that
+ * schema validation can run against the parsed payload.
+ *
+ * Returns the parsed value or the raw content unchanged if parsing fails.
+ */
+export function extractPayload(content: unknown): unknown {
+  if (!Array.isArray(content)) return content;
+
+  for (const block of content) {
+    if (
+      typeof block === "object" &&
+      block !== null &&
+      (block as Record<string, unknown>).type === "text"
+    ) {
+      const text = (block as Record<string, unknown>).text;
+      if (typeof text === "string") {
+        try {
+          return JSON.parse(text);
+        } catch {
+          return text;
+        }
+      }
+    }
+  }
+
+  // Fallback: return content as-is
+  return content;
+}


### PR DESCRIPTION
## Summary
- Adds shape validation for MCP tool responses at the connector boundary, so downstream agents (e.g. InboxSurfaceAgent) get early warnings instead of silently failing on malformed data
- Defines expected response schemas for Gmail (`listEmails`, `getEmail`, `searchEmails`, `sendEmail`) and Google Calendar (`listEvents`, `getEvent`, `createEvent`, `freeSlots`) operations
- Validation is advisory-only: warnings are logged via the existing `this.log()` pattern but responses are always forwarded, so a validation bug can never crash the pipeline

## Test plan
- [x] 16 unit tests covering `validateResponse`, `extractPayload`, and `KNOWN_SCHEMAS` (all passing)
- [ ] Manual verification: connect a Gmail MCP server and confirm validation warnings appear in logs for any mismatched fields
- [ ] Manual verification: confirm normal tool invocations still work end-to-end with no regressions

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)