### PR TITLE
feat: smart email urgency heuristics (no LLM)

### DIFF
--- a/packages/agents/src/ui/email-urgency.test.ts
+++ b/packages/agents/src/ui/email-urgency.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { classifyEmailUrgency, classifyEmailBatch } from "./email-urgency";
+
+describe("classifyEmailUrgency", () => {
+  it("classifies email with urgent keywords as high", () => {
+    const result = classifyEmailUrgency({
+      from: "boss@company.com",
+      subject: "URGENT: Please respond ASAP",
+      snippet: "We need this done immediately",
+      date: new Date().toISOString(),
+      isUnread: true,
+    });
+    expect(result.urgency).toBe("high");
+    expect(result.score).toBeGreaterThanOrEqual(6);
+  });
+
+  it("classifies email with action required as high", () => {
+    const result = classifyEmailUrgency({
+      from: "hr@company.com",
+      subject: "Action Required: Submit your timesheet",
+      snippet: "Deadline is end of day today",
+      date: new Date().toISOString(),
+      isUnread: true,
+    });
+    expect(result.urgency).toBe("high");
+  });
+
+  it("classifies noreply promotional email as low", () => {
+    const result = classifyEmailUrgency({
+      from: "noreply@store.com",
+      subject: "50% off sale - limited time!",
+      snippet: "Unsubscribe from this newsletter",
+      date: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+      isUnread: false,
+    });
+    expect(result.urgency).toBe("low");
+  });
+
+  it("classifies newsletter digest as low", () => {
+    const result = classifyEmailUrgency({
+      from: "digest@news.com",
+      subject: "Your weekly update",
+      snippet: "Here is your weekly digest",
+      date: new Date(Date.now() - 72 * 60 * 60 * 1000).toISOString(),
+      isUnread: false,
+    });
+    expect(result.urgency).toBe("low");
+  });
+
+  it("classifies a routine follow-up email as medium", () => {
+    const result = classifyEmailUrgency({
+      from: "colleague@company.com",
+      subject: "Follow up on the proposal",
+      snippet: "Just wanted to check in on progress",
+      date: new Date(Date.now() - 30 * 60 * 60 * 1000).toISOString(),
+      isUnread: true,
+    });
+    expect(result.urgency).toBe("medium");
+  });
+
+  it("boosts score for deep reply chains", () => {
+    const shallow = classifyEmailUrgency({
+      from: "peer@company.com",
+      subject: "Project update",
+      snippet: "Here is the latest",
+      date: new Date(Date.now() - 30 * 60 * 60 * 1000).toISOString(),
+    });
+    const deep = classifyEmailUrgency({
+      from: "peer@company.com",
+      subject: "Re: Re: Re: Project update",
+      snippet: "Here is the latest",
+      date: new Date(Date.now() - 30 * 60 * 60 * 1000).toISOString(),
+    });
+    expect(deep.score).toBeGreaterThan(shallow.score);
+  });
+
+  it("boosts recent emails", () => {
+    const old = classifyEmailUrgency({
+      from: "someone@company.com",
+      subject: "Hello",
+      snippet: "Just checking in",
+      date: new Date(Date.now() - 72 * 60 * 60 * 1000).toISOString(),
+    });
+    const recent = classifyEmailUrgency({
+      from: "someone@company.com",
+      subject: "Hello",
+      snippet: "Just checking in",
+      date: new Date().toISOString(),
+    });
+    expect(recent.score).toBeGreaterThan(old.score);
+  });
+
+  it("penalizes emails with Gmail promotional labels", () => {
+    const result = classifyEmailUrgency({
+      from: "deals@shop.com",
+      subject: "New arrivals",
+      snippet: "Check out our latest products",
+      labels: ["CATEGORY_PROMOTIONS"],
+    });
+    expect(result.urgency).toBe("low");
+  });
+
+  it("boosts emails with IMPORTANT label", () => {
+    const without = classifyEmailUrgency({
+      from: "someone@company.com",
+      subject: "FYI",
+      snippet: "See attached",
+    });
+    const withLabel = classifyEmailUrgency({
+      from: "someone@company.com",
+      subject: "FYI",
+      snippet: "See attached",
+      labels: ["IMPORTANT"],
+    });
+    expect(withLabel.score).toBeGreaterThan(without.score);
+  });
+
+  it("handles missing fields gracefully", () => {
+    const result = classifyEmailUrgency({});
+    expect(["high", "medium", "low"]).toContain(result.urgency);
+    expect(typeof result.score).toBe("number");
+  });
+});
+
+describe("classifyEmailBatch", () => {
+  it("returns results for all emails in order", () => {
+    const emails = [
+      { from: "boss@co.com", subject: "URGENT: now" },
+      { from: "noreply@spam.com", subject: "Sale ends today" },
+    ];
+    const results = classifyEmailBatch(emails);
+    expect(results).toHaveLength(2);
+    expect(results[0].urgency).toBeDefined();
+    expect(results[1].urgency).toBeDefined();
+  });
+});

--- a/packages/agents/src/ui/email-urgency.ts
+++ b/packages/agents/src/ui/email-urgency.ts
@@ -1,0 +1,268 @@
+/**
+ * Heuristic-based email urgency scoring.
+ *
+ * Assigns a score to each email based on lightweight signals (keywords,
+ * sender patterns, recency, calendar mentions, reply-chain depth) and
+ * maps the score to a high / medium / low urgency level.
+ *
+ * No LLM calls — runs synchronously on raw email data.
+ */
+
+type UrgencyLevel = "high" | "medium" | "low";
+
+interface RawEmail {
+  from?: string;
+  sender?: string;
+  subject?: string;
+  snippet?: string;
+  text?: string;
+  body?: string;
+  date?: string;
+  receivedAt?: string;
+  isUnread?: boolean;
+  unread?: boolean;
+  labels?: string[];
+  /** Thread message count or similar */
+  threadSize?: number;
+  replyCount?: number;
+}
+
+// ── Keyword lists ──────────────────────────────────────────────────
+
+const HIGH_URGENCY_KEYWORDS = [
+  "urgent",
+  "asap",
+  "immediately",
+  "action required",
+  "action needed",
+  "deadline",
+  "time-sensitive",
+  "time sensitive",
+  "critical",
+  "emergency",
+  "expiring",
+  "expires today",
+  "final notice",
+  "last chance",
+  "respond by",
+  "reply needed",
+  "overdue",
+  "past due",
+  "eod",
+  "end of day",
+];
+
+const MEDIUM_URGENCY_KEYWORDS = [
+  "follow up",
+  "follow-up",
+  "followup",
+  "reminder",
+  "pending",
+  "waiting on",
+  "please review",
+  "feedback requested",
+  "review requested",
+  "fyi",
+  "heads up",
+  "heads-up",
+  "invitation",
+  "invite",
+  "rsvp",
+  "meeting",
+  "schedule",
+  "calendar",
+  "call",
+  "sync",
+  "standup",
+  "stand-up",
+];
+
+const LOW_SIGNAL_KEYWORDS = [
+  "unsubscribe",
+  "no-reply",
+  "noreply",
+  "do not reply",
+  "do-not-reply",
+  "newsletter",
+  "digest",
+  "weekly update",
+  "daily update",
+  "promotional",
+  "promo",
+  "sale",
+  "off your",
+  "% off",
+  "limited time",
+  "special offer",
+  "deal of",
+];
+
+// Senders whose emails are typically low-priority (automated / marketing)
+const LOW_PRIORITY_SENDER_PATTERNS = [
+  /no-?reply/i,
+  /noreply/i,
+  /do-?not-?reply/i,
+  /notifications?@/i,
+  /digest@/i,
+  /newsletter@/i,
+  /marketing@/i,
+  /promo(tions?)?@/i,
+  /updates?@/i,
+  /info@/i,
+  /support@/i,
+  /mailer-daemon/i,
+];
+
+// ── Scoring logic ──────────────────────────────────────────────────
+
+function keywordScore(text: string, keywords: string[]): number {
+  const lower = text.toLowerCase();
+  let hits = 0;
+  for (const kw of keywords) {
+    if (lower.includes(kw)) hits++;
+  }
+  return hits;
+}
+
+function recencyScore(dateStr: string | undefined): number {
+  if (!dateStr) return 0;
+  try {
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return 0;
+    const hoursAgo = (Date.now() - d.getTime()) / (1000 * 60 * 60);
+    if (hoursAgo < 1) return 3;
+    if (hoursAgo < 4) return 2;
+    if (hoursAgo < 24) return 1;
+    return 0;
+  } catch {
+    return 0;
+  }
+}
+
+function senderScore(sender: string): number {
+  for (const pattern of LOW_PRIORITY_SENDER_PATTERNS) {
+    if (pattern.test(sender)) return -3;
+  }
+  return 0;
+}
+
+function replyChainScore(email: RawEmail): number {
+  // Deep reply chains (Re: Re: Re:) suggest an active conversation
+  const subject = email.subject ?? "";
+  const reCount = (subject.match(/\bRe:/gi) ?? []).length;
+  if (reCount >= 3) return 2;
+  if (reCount >= 1) return 1;
+
+  // Thread size from metadata
+  const threadSize = email.threadSize ?? email.replyCount ?? 0;
+  if (threadSize >= 5) return 2;
+  if (threadSize >= 2) return 1;
+
+  return 0;
+}
+
+function calendarMentionScore(text: string): number {
+  const calendarPatterns = [
+    /\b\d{1,2}[/\-.]\d{1,2}[/\-.]\d{2,4}\b/,
+    /\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i,
+    /\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*\s+\d{1,2}/i,
+    /\bmeeting\b/i,
+    /\bcalendar\b/i,
+    /\bschedul/i,
+    /\brsvp\b/i,
+    /\bat \d{1,2}(:\d{2})?\s*(am|pm)\b/i,
+  ];
+  let hits = 0;
+  for (const pat of calendarPatterns) {
+    if (pat.test(text)) hits++;
+  }
+  return Math.min(hits, 2); // cap at 2
+}
+
+function labelScore(labels: string[] | undefined): number {
+  if (!labels) return 0;
+  const upper = labels.map((l) => l.toUpperCase());
+  let score = 0;
+  if (upper.includes("IMPORTANT")) score += 2;
+  if (upper.includes("STARRED")) score += 2;
+  if (upper.includes("CATEGORY_PROMOTIONS")) score -= 3;
+  if (upper.includes("CATEGORY_SOCIAL")) score -= 2;
+  if (upper.includes("CATEGORY_UPDATES")) score -= 1;
+  if (upper.includes("SPAM")) score -= 5;
+  return score;
+}
+
+/**
+ * Compute a numeric urgency score for a single raw email.
+ * Higher = more urgent. The score is then mapped to a level.
+ */
+function computeScore(email: RawEmail): number {
+  const sender = email.from ?? email.sender ?? "";
+  const subject = email.subject ?? "";
+  const body = email.snippet ?? email.text ?? email.body ?? "";
+  const searchable = `${subject} ${body}`;
+  const dateStr = email.date ?? email.receivedAt;
+
+  let score = 0;
+
+  // Keyword analysis (subject weighted more heavily)
+  score += keywordScore(subject, HIGH_URGENCY_KEYWORDS) * 4;
+  score += keywordScore(body, HIGH_URGENCY_KEYWORDS) * 2;
+  score += keywordScore(subject, MEDIUM_URGENCY_KEYWORDS) * 2;
+  score += keywordScore(body, MEDIUM_URGENCY_KEYWORDS) * 1;
+  score -= keywordScore(searchable, LOW_SIGNAL_KEYWORDS) * 2;
+
+  // Sender patterns
+  score += senderScore(sender);
+
+  // Recency
+  score += recencyScore(dateStr);
+
+  // Reply chain depth
+  score += replyChainScore(email);
+
+  // Calendar mentions
+  score += calendarMentionScore(searchable);
+
+  // Gmail labels
+  score += labelScore(email.labels);
+
+  // Unread bonus — unread emails are slightly more urgent
+  if (email.isUnread ?? email.unread) {
+    score += 1;
+  }
+
+  return score;
+}
+
+function scoreToLevel(score: number): UrgencyLevel {
+  if (score >= 6) return "high";
+  if (score >= 2) return "medium";
+  return "low";
+}
+
+// ── Public API ─────────────────────────────────────────────────────
+
+export interface UrgencyResult {
+  urgency: UrgencyLevel;
+  score: number;
+}
+
+/**
+ * Classify urgency for a single email using lightweight heuristics.
+ */
+export function classifyEmailUrgency(
+  email: Record<string, unknown>,
+): UrgencyResult {
+  const score = computeScore(email as unknown as RawEmail);
+  return { urgency: scoreToLevel(score), score };
+}
+
+/**
+ * Classify urgency for a batch of emails. Returns results in the same order.
+ */
+export function classifyEmailBatch(
+  emails: Record<string, unknown>[],
+): UrgencyResult[] {
+  return emails.map((email) => classifyEmailUrgency(email));
+}

--- a/packages/agents/src/ui/inbox-surface.ts
+++ b/packages/agents/src/ui/inbox-surface.ts
@@ -6,6 +6,7 @@ import {
 import { BaseAgent } from "../base-agent";
 import type { AgentInput, AgentContext } from "../types";
 import type { DataRetrievalOutput } from "../context/data-retrieval";
+import { classifyEmailUrgency } from "./email-urgency";
 
 interface EmailSummary {
   id: string;
@@ -187,14 +188,19 @@ export class InboxSurfaceAgent extends BaseAgent {
     }
 
     // Default path: map raw email fields directly — no LLM involved
-    const emails: InboxSurfaceData["emails"] = rawEmails.map((email, i) => ({
-      id: String(email.id ?? email.messageId ?? `email-${i}`),
-      from: String(email.from || email.sender || "Unknown"),
-      subject: String(email.subject || "No Subject"),
-      snippet: String(email.snippet ?? email.text ?? email.body ?? "").slice(0, 200),
-      date: String(email.date ?? email.receivedAt ?? ""),
-      isUnread: Boolean(email.isUnread ?? email.unread ?? true),
-    }));
+    // Apply lightweight heuristic urgency scoring (no LLM cost)
+    const emails: InboxSurfaceData["emails"] = rawEmails.map((email, i) => {
+      const { urgency } = classifyEmailUrgency(email);
+      return {
+        id: String(email.id ?? email.messageId ?? `email-${i}`),
+        from: String(email.from || email.sender || "Unknown"),
+        subject: String(email.subject || "No Subject"),
+        snippet: String(email.snippet ?? email.text ?? email.body ?? "").slice(0, 200),
+        date: String(email.date ?? email.receivedAt ?? ""),
+        isUnread: Boolean(email.isUnread ?? email.unread ?? true),
+        urgency,
+      };
+    });
 
     const batchUnreadCount = emails.filter((e) => e.isUnread).length;
     const unreadCount = gmailTotalUnread ?? batchUnreadCount;
@@ -362,16 +368,19 @@ export class InboxSurfaceAgent extends BaseAgent {
       this.log("LLM analysis failed, falling back to raw email data", { error: errMsg });
       const rawEmails = (Array.isArray(truncatedData) ? truncatedData : [truncatedData]) as Record<string, unknown>[];
       return {
-        emails: rawEmails.map((email, i) => ({
-          id: String(email.id ?? email.messageId ?? `email-${i}`),
-          from: String(email.from || email.sender || "Unknown"),
-          subject: String(email.subject || "No Subject"),
-          snippet: String(email.snippet ?? email.text ?? email.body ?? "").slice(0, 200),
-          date: String(email.date ?? email.receivedAt ?? ""),
-          isUnread: Boolean(email.isUnread ?? email.unread ?? true),
-          urgency: "medium" as const,
-        })),
-        overallSummary: `${rawEmails.length} emails (LLM analysis unavailable)`,
+        emails: rawEmails.map((email, i) => {
+          const { urgency } = classifyEmailUrgency(email);
+          return {
+            id: String(email.id ?? email.messageId ?? `email-${i}`),
+            from: String(email.from || email.sender || "Unknown"),
+            subject: String(email.subject || "No Subject"),
+            snippet: String(email.snippet ?? email.text ?? email.body ?? "").slice(0, 200),
+            date: String(email.date ?? email.receivedAt ?? ""),
+            isUnread: Boolean(email.isUnread ?? email.unread ?? true),
+            urgency,
+          };
+        }),
+        overallSummary: `${rawEmails.length} emails (LLM analysis unavailable, heuristic urgency applied)`,
       };
     }
   }


### PR DESCRIPTION
## Summary
- Adds a new `email-urgency.ts` module with heuristic-based urgency scoring: subject/body keywords (urgent, ASAP, deadline, etc.), sender patterns (noreply, newsletters = low), recency, reply chain depth, calendar mentions, and Gmail label signals
- Integrates scoring into the inbox agent's default (non-WaibScan) path so emails get urgency levels without any LLM cost
- Applies the same heuristics as fallback when LLM analysis fails, replacing the blanket "medium" default
- The existing `GmailEmailCard` urgency badge (high/medium/low with colored styling) displays automatically — no frontend changes needed

Closes #212

## Test plan
- [x] Unit tests for urgency scoring (11 tests covering high/medium/low classification, keyword detection, sender patterns, recency, reply chains, label signals, edge cases)
- [ ] Manual: verify urgency badges appear on inbox emails without triggering WaibScan
- [ ] Manual: verify promotional/noreply emails show "low" urgency
- [ ] Manual: verify emails with urgent keywords show "high" urgency

🤖 Generated with [Claude Code](https://claude.com/claude-code)