### PR TITLE
feat: add in-memory rate limiting for API endpoints

### DIFF
--- a/apps/backend/src/__tests__/rate-limiter.test.ts
+++ b/apps/backend/src/__tests__/rate-limiter.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { RateLimiter, type RateLimitConfig } from "../rate-limiter";
+
+function makeConfig(overrides: Partial<RateLimitConfig> = {}): RateLimitConfig {
+  return { maxRequests: 5, windowMs: 1000, ...overrides };
+}
+
+describe("RateLimiter", () => {
+  let limiter: RateLimiter;
+
+  afterEach(() => {
+    limiter?.stop();
+  });
+
+  it("allows requests under the limit", () => {
+    limiter = new RateLimiter(makeConfig());
+    for (let i = 0; i < 5; i++) {
+      const result = limiter.check("client-a");
+      expect(result.allowed).toBe(true);
+      expect(result.remaining).toBe(4 - i);
+    }
+  });
+
+  it("rejects requests over the limit", () => {
+    limiter = new RateLimiter(makeConfig({ maxRequests: 3 }));
+    limiter.check("client-b");
+    limiter.check("client-b");
+    limiter.check("client-b");
+
+    const result = limiter.check("client-b");
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.retryAfterSecs).toBeGreaterThan(0);
+  });
+
+  it("tracks clients independently", () => {
+    limiter = new RateLimiter(makeConfig({ maxRequests: 1 }));
+    expect(limiter.check("client-x").allowed).toBe(true);
+    expect(limiter.check("client-x").allowed).toBe(false);
+    // Different client should still be allowed
+    expect(limiter.check("client-y").allowed).toBe(true);
+  });
+
+  it("resets after the window expires", async () => {
+    limiter = new RateLimiter(makeConfig({ maxRequests: 1, windowMs: 50 }));
+    expect(limiter.check("client-z").allowed).toBe(true);
+    expect(limiter.check("client-z").allowed).toBe(false);
+
+    // Wait for window to expire
+    await new Promise((r) => setTimeout(r, 60));
+    expect(limiter.check("client-z").allowed).toBe(true);
+  });
+});

--- a/apps/backend/src/rate-limiter.ts
+++ b/apps/backend/src/rate-limiter.ts
@@ -1,0 +1,112 @@
+/**
+ * In-memory sliding-window rate limiter.
+ *
+ * Each client (identified by IP) gets a window of `windowMs` milliseconds
+ * during which they may make up to `maxRequests` requests. Expired entries
+ * are pruned lazily on each check and periodically via a sweep timer.
+ *
+ * Configurable via environment variables:
+ *   RATE_LIMIT_MAX       — max requests per window  (default: 100)
+ *   RATE_LIMIT_WINDOW_MS — window size in ms         (default: 60 000 = 1 min)
+ */
+
+export interface RateLimitConfig {
+  /** Maximum requests allowed within the window. */
+  maxRequests: number;
+  /** Window duration in milliseconds. */
+  windowMs: number;
+}
+
+interface ClientRecord {
+  /** Timestamps (epoch ms) of requests within the current window. */
+  timestamps: number[];
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  /** Requests remaining in the current window. */
+  remaining: number;
+  /** Seconds until the oldest request in the window expires (for Retry-After). */
+  retryAfterSecs: number;
+}
+
+export function loadRateLimitConfig(): RateLimitConfig {
+  return {
+    maxRequests: Number(process.env.RATE_LIMIT_MAX) || 100,
+    windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS) || 60_000,
+  };
+}
+
+export class RateLimiter {
+  private clients = new Map<string, ClientRecord>();
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  readonly config: RateLimitConfig;
+
+  constructor(config: RateLimitConfig) {
+    this.config = config;
+
+    // Periodically sweep stale entries to prevent memory leaks from
+    // clients that made a burst of requests then disappeared.
+    this.sweepTimer = setInterval(() => this.sweep(), config.windowMs * 2);
+    // Allow the process to exit even if the timer is still running.
+    if (this.sweepTimer && typeof this.sweepTimer === "object" && "unref" in this.sweepTimer) {
+      (this.sweepTimer as NodeJS.Timeout).unref();
+    }
+  }
+
+  /**
+   * Check whether a request from `clientId` is allowed.
+   * If allowed, the request is recorded; otherwise it is not.
+   */
+  check(clientId: string): RateLimitResult {
+    const now = Date.now();
+    const windowStart = now - this.config.windowMs;
+
+    let record = this.clients.get(clientId);
+    if (!record) {
+      record = { timestamps: [] };
+      this.clients.set(clientId, record);
+    }
+
+    // Prune timestamps outside the window
+    record.timestamps = record.timestamps.filter((t) => t > windowStart);
+
+    if (record.timestamps.length >= this.config.maxRequests) {
+      // Oldest request in the window — how long until it expires
+      const oldestInWindow = record.timestamps[0];
+      const retryAfterMs = oldestInWindow + this.config.windowMs - now;
+      return {
+        allowed: false,
+        remaining: 0,
+        retryAfterSecs: Math.ceil(retryAfterMs / 1000),
+      };
+    }
+
+    // Record this request
+    record.timestamps.push(now);
+    return {
+      allowed: true,
+      remaining: this.config.maxRequests - record.timestamps.length,
+      retryAfterSecs: 0,
+    };
+  }
+
+  /** Remove stale client entries. */
+  private sweep(): void {
+    const windowStart = Date.now() - this.config.windowMs;
+    for (const [clientId, record] of this.clients) {
+      record.timestamps = record.timestamps.filter((t) => t > windowStart);
+      if (record.timestamps.length === 0) {
+        this.clients.delete(clientId);
+      }
+    }
+  }
+
+  /** Stop the background sweep timer (useful for graceful shutdown / tests). */
+  stop(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+  }
+}

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -11,6 +11,7 @@ import {
   createWebSocketHandlers,
   type WebSocketData,
 } from "./ws";
+import { RateLimiter, loadRateLimitConfig } from "./rate-limiter";
 
 const PORT = Number(process.env.PORT) || 3001;
 
@@ -42,6 +43,7 @@ const startTime = Date.now();
 
 export function startServer(deps: ServerDeps) {
   const wsHandlers = createWebSocketHandlers(deps.eventBus, deps.memoryStore);
+  const rateLimiter = new RateLimiter(loadRateLimitConfig());
 
   const server = Bun.serve<WebSocketData>({
     port: PORT,
@@ -54,7 +56,7 @@ export function startServer(deps: ServerDeps) {
         return new Response(null, { status: 204, headers: CORS_HEADERS });
       }
 
-      // WebSocket upgrade
+      // WebSocket upgrade — not rate-limited
       if (url.pathname === "/ws") {
         const upgraded = server.upgrade(req, {
           data: {
@@ -66,12 +68,40 @@ export function startServer(deps: ServerDeps) {
         return jsonResponse({ error: "WebSocket upgrade failed" }, 400);
       }
 
-      // Health check
+      // Health check — not rate-limited
       if (url.pathname === "/health" && req.method === "GET") {
         return jsonResponse({
           status: "ok",
           uptime: Date.now() - startTime,
         });
+      }
+
+      // --- Rate limiting (applies to all /api/* routes below) ---
+      if (url.pathname.startsWith("/api/")) {
+        const clientIp =
+          req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+          req.headers.get("x-real-ip") ||
+          "unknown";
+        const result = rateLimiter.check(clientIp);
+
+        if (!result.allowed) {
+          return new Response(
+            JSON.stringify({
+              error: "Too many requests",
+              retryAfter: result.retryAfterSecs,
+            }),
+            {
+              status: 429,
+              headers: {
+                "Content-Type": "application/json",
+                "Retry-After": String(result.retryAfterSecs),
+                "X-RateLimit-Limit": String(rateLimiter.config.maxRequests),
+                "X-RateLimit-Remaining": "0",
+                ...CORS_HEADERS,
+              },
+            },
+          );
+        }
       }
 
       // Task management endpoints
@@ -388,6 +418,14 @@ export function startServer(deps: ServerDeps) {
 
     websocket: wsHandlers,
   });
+
+  // Attach cleanup so callers can stop the sweep timer on shutdown
+  (server as any)._rateLimiter = rateLimiter;
+  const origStop = server.stop.bind(server);
+  server.stop = (closeActiveConnections?: boolean) => {
+    rateLimiter.stop();
+    return origStop(closeActiveConnections);
+  };
 
   return server;
 }


### PR DESCRIPTION
## Summary
- Adds a sliding-window in-memory rate limiter applied to all `/api/*` endpoints
- WebSocket (`/ws`) and health check (`/health`) are excluded from rate limiting
- Returns `429 Too Many Requests` with `Retry-After` header when limit is exceeded
- Configurable via `RATE_LIMIT_MAX` (default: 100 req) and `RATE_LIMIT_WINDOW_MS` (default: 60s) env vars
- No external dependencies — pure TypeScript implementation
- Includes unit tests covering allow/deny/reset/per-client isolation

Closes #222

## Test plan
- [x] Unit tests pass (`bun test apps/backend/src/__tests__/rate-limiter.test.ts` — 4/4)
- [ ] Manual: send >100 requests in 1 minute to `/api/tasks` and verify 429 response
- [ ] Manual: verify `/ws` and `/health` are not rate-limited

🤖 Generated with [Claude Code](https://claude.com/claude-code)