### PR TITLE
feat: add multi-surface dashboard layout (inbox + calendar side by side)

### DIFF
--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -420,6 +420,10 @@ body {
   grid-column: span 6;
 }
 
+.surface-cell.two-thirds {
+  grid-column: span 8;
+}
+
 .surface-cell.third {
   grid-column: span 4;
 }
@@ -428,10 +432,14 @@ body {
   .surface-cell.third {
     grid-column: span 6;
   }
+  .surface-cell.two-thirds {
+    grid-column: span 12;
+  }
 }
 
 @media (max-width: 768px) {
   .surface-cell.half,
+  .surface-cell.two-thirds,
   .surface-cell.third {
     grid-column: span 12;
   }
@@ -1831,6 +1839,7 @@ body {
   }
 
   .surface-cell.half,
+  .surface-cell.two-thirds,
   .surface-cell.third,
   .surface-cell.full {
     grid-column: span 12;

--- a/packages/agents/src/ui/layout-composer.ts
+++ b/packages/agents/src/ui/layout-composer.ts
@@ -142,16 +142,27 @@ export class LayoutComposerAgent extends BaseAgent {
    * Map resolved surfaces to LayoutDirectives.
    *
    * - Assigns sequential position numbers (0 = first/top)
-   * - Width defaults to "full" for primary, "half" for secondary
+   * - Dashboard mode (2 surfaces): primary gets "two-thirds", secondary gets "third"
+   * - Single surface: primary gets "full"
+   * - 3+ surfaces: secondary surfaces default to "half"
    * - Prominence defaults from layoutHints or "standard"
    * - Max 4 visible surfaces
    */
   private buildDirectives(surfaces: SurfaceSpec[]): LayoutDirective[] {
-    return surfaces.slice(0, MAX_VISIBLE_SURFACES).map((surface, idx) => {
+    const visible = surfaces.slice(0, MAX_VISIBLE_SURFACES);
+    const isDashboard = visible.length === 2;
+
+    return visible.map((surface, idx) => {
       const hints: LayoutHints = surface.layoutHints;
       const position = hints.position ?? "secondary";
 
-      const defaultWidth = position === "primary" ? "full" : "half";
+      let defaultWidth: string;
+      if (isDashboard) {
+        // Dashboard layout: primary (2/3) + secondary (1/3)
+        defaultWidth = position === "primary" ? "two-thirds" : "third";
+      } else {
+        defaultWidth = position === "primary" ? "full" : "half";
+      }
 
       return {
         surfaceId: surface.surfaceId,

--- a/packages/types/src/surfaces.ts
+++ b/packages/types/src/surfaces.ts
@@ -15,7 +15,7 @@ export interface SurfaceAffordance {
 }
 
 export interface LayoutHints {
-  width?: "full" | "half" | "third" | "auto";
+  width?: "full" | "two-thirds" | "half" | "third" | "auto";
   position?: "primary" | "secondary" | "sidebar" | "overlay";
   prominence?: "hero" | "standard" | "compact" | "minimal";
 }


### PR DESCRIPTION
## Summary
- Add `two-thirds` width option to `LayoutHints` type and CSS grid system
- Update `LayoutComposerAgent` to automatically apply 2/3 + 1/3 dashboard split when exactly 2 surfaces are composed (e.g. inbox + calendar)
- Responsive: stacks vertically on tablet (<=1024px) and mobile (<=768px)

Closes #215

## Test plan
- [ ] Verify inbox + calendar side by side at desktop widths (>1024px): inbox 2/3, calendar 1/3
- [ ] Verify responsive stacking at tablet (<=1024px): two-thirds goes full-width, third goes half
- [ ] Verify full stacking at mobile (<=768px): all surfaces span full width
- [ ] Verify single-surface layout unchanged (still full width)
- [ ] Verify 3+ surface layout unchanged (primary full, secondaries half)

🤖 Generated with [Claude Code](https://claude.com/claude-code)