### PR TITLE
feat: add email quick actions on hover (archive, reply, snooze)

### DIFF
--- a/apps/frontend/src/blocks/components/domain/gmail/GmailEmailCard.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailEmailCard.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import type { BlockProps } from "../../../registry";
 
 interface GmailEmailCardProps {
@@ -32,8 +33,9 @@ function getInitials(name: string): string {
   return name.slice(0, 2).toUpperCase();
 }
 
-export function GmailEmailCard({ block }: BlockProps) {
+export function GmailEmailCard({ block, onEvent }: BlockProps) {
   const {
+    emailId,
     from,
     subject,
     snippet,
@@ -56,6 +58,14 @@ export function GmailEmailCard({ block }: BlockProps) {
   ]
     .filter(Boolean)
     .join(" ");
+
+  const handleQuickAction = useCallback(
+    (action: "archive" | "reply" | "snooze", e: React.MouseEvent) => {
+      e.stopPropagation();
+      onEvent?.(action, { emailId, from, subject });
+    },
+    [onEvent, emailId, from, subject],
+  );
 
   return (
     <div className={cardClass} role="listitem" aria-label={`${isUnread ? "Unread: " : ""}${subject || "No Subject"} from ${from}`}>
@@ -89,6 +99,45 @@ export function GmailEmailCard({ block }: BlockProps) {
             {hasStarred ? "\u2605" : "\u2606"}
           </span>
         )}
+      </div>
+
+      <div className="gmail-email-card__quick-actions" aria-label="Quick actions">
+        <button
+          type="button"
+          className="gmail-email-card__quick-btn"
+          title="Archive"
+          aria-label="Archive email"
+          onClick={(e) => handleQuickAction("archive", e)}
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M1.5 4.5h13M2.5 4.5v8a1 1 0 001 1h9a1 1 0 001-1v-8M5.5 7.5h5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+            <path d="M0.5 2.5h15v2h-15z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/>
+          </svg>
+        </button>
+        <button
+          type="button"
+          className="gmail-email-card__quick-btn"
+          title="Reply"
+          aria-label="Reply to email"
+          onClick={(e) => handleQuickAction("reply", e)}
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M6.5 4L2.5 8l4 4M2.5 8h7a4 4 0 014 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </button>
+        <button
+          type="button"
+          className="gmail-email-card__quick-btn"
+          title="Snooze"
+          aria-label="Snooze email"
+          onClick={(e) => handleQuickAction("snooze", e)}
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="8" cy="8.5" r="5.5" stroke="currentColor" strokeWidth="1.3"/>
+            <path d="M8 5.5v3l2 1.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+            <path d="M5.5 1.5h5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+          </svg>
+        </button>
       </div>
     </div>
   );

--- a/apps/frontend/src/styles/gmail-components.css
+++ b/apps/frontend/src/styles/gmail-components.css
@@ -131,6 +131,67 @@
   line-height: 1;
 }
 
+/* ---- GmailEmailCard Quick Actions ---- */
+
+.gmail-email-card__quick-actions {
+  position: absolute;
+  right: var(--space-2);
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 2px;
+  box-shadow: var(--shadow-sm);
+}
+
+.gmail-email-card {
+  position: relative;
+}
+
+.gmail-email-card:hover .gmail-email-card__quick-actions,
+.gmail-email-card:focus-within .gmail-email-card__quick-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.gmail-email-card__quick-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  font-family: var(--font-sans);
+  line-height: 1;
+}
+
+.gmail-email-card__quick-btn:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.gmail-email-card__quick-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.gmail-email-card__quick-btn:active {
+  background: var(--color-border);
+}
+
 /* ---- GmailInboxList ---- */
 
 .gmail-inbox-list {
@@ -375,6 +436,10 @@
   }
 
   .gmail-email-card__actions {
+    display: none;
+  }
+
+  .gmail-email-card__quick-actions {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- Adds hover overlay on `GmailEmailCard` with three quick-action buttons: Archive, Reply, and Snooze
- Each button dispatches the corresponding event name (`archive`, `reply`, `snooze`) via the existing `onEvent` callback with `{ emailId, from, subject }` payload
- Uses BEM naming and CSS custom properties; overlay appears on hover and focus-within, hidden on mobile viewports
- Buttons are keyboard accessible with `focus-visible` outlines and proper ARIA labels

## Test plan
- [ ] Hover over a Gmail email card and verify the action overlay appears on the right side
- [ ] Click each button (Archive, Reply, Snooze) and verify it dispatches the correct event
- [ ] Tab into the card and verify the overlay appears via `focus-within`
- [ ] Verify buttons have visible focus outlines when focused via keyboard
- [ ] Resize to mobile viewport (<640px) and verify the overlay is hidden
- [ ] Verify clicking an action button does not trigger the card's own click handler (stopPropagation)

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)