### PR TITLE
feat: add CSS theme system with user preference storage

### DIFF
--- a/apps/frontend/src/hooks/useTheme.ts
+++ b/apps/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+
+export type Theme = "dark" | "light" | "auto";
+
+const STORAGE_KEY = "waibspace-theme";
+const VALID_THEMES: Theme[] = ["dark", "light", "auto"];
+
+/* ---------- external store ---------- */
+
+let listeners: Array<() => void> = [];
+
+function subscribe(cb: () => void) {
+  listeners = [...listeners, cb];
+  return () => {
+    listeners = listeners.filter((l) => l !== cb);
+  };
+}
+
+function getSnapshot(): Theme {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored && VALID_THEMES.includes(stored as Theme)) {
+    return stored as Theme;
+  }
+  return "dark"; // default matches existing dark palette
+}
+
+function applyTheme(theme: Theme) {
+  document.documentElement.setAttribute("data-theme", theme);
+}
+
+/* ---------- hook ---------- */
+
+export function useTheme() {
+  const theme = useSyncExternalStore(subscribe, getSnapshot);
+
+  // Apply data-theme attribute whenever the value changes
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const setTheme = useCallback((next: Theme) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    applyTheme(next);
+    // Notify all subscribers
+    listeners.forEach((l) => l());
+  }, []);
+
+  return { theme, setTheme } as const;
+}
+
+/* ---------- early init (call from main.tsx before render) ---------- */
+
+export function initTheme() {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  const theme: Theme =
+    stored && VALID_THEMES.includes(stored as Theme)
+      ? (stored as Theme)
+      : "dark";
+  applyTheme(theme);
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/global.css";
+import "./styles/theme.css";
 import "./styles/gmail-components.css";
+import { initTheme } from "./hooks/useTheme";
+
+// Apply saved theme before first paint to avoid flash
+initTheme();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/apps/frontend/src/pages/SettingsPage.tsx
+++ b/apps/frontend/src/pages/SettingsPage.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
 import { ConnectionManager } from "../components/ConnectionManager";
+import { useTheme, type Theme } from "../hooks/useTheme";
 
 type SettingsSection = "connections" | "preferences" | "about";
 
 export default function SettingsPage() {
   const [activeSection, setActiveSection] = useState<SettingsSection>("connections");
-  const [theme, setTheme] = useState<"dark" | "light">("dark");
+  const { theme, setTheme } = useTheme();
   const [notifyErrors, setNotifyErrors] = useState(true);
   const [notifyTaskComplete, setNotifyTaskComplete] = useState(true);
 
@@ -46,22 +47,19 @@ export default function SettingsPage() {
                 <div className="settings-row__info">
                   <span className="settings-row__label">Theme</span>
                   <span className="settings-row__description">
-                    Choose between dark and light mode
+                    Choose dark, light, or auto (follows system preference)
                   </span>
                 </div>
                 <div className="settings-toggle-group">
-                  <button
-                    className={`settings-toggle-group__btn ${theme === "dark" ? "settings-toggle-group__btn--active" : ""}`}
-                    onClick={() => setTheme("dark")}
-                  >
-                    Dark
-                  </button>
-                  <button
-                    className={`settings-toggle-group__btn ${theme === "light" ? "settings-toggle-group__btn--active" : ""}`}
-                    onClick={() => setTheme("light")}
-                  >
-                    Light
-                  </button>
+                  {(["dark", "light", "auto"] as Theme[]).map((opt) => (
+                    <button
+                      key={opt}
+                      className={`settings-toggle-group__btn ${theme === opt ? "settings-toggle-group__btn--active" : ""}`}
+                      onClick={() => setTheme(opt)}
+                    >
+                      {opt.charAt(0).toUpperCase() + opt.slice(1)}
+                    </button>
+                  ))}
                 </div>
               </div>
             </div>

--- a/apps/frontend/src/styles/theme.css
+++ b/apps/frontend/src/styles/theme.css
@@ -1,0 +1,122 @@
+/* ================================ */
+/* Theme System                     */
+/* ================================ */
+
+/*
+ * The :root vars in global.css define the dark theme (default).
+ * This file provides overrides for [data-theme="light"] and
+ * a system-preference media query for [data-theme="auto"].
+ */
+
+/* ---- Light theme ---- */
+[data-theme="light"] {
+  /* Backgrounds */
+  --color-bg: #f5f6f8;
+  --color-bg-elevated: #ffffff;
+  --color-surface: #ffffff;
+  --color-surface-hover: #f0f1f4;
+  --color-surface-active: #e5e7ec;
+
+  /* Borders */
+  --color-border: rgba(0, 0, 0, 0.10);
+  --color-border-subtle: rgba(0, 0, 0, 0.05);
+  --color-border-strong: rgba(0, 0, 0, 0.18);
+
+  /* Text */
+  --color-text: #1a1d26;
+  --color-text-secondary: #5a5f6d;
+  --color-muted: #8b8f9c;
+
+  /* Accent — keep hue, slightly deeper for readability on white */
+  --color-accent: #4f46e5;
+  --color-accent-hover: #6366f1;
+  --color-accent-subtle: rgba(79, 70, 229, 0.10);
+  --color-accent-muted: rgba(79, 70, 229, 0.05);
+
+  /* Semantic — keep hues, adjust for light bg readability */
+  --color-success: #16a34a;
+  --color-success-subtle: rgba(22, 163, 74, 0.10);
+  --color-success-text: #15803d;
+
+  --color-warning: #ca8a04;
+  --color-warning-subtle: rgba(202, 138, 4, 0.10);
+  --color-warning-text: #a16207;
+
+  --color-danger: #dc2626;
+  --color-danger-subtle: rgba(220, 38, 38, 0.08);
+  --color-danger-text: #b91c1c;
+
+  --color-info: #2563eb;
+  --color-info-subtle: rgba(37, 99, 235, 0.10);
+  --color-info-text: #1d4ed8;
+
+  --color-neutral: #6b7280;
+  --color-neutral-subtle: rgba(107, 114, 128, 0.10);
+
+  /* Shadows — lighter for light bg */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.12);
+  --shadow-xl: 0 16px 48px rgba(0, 0, 0, 0.16);
+  --shadow-glow-accent: 0 0 20px rgba(79, 70, 229, 0.12);
+  --shadow-glow-success: 0 0 20px rgba(22, 163, 74, 0.10);
+  --shadow-glow-danger: 0 0 20px rgba(220, 38, 38, 0.10);
+
+  /* Block card theming */
+  --block-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --block-card-border: 1px solid rgba(0, 0, 0, 0.10);
+}
+
+/* ---- Auto theme: respect OS preference ---- */
+@media (prefers-color-scheme: light) {
+  [data-theme="auto"] {
+    --color-bg: #f5f6f8;
+    --color-bg-elevated: #ffffff;
+    --color-surface: #ffffff;
+    --color-surface-hover: #f0f1f4;
+    --color-surface-active: #e5e7ec;
+
+    --color-border: rgba(0, 0, 0, 0.10);
+    --color-border-subtle: rgba(0, 0, 0, 0.05);
+    --color-border-strong: rgba(0, 0, 0, 0.18);
+
+    --color-text: #1a1d26;
+    --color-text-secondary: #5a5f6d;
+    --color-muted: #8b8f9c;
+
+    --color-accent: #4f46e5;
+    --color-accent-hover: #6366f1;
+    --color-accent-subtle: rgba(79, 70, 229, 0.10);
+    --color-accent-muted: rgba(79, 70, 229, 0.05);
+
+    --color-success: #16a34a;
+    --color-success-subtle: rgba(22, 163, 74, 0.10);
+    --color-success-text: #15803d;
+
+    --color-warning: #ca8a04;
+    --color-warning-subtle: rgba(202, 138, 4, 0.10);
+    --color-warning-text: #a16207;
+
+    --color-danger: #dc2626;
+    --color-danger-subtle: rgba(220, 38, 38, 0.08);
+    --color-danger-text: #b91c1c;
+
+    --color-info: #2563eb;
+    --color-info-subtle: rgba(37, 99, 235, 0.10);
+    --color-info-text: #1d4ed8;
+
+    --color-neutral: #6b7280;
+    --color-neutral-subtle: rgba(107, 114, 128, 0.10);
+
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+    --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.12);
+    --shadow-xl: 0 16px 48px rgba(0, 0, 0, 0.16);
+    --shadow-glow-accent: 0 0 20px rgba(79, 70, 229, 0.12);
+    --shadow-glow-success: 0 0 20px rgba(22, 163, 74, 0.10);
+    --shadow-glow-danger: 0 0 20px rgba(220, 38, 38, 0.10);
+
+    --block-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    --block-card-border: 1px solid rgba(0, 0, 0, 0.10);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `data-theme` attribute-based CSS theming system with **dark**, **light**, and **auto** (system preference) modes
- Creates `useTheme` hook that persists the user's choice to `localStorage` and syncs the `data-theme` attribute on `<html>`
- Calls `initTheme()` before React render to prevent a flash of wrong theme on page load
- Wires the existing Settings > Preferences theme toggle to the new hook, adding an "Auto" option

## Changes
- **New** `apps/frontend/src/styles/theme.css` — light theme overrides for all CSS custom properties (colors, shadows, borders) plus `@media (prefers-color-scheme: light)` block for auto mode
- **New** `apps/frontend/src/hooks/useTheme.ts` — `useTheme()` hook and `initTheme()` initializer
- **Modified** `apps/frontend/src/main.tsx` — imports theme.css, calls `initTheme()` before render
- **Modified** `apps/frontend/src/pages/SettingsPage.tsx` — uses `useTheme` hook, renders dark/light/auto toggle group

## Test plan
- [ ] Open Settings > Preferences, verify Dark/Light/Auto buttons render
- [ ] Click Light — verify all pages switch to light palette (white backgrounds, dark text)
- [ ] Click Dark — verify original dark palette is restored
- [ ] Click Auto — verify it follows OS dark/light preference
- [ ] Reload page — verify chosen theme persists (no flash)
- [ ] Clear localStorage, reload — verify dark is the default

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)