### PR TITLE
feat: add structured logging with levels and trace correlation

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@waibspace/db": "workspace:*",
+    "@waibspace/logger": "workspace:*",
     "@waibspace/types": "workspace:*",
     "@waibspace/event-bus": "workspace:*",
     "@waibspace/orchestrator": "workspace:*",

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,5 +1,7 @@
 import { EventBus } from "@waibspace/event-bus";
 import type { WaibEvent } from "@waibspace/types";
+import { createLogger } from "@waibspace/logger";
+
 import type { ServerMessage, ComposedLayout } from "@waibspace/ui-renderer-contract";
 import { Orchestrator, AgentRegistry, InMemoryPendingActionStore } from "@waibspace/orchestrator";
 import {
@@ -50,10 +52,11 @@ import { broadcast } from "./ws";
 
 // ---------- 1. Event Bus ----------
 const bus = new EventBus();
+const log = createLogger("backend");
 
 // ---------- 1b. Database ----------
 const db = new WaibDatabase("./data/waibspace.db");
-console.log("[backend] SQLite database initialized");
+log.info("SQLite database initialized");
 
 // ---------- 2. Model Provider ----------
 const modelRegistry = new ModelProviderRegistry();
@@ -72,31 +75,31 @@ const connectorRegistry = new ConnectorRegistry();
 const webFetchConnector = new WebFetchConnector("web-fetch", "Web Fetch");
 await webFetchConnector.connect();
 connectorRegistry.register(webFetchConnector);
-console.log("[backend] WebFetch connector registered");
+log.info("WebFetch connector registered");
 
 // Gmail connector — use mock fixture data when MOCK_CONNECTORS is enabled
 if (process.env.MOCK_CONNECTORS === "true") {
   const mockGmail = new MockGmailConnector();
   await mockGmail.connect();
   connectorRegistry.register(mockGmail);
-  console.log("[backend] MockGmailConnector registered (MOCK_CONNECTORS=true)");
+  log.info("MockGmailConnector registered", { mock: true });
 
   const mockCalendar = new MockCalendarConnector();
   await mockCalendar.connect();
   connectorRegistry.register(mockCalendar);
-  console.log("[backend] MockCalendarConnector registered (MOCK_CONNECTORS=true)");
+  log.info("MockCalendarConnector registered", { mock: true });
 } else {
   const gmailConnector = new GmailConnector();
   await gmailConnector.connect();
   if (gmailConnector.isConnected()) {
     connectorRegistry.register(gmailConnector);
-    console.log("[backend] GmailConnector registered");
+    log.info("GmailConnector registered");
   }
 }
 
 // ---------- 4. Policy Engine ----------
 const policyEngine = new PolicyEngine(DEFAULT_POLICY_RULES);
-console.log(`[backend] Policy engine initialized with ${policyEngine.getRules().length} rules`);
+log.info("Policy engine initialized", { ruleCount: policyEngine.getRules().length });
 
 // ---------- 4b. MCP Server Registry ----------
 const mcpRegistry = new MCPServerRegistry(policyEngine, db);
@@ -111,18 +114,19 @@ for (const server of mcpRegistry.getServers()) {
       if (connector) {
         connectorRegistry.register(connector);
       }
-      console.log(`[backend] MCP server "${server.config.name}" connected`);
+      log.info("MCP server connected", { serverName: server.config.name });
     } catch (err) {
-      console.warn(
-        `[backend] MCP server "${server.config.name}" failed to connect:`,
-        err instanceof Error ? err.message : err,
-      );
+      log.warn("MCP server failed to connect", {
+        serverName: server.config.name,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 }
-console.log(
-  `[backend] MCP registry: ${mcpRegistry.getServers().length} server(s), ${mcpRegistry.getAllTools().length} tool(s)`,
-);
+log.info("MCP registry loaded", {
+  serverCount: mcpRegistry.getServers().length,
+  toolCount: mcpRegistry.getAllTools().length,
+});
 
 // ---------- 5. Agent Registry ----------
 const agentRegistry = new AgentRegistry();
@@ -158,16 +162,17 @@ agentRegistry.register(new ProvenanceAnnotatorAgent());
 // Execution agents
 agentRegistry.register(new ActionExecutorAgent());
 
-console.log(
-  `[backend] Registered ${agentRegistry.getAll().length} agents: ${agentRegistry.getAll().map((a: { id: string }) => a.id).join(", ")}`,
-);
+log.info("Agent registry initialized", {
+  agentCount: agentRegistry.getAll().length,
+  agents: agentRegistry.getAll().map((a: { id: string }) => a.id),
+});
 
 // ---------- 6. Memory Store ----------
 const memoryStore = new MemoryStore(db, bus);
 
 // ---------- 6b. Pending Action Store ----------
 const pendingActionStore = new InMemoryPendingActionStore();
-console.log("[backend] Pending action store initialized (in-memory)");
+log.info("Pending action store initialized");
 
 // ---------- 7. Orchestrator ----------
 const orchestrator = new Orchestrator(bus, agentRegistry, {
@@ -193,9 +198,10 @@ for (const task of MVP_BACKGROUND_TASKS) {
   scheduler.register(task);
 }
 scheduler.start();
-console.log(
-  `[backend] Registered ${MVP_BACKGROUND_TASKS.length} background tasks: ${MVP_BACKGROUND_TASKS.map((t) => t.id).join(", ")}`,
-);
+log.info("Background tasks registered", {
+  taskCount: MVP_BACKGROUND_TASKS.length,
+  tasks: MVP_BACKGROUND_TASKS.map((t) => t.id),
+});
 
 // ---------- 10. Route user events to orchestrator ----------
 const USER_EVENT_PATTERNS = [
@@ -219,16 +225,14 @@ for (const pattern of USER_EVENT_PATTERNS) {
     if (PASSIVE_OBSERVATION_TYPES.has(event.type)) return;
 
     const traceId = event.traceId;
-    console.log(
-      `[backend] [trace:${traceId}] Routing event "${event.type}" to orchestrator`,
-    );
+    log.child({ traceId }).info("Routing event to orchestrator", { eventType: event.type });
     try {
       await orchestrator.processEvent(event);
     } catch (err) {
-      console.error(
-        `[backend] [trace:${traceId}] Orchestrator error for "${event.type}":`,
-        err,
-      );
+      log.child({ traceId }).error("Orchestrator error", {
+        eventType: event.type,
+        error: err instanceof Error ? err.message : String(err),
+      });
       // Send error to all clients with partial status
       const errorMessage =
         err instanceof Error ? err.message : "Unknown orchestrator error";
@@ -265,9 +269,7 @@ bus.on("surface.composed", (event: WaibEvent) => {
     type: "surface.update",
     payload: event.payload as ComposedLayout,
   };
-  console.log(
-    `[backend] [trace:${event.traceId}] Broadcasting surface.composed to WebSocket clients`,
-  );
+  log.child({ traceId: event.traceId }).debug("Broadcasting surface.composed to WebSocket clients");
   broadcast(message);
 });
 
@@ -275,16 +277,14 @@ bus.on("surface.composed", (event: WaibEvent) => {
 const server = startServer({ eventBus: bus, orchestrator, memoryStore, scheduler, mcpRegistry, connectorRegistry, db, pendingActionStore });
 
 const PORT = Number(process.env.PORT) || 3001;
-console.log(`[backend] WaibSpace backend started`);
-console.log(`[backend] HTTP & WebSocket listening on port ${PORT}`);
-console.log(`[backend] Started at ${new Date().toISOString()}`);
+log.info("WaibSpace backend started", { port: PORT });
 
 // ---------- 13. Graceful Shutdown ----------
 function handleShutdown(signal: string) {
-  console.log(`[backend] Received ${signal}, shutting down gracefully...`);
+  log.info("Shutting down", { signal });
   scheduler.stop();
   server.stop();
-  console.log("[backend] Shutdown complete");
+  log.info("Shutdown complete");
   process.exit(0);
 }
 

--- a/apps/backend/src/ws.ts
+++ b/apps/backend/src/ws.ts
@@ -4,6 +4,9 @@ import { isValidClientMessage } from "@waibspace/ui-renderer-contract";
 import { EventBus, createEvent, createTraceId } from "@waibspace/event-bus";
 import type { MemoryStore } from "@waibspace/memory";
 import type { SurfaceSpec } from "@waibspace/types";
+import { createLogger } from "@waibspace/logger";
+
+const log = createLogger("ws");
 
 export interface WebSocketData {
   connectionId: string;
@@ -25,10 +28,10 @@ export function broadcast(message: ServerMessage): void {
     try {
       ws.send(raw);
     } catch (err) {
-      console.error(
-        `[ws] broadcast send failed for ${ws.data.connectionId}:`,
-        err,
-      );
+      log.error("Broadcast send failed", {
+        connectionId: ws.data.connectionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
       clients.delete(ws);
     }
   }
@@ -123,10 +126,11 @@ async function sendPendingSurfaces(
     key: e.key,
     preparedAt: e.updatedAt,
   }));
-  console.log(
-    `[ws] [trace:${traceId}] Sent ${surfaces.length} pending surface(s) to ${ws.data.connectionId}`,
+  log.child({ traceId }).info("Sent pending surfaces", {
+    connectionId: ws.data.connectionId,
+    surfaceCount: surfaces.length,
     preparedAt,
-  );
+  });
 }
 
 /**
@@ -136,17 +140,15 @@ export function createWebSocketHandlers(bus: EventBus, memoryStore?: MemoryStore
   return {
     open(ws: ServerWebSocket<WebSocketData>) {
       clients.add(ws);
-      console.log(
-        `[ws] client connected: ${ws.data.connectionId} (total: ${clients.size})`,
-      );
+      log.info("Client connected", { connectionId: ws.data.connectionId, totalClients: clients.size });
 
       // Send any pre-prepared surfaces to the newly connected client
       if (memoryStore) {
         sendPendingSurfaces(ws, memoryStore).catch((err) => {
-          console.error(
-            `[ws] Failed to send pending surfaces to ${ws.data.connectionId}:`,
-            err,
-          );
+          log.error("Failed to send pending surfaces", {
+            connectionId: ws.data.connectionId,
+            error: err instanceof Error ? err.message : String(err),
+          });
         });
       }
     },
@@ -159,7 +161,7 @@ export function createWebSocketHandlers(bus: EventBus, memoryStore?: MemoryStore
       try {
         parsed = JSON.parse(raw);
       } catch {
-        console.error(`[ws] [trace:${traceId}] Invalid JSON from ${ws.data.connectionId}`);
+        log.child({ traceId }).error("Invalid JSON from client", { connectionId: ws.data.connectionId });
         const errorMsg: ServerMessage = {
           type: "error",
           payload: { message: "Invalid JSON", code: "INVALID_JSON" },
@@ -169,7 +171,7 @@ export function createWebSocketHandlers(bus: EventBus, memoryStore?: MemoryStore
       }
 
       if (!isValidClientMessage(parsed)) {
-        console.error(`[ws] [trace:${traceId}] Invalid message format from ${ws.data.connectionId}`);
+        log.child({ traceId }).error("Invalid message format", { connectionId: ws.data.connectionId });
         const errorMsg: ServerMessage = {
           type: "error",
           payload: {
@@ -185,16 +187,16 @@ export function createWebSocketHandlers(bus: EventBus, memoryStore?: MemoryStore
       const eventType = mapClientMessageToEventType(clientMsg);
       const source = `ws:${ws.data.connectionId}`;
 
-      console.log(
-        `[ws] [trace:${traceId}] message from ${ws.data.connectionId}: ${clientMsg.type} -> ${eventType}`,
-      );
+      log.child({ traceId }).debug("Message received", {
+        connectionId: ws.data.connectionId,
+        messageType: clientMsg.type,
+        eventType,
+      });
 
       // If this is a user.interaction with a batch, emit individual events for each observation
       if (clientMsg.type === "user.interaction" && clientMsg.payload.batch && clientMsg.payload.batch.length > 0) {
         const { batch, ...basePayload } = clientMsg.payload;
-        console.log(
-          `[ws] [trace:${traceId}] Processing observation batch of ${batch.length} item(s)`,
-        );
+        log.child({ traceId }).debug("Processing observation batch", { batchSize: batch.length });
         for (const observation of batch) {
           const obsEventType = `user.interaction.${observation.interactionType}`;
           const obsPayload = {
@@ -225,13 +227,11 @@ export function createWebSocketHandlers(bus: EventBus, memoryStore?: MemoryStore
 
     close(ws: ServerWebSocket<WebSocketData>) {
       clients.delete(ws);
-      console.log(
-        `[ws] client disconnected: ${ws.data.connectionId} (total: ${clients.size})`,
-      );
+      log.info("Client disconnected", { connectionId: ws.data.connectionId, totalClients: clients.size });
     },
 
     error(ws: ServerWebSocket<WebSocketData>, error: Error) {
-      console.error(`[ws] error for ${ws.data.connectionId}:`, error);
+      log.error("WebSocket error", { connectionId: ws.data.connectionId, error: error.message });
       clients.delete(ws);
     },
   };

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "waibspace",
@@ -15,7 +16,9 @@
       "dependencies": {
         "@waibspace/agents": "workspace:*",
         "@waibspace/connectors": "workspace:*",
+        "@waibspace/db": "workspace:*",
         "@waibspace/event-bus": "workspace:*",
+        "@waibspace/logger": "workspace:*",
         "@waibspace/memory": "workspace:*",
         "@waibspace/model-provider": "workspace:*",
         "@waibspace/orchestrator": "workspace:*",
@@ -49,6 +52,7 @@
       "dependencies": {
         "@waibspace/connectors": "workspace:*",
         "@waibspace/event-bus": "workspace:*",
+        "@waibspace/logger": "workspace:*",
         "@waibspace/memory": "workspace:*",
         "@waibspace/model-provider": "workspace:*",
         "@waibspace/surfaces": "workspace:*",
@@ -61,11 +65,16 @@
       "version": "0.0.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "@waibspace/db": "workspace:*",
         "@waibspace/policy": "workspace:*",
         "@waibspace/types": "workspace:*",
         "google-auth-library": "^9.15.1",
         "googleapis": "^171.4.0",
       },
+    },
+    "packages/db": {
+      "name": "@waibspace/db",
+      "version": "0.0.1",
     },
     "packages/event-bus": {
       "name": "@waibspace/event-bus",
@@ -74,10 +83,15 @@
         "@waibspace/types": "workspace:*",
       },
     },
+    "packages/logger": {
+      "name": "@waibspace/logger",
+      "version": "0.0.1",
+    },
     "packages/memory": {
       "name": "@waibspace/memory",
       "version": "0.0.1",
       "dependencies": {
+        "@waibspace/db": "workspace:*",
         "@waibspace/event-bus": "workspace:*",
         "@waibspace/types": "workspace:*",
       },
@@ -97,6 +111,7 @@
         "@waibspace/agents": "workspace:*",
         "@waibspace/connectors": "workspace:*",
         "@waibspace/event-bus": "workspace:*",
+        "@waibspace/logger": "workspace:*",
         "@waibspace/memory": "workspace:*",
         "@waibspace/policy": "workspace:*",
         "@waibspace/types": "workspace:*",
@@ -318,9 +333,13 @@
 
     "@waibspace/connectors": ["@waibspace/connectors@workspace:packages/connectors"],
 
+    "@waibspace/db": ["@waibspace/db@workspace:packages/db"],
+
     "@waibspace/event-bus": ["@waibspace/event-bus@workspace:packages/event-bus"],
 
     "@waibspace/frontend": ["@waibspace/frontend@workspace:apps/frontend"],
+
+    "@waibspace/logger": ["@waibspace/logger@workspace:packages/logger"],
 
     "@waibspace/memory": ["@waibspace/memory@workspace:packages/memory"],
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
+    "@waibspace/logger": "workspace:*",
     "@waibspace/types": "workspace:*",
     "@waibspace/event-bus": "workspace:*",
     "@waibspace/model-provider": "workspace:*",

--- a/packages/agents/src/base-agent.ts
+++ b/packages/agents/src/base-agent.ts
@@ -8,6 +8,7 @@ import type {
   CompletionResponse,
   ModelRoleConfig,
 } from "@waibspace/model-provider";
+import { createLogger, type Logger } from "@waibspace/logger";
 import type { Agent, AgentInput, AgentContext } from "./types";
 
 export abstract class BaseAgent implements Agent {
@@ -15,6 +16,7 @@ export abstract class BaseAgent implements Agent {
   readonly name: string;
   readonly type: string;
   readonly category: AgentCategory;
+  protected readonly logger: Logger;
 
   constructor(config: {
     id: string;
@@ -26,6 +28,7 @@ export abstract class BaseAgent implements Agent {
     this.name = config.name;
     this.type = config.type;
     this.category = config.category;
+    this.logger = createLogger(`agent:${config.id}`);
   }
 
   abstract execute(
@@ -95,7 +98,7 @@ export abstract class BaseAgent implements Agent {
     });
   }
 
-  protected log(message: string, data?: unknown): void {
-    console.log(`[${this.category}:${this.name}] ${message}`, data ?? "");
+  protected log(message: string, data?: Record<string, unknown>): void {
+    this.logger.info(message, { category: this.category, ...data });
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@waibspace/logger",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,2 @@
+export { Logger, createLogger } from "./logger";
+export type { LogLevel, LogEntry, LoggerOptions } from "./logger";

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,0 +1,112 @@
+/**
+ * Lightweight structured logger with level filtering and trace correlation.
+ *
+ * Output format: newline-delimited JSON (one object per log line).
+ * Respects the LOG_LEVEL environment variable (default: "info").
+ *
+ * No external dependencies — uses console.log/error for output.
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+export interface LogEntry {
+  level: LogLevel;
+  msg: string;
+  component: string;
+  timestamp: string;
+  traceId?: string;
+  [key: string]: unknown;
+}
+
+export interface LoggerOptions {
+  /** Component/module name included in every log entry */
+  component: string;
+  /** Optional trace ID to correlate logs across the pipeline */
+  traceId?: string;
+  /** Override the minimum log level (defaults to LOG_LEVEL env or "info") */
+  level?: LogLevel;
+}
+
+function getEnvLevel(): LogLevel {
+  const env = (typeof process !== "undefined" && process.env?.LOG_LEVEL) || "info";
+  const normalized = env.toLowerCase() as LogLevel;
+  return normalized in LEVEL_ORDER ? normalized : "info";
+}
+
+export class Logger {
+  readonly component: string;
+  readonly traceId: string | undefined;
+  private minLevel: number;
+
+  constructor(options: LoggerOptions) {
+    this.component = options.component;
+    this.traceId = options.traceId;
+    this.minLevel = LEVEL_ORDER[options.level ?? getEnvLevel()];
+  }
+
+  /**
+   * Create a child logger that inherits the parent's settings but can override
+   * component name and/or traceId.
+   */
+  child(overrides: Partial<LoggerOptions>): Logger {
+    return new Logger({
+      component: overrides.component ?? this.component,
+      traceId: overrides.traceId ?? this.traceId,
+      level: overrides.level,
+    });
+  }
+
+  debug(msg: string, data?: Record<string, unknown>): void {
+    this.write("debug", msg, data);
+  }
+
+  info(msg: string, data?: Record<string, unknown>): void {
+    this.write("info", msg, data);
+  }
+
+  warn(msg: string, data?: Record<string, unknown>): void {
+    this.write("warn", msg, data);
+  }
+
+  error(msg: string, data?: Record<string, unknown>): void {
+    this.write("error", msg, data);
+  }
+
+  private write(level: LogLevel, msg: string, data?: Record<string, unknown>): void {
+    if (LEVEL_ORDER[level] < this.minLevel) return;
+
+    const entry: LogEntry = {
+      level,
+      msg,
+      component: this.component,
+      timestamp: new Date().toISOString(),
+      ...(this.traceId ? { traceId: this.traceId } : {}),
+      ...data,
+    };
+
+    const line = JSON.stringify(entry);
+
+    // Use console.error for warn/error so they go to stderr;
+    // debug/info go to stdout via console.log.
+    if (level === "error" || level === "warn") {
+      console.error(line);
+    } else {
+      console.log(line);
+    }
+  }
+}
+
+/**
+ * Create a root logger for a given component.
+ * Shorthand for `new Logger({ component })`.
+ */
+export function createLogger(component: string, traceId?: string): Logger {
+  return new Logger({ component, traceId });
+}

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
+    "@waibspace/logger": "workspace:*",
     "@waibspace/types": "workspace:*",
     "@waibspace/event-bus": "workspace:*",
     "@waibspace/agents": "workspace:*",

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -6,6 +6,7 @@ import type { MemoryStore } from "@waibspace/memory";
 import type { ConnectorRegistry } from "@waibspace/connectors";
 import type { PolicyEngine } from "@waibspace/policy";
 import type { WaibDatabase } from "@waibspace/db";
+import { createLogger, type Logger } from "@waibspace/logger";
 import { AgentRegistry } from "./agent-registry";
 import { buildExecutionPlan } from "./execution-planner";
 import { createPipelineTrace, logTrace } from "./trace";
@@ -23,11 +24,15 @@ export interface OrchestratorOptions {
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 export class Orchestrator {
+  private readonly log: Logger;
+
   constructor(
     private eventBus: EventBus,
     private registry: AgentRegistry,
     private options?: OrchestratorOptions,
-  ) {}
+  ) {
+    this.log = createLogger("orchestrator");
+  }
 
   private logToDb(
     eventType: string,
@@ -127,9 +132,11 @@ export class Orchestrator {
               error: errorMsg,
               durationMs: result.value.timing?.durationMs,
             }, "error");
-            console.error(
-              `[Orchestrator] [trace:${traceId}] Agent ${agent.id} returned error in phase "${phase.category}": ${errorMsg}`,
-            );
+            this.log.child({ traceId }).error("Agent returned error", {
+              agentId: agent.id,
+              phase: phase.category,
+              error: errorMsg,
+            });
           } else {
             // Log successful agent completion with output summary
             // Include full output for context agents (planner, connector-selection, data-retrieval)
@@ -158,9 +165,11 @@ export class Orchestrator {
             phase: phase.category,
             error: errorMsg,
           }, "error");
-          console.error(
-            `[Orchestrator] [trace:${traceId}] Agent ${agent.id} crashed in phase "${phase.category}": ${errorMsg}`,
-          );
+          this.log.child({ traceId }).error("Agent crashed", {
+            agentId: agent.id,
+            phase: phase.category,
+            error: errorMsg,
+          });
         }
       }
 
@@ -240,9 +249,9 @@ export class Orchestrator {
     } else if (errors.length > 0) {
       // No surfaces produced but there were errors - emit an error event
       // so the frontend knows something went wrong
-      console.error(
-        `[Orchestrator] [trace:${traceId}] Pipeline produced no surfaces. ${errors.length} error(s) occurred.`,
-      );
+      this.log.child({ traceId }).error("Pipeline produced no surfaces", {
+        errorCount: errors.length,
+      });
       const errorEvent = createEvent(
         "surface.composed",
         {
@@ -281,9 +290,10 @@ export class Orchestrator {
     }, errors.length > 0 ? "warn" : "info");
 
     if (errors.length > 0) {
-      console.warn(
-        `[Orchestrator] [trace:${traceId}] Completed with ${errors.length} error(s): ${errors.map((e) => e.agentId).join(", ")}`,
-      );
+      this.log.child({ traceId }).warn("Pipeline completed with errors", {
+        errorCount: errors.length,
+        failedAgents: errors.map((e) => e.agentId),
+      });
     }
   }
 }

--- a/packages/orchestrator/src/trace.ts
+++ b/packages/orchestrator/src/trace.ts
@@ -1,4 +1,7 @@
 import type { AgentCategory, AgentOutput } from "@waibspace/types";
+import { createLogger } from "@waibspace/logger";
+
+const log = createLogger("pipeline-trace");
 
 export interface PipelineTrace {
   traceId: string;
@@ -114,23 +117,28 @@ function aggregateByCategory(
 export function logTrace(trace: PipelineTrace): void {
   const totalDuration = trace.endMs - trace.startMs;
   const categories = aggregateByCategory(trace.phases);
+  const traceLog = log.child({ traceId: trace.traceId });
 
-  console.log(`[trace:${trace.traceId}] Pipeline complete in ${totalDuration}ms`);
-
+  const breakdown: Record<string, { durationMs: number; agents: Array<{ agentId: string; durationMs: number }> }> = {};
   for (const [category, data] of categories) {
-    const agentDetails = data.agents
-      .map((a) => `${a.agentId}: ${a.durationMs}ms`)
-      .join(", ");
-    console.log(`  ${category}: ${data.durationMs}ms (${agentDetails})`);
+    breakdown[category] = data;
   }
+
+  traceLog.info("Pipeline complete", {
+    durationMs: totalDuration,
+    eventType: trace.eventType,
+    phases: breakdown,
+  });
 
   // Log slow agents as warnings (> 1 second)
   for (const phase of trace.phases) {
     for (const agent of phase.agents) {
       if (agent.durationMs > 1000) {
-        console.warn(
-          `[trace:${trace.traceId}] SLOW AGENT: ${agent.agentId} took ${agent.durationMs}ms (${agent.status})`,
-        );
+        traceLog.warn("Slow agent detected", {
+          agentId: agent.agentId,
+          durationMs: agent.durationMs,
+          status: agent.status,
+        });
       }
     }
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,7 +24,8 @@
       "@waibspace/surfaces": ["./packages/surfaces/src/index.ts"],
       "@waibspace/model-provider": ["./packages/model-provider/src/index.ts"],
       "@waibspace/db": ["./packages/db/src/index.ts"],
-      "@waibspace/ui-renderer-contract": ["./packages/ui-renderer-contract/src/index.ts"]
+      "@waibspace/ui-renderer-contract": ["./packages/ui-renderer-contract/src/index.ts"],
+      "@waibspace/logger": ["./packages/logger/src/index.ts"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     { "path": "packages/db" },
     { "path": "packages/ui-renderer-contract" },
     { "path": "apps/backend" },
+    { "path": "packages/logger" },
     { "path": "apps/frontend" }
   ],
   "include": []


### PR DESCRIPTION
## Summary
- Introduces `@waibspace/logger` — a lightweight, zero-dependency structured logger outputting newline-delimited JSON
- Supports `debug`, `info`, `warn`, `error` levels with `LOG_LEVEL` env var filtering (default: `info`)
- Provides `child()` method for traceId correlation across the pipeline
- Replaces all `console.log/warn/error` calls in the orchestrator, agent base class, backend entry point, and WebSocket handler with structured log entries

## Changes
- **New package**: `packages/logger/` with `Logger` class and `createLogger` factory
- **`packages/agents/src/base-agent.ts`**: `log()` helper now emits structured JSON via the logger
- **`packages/orchestrator/src/orchestrator.ts`**: All console calls replaced with `this.log.child({ traceId })` calls
- **`packages/orchestrator/src/trace.ts`**: Pipeline trace summary now outputs structured JSON
- **`apps/backend/src/index.ts`**: All startup and event-routing logs now structured
- **`apps/backend/src/ws.ts`**: WebSocket lifecycle and message logs now structured

## Example output
```json
{"level":"info","msg":"WaibSpace backend started","component":"backend","timestamp":"2026-03-09T12:00:00.000Z","port":3001}
{"level":"info","msg":"Routing event to orchestrator","component":"backend","timestamp":"...","traceId":"abc123","eventType":"user.message.received"}
{"level":"warn","msg":"Slow agent detected","component":"pipeline-trace","timestamp":"...","traceId":"abc123","agentId":"intent-agent","durationMs":1250}
```

## Test plan
- [ ] Verify `bun run dev:backend` starts and logs structured JSON to stdout/stderr
- [ ] Confirm `LOG_LEVEL=debug` shows debug-level messages, `LOG_LEVEL=error` suppresses info/warn
- [ ] Send a message via the frontend and verify traceId appears consistently across log lines
- [ ] Check that warn/error output goes to stderr (visible with `2>/dev/null` filtering)

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)