### PR TITLE
feat: implement connection test button in Settings

### DIFF
--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -180,6 +180,16 @@ export function startServer(deps: ServerDeps) {
         }
       }
 
+      // POST /api/mcp/servers/:id/test — ping a connected server
+      const testMatch = url.pathname.match(/^\/api\/mcp\/servers\/([^/]+)\/test$/);
+      if (testMatch && req.method === "POST") {
+        if (!deps.mcpRegistry) {
+          return jsonResponse({ error: "MCP registry not available" }, 503);
+        }
+        const result = await deps.mcpRegistry.testServer(testMatch[1]);
+        return jsonResponse(result, result.ok ? 200 : 502);
+      }
+
       // GET /api/mcp/servers/:id/tools — list tools for a server
       const toolsMatch = url.pathname.match(/^\/api\/mcp\/servers\/([^/]+)\/tools$/);
       if (toolsMatch && req.method === "GET") {

--- a/apps/frontend/src/components/ConnectionManager.tsx
+++ b/apps/frontend/src/components/ConnectionManager.tsx
@@ -11,6 +11,10 @@ export function ConnectionManager() {
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [testLoading, setTestLoading] = useState<string | null>(null);
+  const [testResults, setTestResults] = useState<
+    Record<string, { ok: boolean; latencyMs?: number; toolCount?: number; error?: string }>
+  >({});
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Form state
@@ -103,6 +107,28 @@ export function ConnectionManager() {
       await fetchServers();
     } finally {
       setActionLoading(null);
+    }
+  };
+
+  const testServer = async (id: string) => {
+    setTestLoading(id);
+    // Clear previous result for this server
+    setTestResults((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    try {
+      const res = await fetch(`/api/mcp/servers/${id}/test`, { method: "POST" });
+      const data = await res.json();
+      setTestResults((prev) => ({ ...prev, [id]: data }));
+    } catch {
+      setTestResults((prev) => ({
+        ...prev,
+        [id]: { ok: false, error: "Network error — could not reach backend" },
+      }));
+    } finally {
+      setTestLoading(null);
     }
   };
 
@@ -296,6 +322,22 @@ export function ConnectionManager() {
                     available
                   </span>
                 )}
+                {server.connected && (
+                  <button
+                    className="conn-action-btn conn-action-btn--test"
+                    onClick={() => testServer(server.config.id)}
+                    disabled={testLoading === server.config.id}
+                  >
+                    {testLoading === server.config.id ? (
+                      <>
+                        <span className="conn-test-spinner" />
+                        Testing...
+                      </>
+                    ) : (
+                      "Test"
+                    )}
+                  </button>
+                )}
                 <button
                   className={`conn-action-btn ${server.connected ? "disconnect" : "connect"}`}
                   onClick={() =>
@@ -344,6 +386,21 @@ export function ConnectionManager() {
                 <span className="conn-error-icon">!</span>
                 <span className="conn-error-message">
                   {friendlyConnectionError(server.error, server.config)}
+                </span>
+              </div>
+            )}
+
+            {testResults[server.config.id] && (
+              <div
+                className={`conn-test-result ${testResults[server.config.id].ok ? "conn-test-result--success" : "conn-test-result--failure"}`}
+              >
+                <span className="conn-test-result__icon">
+                  {testResults[server.config.id].ok ? "\u2713" : "\u2717"}
+                </span>
+                <span className="conn-test-result__message">
+                  {testResults[server.config.id].ok
+                    ? `Connection healthy — ${testResults[server.config.id].latencyMs}ms latency, ${testResults[server.config.id].toolCount} tool${testResults[server.config.id].toolCount !== 1 ? "s" : ""} reachable`
+                    : `Test failed — ${testResults[server.config.id].error}`}
                 </span>
               </div>
             )}

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -2783,6 +2783,64 @@ body {
   line-height: var(--leading-relaxed);
 }
 
+/* Test Connection */
+.conn-action-btn--test {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.conn-action-btn--test:hover:not(:disabled) {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.conn-test-spinner {
+  display: inline-block;
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 2px solid var(--color-border-strong);
+  border-top-color: var(--color-accent);
+  border-radius: 50%;
+  animation: conn-spin 0.6s linear infinite;
+}
+
+@keyframes conn-spin {
+  to { transform: rotate(360deg); }
+}
+
+.conn-test-result {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  line-height: 1.4;
+}
+
+.conn-test-result--success {
+  background: var(--color-success-subtle);
+  border: 1px solid color-mix(in srgb, var(--color-success) 30%, transparent);
+  color: var(--color-success);
+}
+
+.conn-test-result--failure {
+  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-danger) 30%, transparent);
+  color: var(--color-danger);
+}
+
+.conn-test-result__icon {
+  flex-shrink: 0;
+  font-weight: var(--weight-bold);
+  font-size: var(--text-md);
+}
+
+.conn-test-result__message {
+  color: var(--color-text-secondary);
+}
+
 /* ================================ */
 /* Connection Guide Surface         */
 /* ================================ */

--- a/packages/connectors/src/mcp/mcp-connector.ts
+++ b/packages/connectors/src/mcp/mcp-connector.ts
@@ -82,6 +82,22 @@ export class MCPConnector extends BaseConnector {
     return [...this.discoveredTools];
   }
 
+  /** Ping the server by listing tools and return latency in ms. */
+  async ping(): Promise<{ ok: true; latencyMs: number; toolCount: number } | { ok: false; error: string }> {
+    if (!this.client || !this.connected) {
+      return { ok: false, error: "Server is not connected" };
+    }
+    const start = performance.now();
+    try {
+      const response = await this.client.listTools();
+      const latencyMs = Math.round(performance.now() - start);
+      return { ok: true, latencyMs, toolCount: response.tools.length };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { ok: false, error: message };
+    }
+  }
+
   protected async doFetch(
     request: ConnectorRequest,
   ): Promise<ConnectorResponse> {

--- a/packages/connectors/src/mcp/registry.ts
+++ b/packages/connectors/src/mcp/registry.ts
@@ -121,6 +121,18 @@ export class MCPServerRegistry {
     return tools;
   }
 
+  /** Ping a connected server and return latency info. */
+  async testServer(id: string): Promise<{ ok: true; latencyMs: number; toolCount: number } | { ok: false; error: string }> {
+    const entry = this.servers.get(id);
+    if (!entry) {
+      return { ok: false, error: `MCP server "${id}" not found` };
+    }
+    if (!entry.connector.isConnected()) {
+      return { ok: false, error: "Server is not connected" };
+    }
+    return entry.connector.ping();
+  }
+
   /** Get a connected MCPConnector by server ID. */
   getConnector(id: string): MCPConnector | undefined {
     return this.servers.get(id)?.connector;


### PR DESCRIPTION
## Summary
- Adds a **Test Connection** button to each connected MCP server card in Settings
- Backend `POST /api/mcp/servers/:id/test` endpoint pings the server via `listTools()` and returns latency + tool count
- Frontend shows a spinner during the test, then displays a success banner (with latency in ms) or a failure banner with the error message
- Uses CSS custom properties and BEM naming consistent with the existing connection manager styles

Closes #211

## Test plan
- [ ] Connect an MCP server in Settings, click "Test" — verify spinner appears, then green success banner with latency
- [ ] Disconnect the server and verify the Test button is hidden (only shown for connected servers)
- [ ] Simulate a failing server (e.g. kill the MCP process) and click Test — verify red failure banner appears
- [ ] Verify no regressions in connect/disconnect/delete flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)