### PR TITLE
feat: implement LayoutOrchestrator surface diffing

### DIFF
--- a/apps/frontend/src/blocks/WaibRenderer.tsx
+++ b/apps/frontend/src/blocks/WaibRenderer.tsx
@@ -15,7 +15,7 @@
  *                         └─ children BlockNodes (recursive)
  */
 
-import { useCallback, useContext, useEffect, type ReactNode } from "react";
+import { memo, useCallback, useContext, useEffect, type ReactNode } from "react";
 import type { ComponentBlock, ComponentEventAction } from "@waibspace/types";
 import { ObservationCollectorProvider } from "./ObservationCollector";
 import { BlockStateProvider, BlockStateContext } from "./BlockStateStore";
@@ -33,7 +33,7 @@ export interface WaibRendererProps {
   send: (type: string, payload: unknown) => void;
 }
 
-export function WaibRenderer({ blocks, send }: WaibRendererProps) {
+export const WaibRenderer = memo(function WaibRenderer({ blocks, send }: WaibRendererProps) {
   useEffect(() => {
     registerPrimitiveBlocks();
     registerDomainComponents();
@@ -43,12 +43,12 @@ export function WaibRenderer({ blocks, send }: WaibRendererProps) {
     <ObservationCollectorProvider send={send}>
       <BlockStateProvider>
         {blocks.map((block) => (
-          <BlockNode key={block.id} block={block} send={send} />
+          <MemoizedBlockNode key={block.id} block={block} send={send} />
         ))}
       </BlockStateProvider>
     </ObservationCollectorProvider>
   );
-}
+});
 
 // ---------------------------------------------------------------------------
 // BlockNode — per-block recursive renderer
@@ -138,7 +138,7 @@ function BlockNode({ block, send }: BlockNodeProps) {
   let childNodes: ReactNode = null;
   if (block.children && block.children.length > 0) {
     childNodes = block.children.map((child) => (
-      <BlockNode key={child.id} block={child} send={send} />
+      <MemoizedBlockNode key={child.id} block={child} send={send} />
     ));
   }
 
@@ -150,3 +150,20 @@ function BlockNode({ block, send }: BlockNodeProps) {
     </BlockErrorBoundary>
   );
 }
+
+// ---------------------------------------------------------------------------
+// MemoizedBlockNode — skips re-render when block reference is stable
+// ---------------------------------------------------------------------------
+
+const MemoizedBlockNode = memo(BlockNode, (prev, next) => {
+  // If the block object reference is the same, skip re-render
+  if (prev.block === next.block && prev.send === next.send) return true;
+  // If the block id/type/props are identical, skip re-render
+  if (prev.block.id !== next.block.id) return false;
+  if (prev.block.type !== next.block.type) return false;
+  if (prev.send !== next.send) return false;
+  // For prop equality, rely on reference equality (which we guarantee via
+  // the useSurfaceDiff hook returning stable block references for unchanged
+  // surfaces).
+  return prev.block === next.block;
+});

--- a/apps/frontend/src/components/BlockSurfaceRenderer.tsx
+++ b/apps/frontend/src/components/BlockSurfaceRenderer.tsx
@@ -8,12 +8,13 @@
  * the onInteraction/onAction callbacks that HomePage expects.
  */
 
-import { useMemo, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ComposedLayout } from "@waibspace/ui-renderer-contract";
 import type { SurfaceAction, ComponentBlock } from "@waibspace/types";
 import { WaibRenderer } from "../blocks/WaibRenderer";
-import { transformSurface } from "../blocks/transformers";
 import { ErrorSurface } from "./ErrorSurface";
+import { useSurfaceDiff } from "../hooks/useSurfaceDiff";
+import { isLayoutStale } from "../lib/surface-diff";
 
 // ---------------------------------------------------------------------------
 // Props — identical to SurfaceRenderer
@@ -103,29 +104,23 @@ export function BlockSurfaceRenderer({
   pipelinePhase,
   loadingServices,
 }: BlockSurfaceRendererProps) {
-  // Transform ComposedLayout into ComponentBlock[] per surface
-  const surfaceBlocks = useMemo<
-    Array<{ blocks: ComponentBlock[]; width: string; prominence: string; surfaceId: string; position: number }>
-  >(() => {
-    if (!layout || layout.surfaces.length === 0) return [];
-    const directiveMap = new Map(
-      layout.layout.map((d) => [d.surfaceId, d]),
-    );
-    return layout.surfaces.map((spec, index) => {
-      const directive = directiveMap.get(spec.surfaceId);
-      const blocks = transformSurface(spec);
-      if (import.meta.env.DEV) {
-        console.log(`[BlockRenderer] ${spec.surfaceType}/${spec.surfaceId}`, blocks);
-      }
-      return {
-        blocks,
-        width: directive?.width ?? "full",
-        prominence: directive?.prominence ?? "standard",
-        surfaceId: spec.surfaceId,
-        position: directive?.position ?? index,
-      };
-    });
-  }, [layout]);
+  // Diff-aware surface transformation: only recomputes blocks for surfaces
+  // whose data actually changed. Unchanged surfaces retain stable block
+  // references, allowing React.memo in WaibRenderer to skip re-renders.
+  const { surfaces: surfaceBlocks, diff } = useSurfaceDiff(layout);
+
+  // Log diff summary in development
+  if (import.meta.env.DEV && diff) {
+    const { added, removed, changed, unchanged } = diff;
+    if (added.length || removed.length || changed.length) {
+      console.log(
+        `[SurfaceDiff] +${added.length} -${removed.length} ~${changed.length} =${unchanged.length}`,
+      );
+    }
+  }
+
+  // Staleness indicator: warn if layout data is old
+  const isStale = layout ? isLayoutStale(layout) : false;
 
   // Progressive reveal animation
   const [revealedIds, setRevealedIds] = useState<Set<string>>(new Set());
@@ -271,6 +266,13 @@ export function BlockSurfaceRenderer({
           <div className="loading-banner">
             <div className="loading-spinner small" />
             <span>{PHASE_LABELS[pipelinePhase] ?? pipelinePhase}</span>
+          </div>
+        </div>
+      )}
+      {isStale && (
+        <div className="surface-cell full" style={{ order: -2 }}>
+          <div className="stale-banner">
+            Data may be outdated. Refreshing...
           </div>
         </div>
       )}

--- a/apps/frontend/src/hooks/useSurfaceDiff.ts
+++ b/apps/frontend/src/hooks/useSurfaceDiff.ts
@@ -1,0 +1,125 @@
+/**
+ * useSurfaceDiff — React hook for surface-level diffing.
+ *
+ * Tracks the previous ComposedLayout and computes a diff against the new one.
+ * Returns the diff result plus a stable map of transformed blocks, only
+ * recomputing blocks for surfaces that actually changed.
+ */
+
+import { useRef, useMemo } from "react";
+import type { ComposedLayout } from "@waibspace/ui-renderer-contract";
+import type { ComponentBlock } from "@waibspace/types";
+import { diffLayouts, type SurfaceDiffResult } from "../lib/surface-diff";
+import { transformSurface } from "../blocks/transformers";
+
+export interface SurfaceEntry {
+  blocks: ComponentBlock[];
+  width: string;
+  prominence: string;
+  surfaceId: string;
+  position: number;
+  /** Monotonic version counter — increments only when the surface data changes */
+  version: number;
+}
+
+interface DiffState {
+  /** The previous layout (for diffing against the next update) */
+  previousLayout: ComposedLayout | null;
+  /** Cached transformed blocks keyed by surfaceId */
+  cache: Map<string, SurfaceEntry>;
+  /** Per-surface version counter */
+  versions: Map<string, number>;
+}
+
+export interface UseSurfaceDiffResult {
+  /** Surface entries with stable block references for unchanged surfaces */
+  surfaces: SurfaceEntry[];
+  /** The diff result from comparing old layout to new layout */
+  diff: SurfaceDiffResult | null;
+}
+
+/**
+ * Given a ComposedLayout, returns surface entries where unchanged surfaces
+ * retain their previous block references (enabling React.memo to skip
+ * re-rendering them).
+ */
+export function useSurfaceDiff(
+  layout: ComposedLayout | null,
+): UseSurfaceDiffResult {
+  const stateRef = useRef<DiffState>({
+    previousLayout: null,
+    cache: new Map(),
+    versions: new Map(),
+  });
+
+  const result = useMemo<UseSurfaceDiffResult>(() => {
+    if (!layout || layout.surfaces.length === 0) {
+      return { surfaces: [], diff: null };
+    }
+
+    const state = stateRef.current;
+    const diff = diffLayouts(state.previousLayout, layout);
+
+    const directiveMap = new Map(
+      layout.layout.map((d) => [d.surfaceId, d]),
+    );
+
+    const newCache = new Map<string, SurfaceEntry>();
+
+    for (let index = 0; index < layout.surfaces.length; index++) {
+      const spec = layout.surfaces[index];
+      const directive = directiveMap.get(spec.surfaceId);
+      const surfaceId = spec.surfaceId;
+
+      if (diff.unchanged.includes(surfaceId) && state.cache.has(surfaceId)) {
+        // Surface data is identical — reuse the cached blocks reference.
+        // Only update layout-level props (position/width) which are cheap.
+        const cached = state.cache.get(surfaceId)!;
+        const entry: SurfaceEntry = {
+          ...cached,
+          width: directive?.width ?? "full",
+          prominence: directive?.prominence ?? "standard",
+          position: directive?.position ?? index,
+        };
+        newCache.set(surfaceId, entry);
+      } else {
+        // Surface is new or changed — recompute blocks
+        const blocks = transformSurface(spec);
+        const prevVersion = state.versions.get(surfaceId) ?? 0;
+        const version = prevVersion + 1;
+        state.versions.set(surfaceId, version);
+
+        if (import.meta.env.DEV) {
+          const reason = diff.added.includes(surfaceId) ? "added" : "changed";
+          console.log(
+            `[SurfaceDiff] ${reason}: ${spec.surfaceType}/${surfaceId} (v${version})`,
+            blocks,
+          );
+        }
+
+        const entry: SurfaceEntry = {
+          blocks,
+          width: directive?.width ?? "full",
+          prominence: directive?.prominence ?? "standard",
+          surfaceId,
+          position: directive?.position ?? index,
+          version,
+        };
+        newCache.set(surfaceId, entry);
+      }
+    }
+
+    // Update state for next diff cycle
+    state.previousLayout = layout;
+    state.cache = newCache;
+
+    // Return entries in layout order
+    const surfaces = layout.surfaces
+      .map((spec) => newCache.get(spec.surfaceId)!)
+      .filter(Boolean);
+
+    return { surfaces, diff };
+  }, [layout]);
+
+  return result;
+}

--- a/apps/frontend/src/lib/surface-diff.test.ts
+++ b/apps/frontend/src/lib/surface-diff.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from "bun:test";
+import {
+  blocksEqual,
+  surfaceSpecEqual,
+  diffLayouts,
+  isLayoutStale,
+} from "./surface-diff";
+import type { ComponentBlock, SurfaceSpec } from "@waibspace/types";
+import type { ComposedLayout } from "@waibspace/ui-renderer-contract";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBlock(overrides: Partial<ComponentBlock> = {}): ComponentBlock {
+  return {
+    id: "block-1",
+    type: "Text",
+    props: { content: "hello" },
+    ...overrides,
+  };
+}
+
+function makeSurface(overrides: Partial<SurfaceSpec> = {}): SurfaceSpec {
+  return {
+    surfaceType: "inbox",
+    surfaceId: "surface-1",
+    title: "Inbox",
+    priority: 1,
+    data: { items: [] },
+    actions: [],
+    affordances: [],
+    layoutHints: {},
+    provenance: { sourceAgent: "test", timestamp: Date.now(), dataState: "raw" },
+    confidence: 1.0,
+    ...overrides,
+  } as SurfaceSpec;
+}
+
+function makeLayout(
+  surfaces: SurfaceSpec[],
+  overrides: Partial<ComposedLayout> = {},
+): ComposedLayout {
+  return {
+    surfaces,
+    layout: surfaces.map((s, i) => ({
+      surfaceId: s.surfaceId,
+      position: i,
+      width: "half",
+      prominence: "standard",
+    })),
+    timestamp: Date.now(),
+    traceId: "trace-1",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// blocksEqual
+// ---------------------------------------------------------------------------
+
+describe("blocksEqual", () => {
+  it("returns true for identical block arrays", () => {
+    const a = [makeBlock()];
+    expect(blocksEqual(a, a)).toBe(true);
+  });
+
+  it("returns true for structurally equal blocks", () => {
+    const a = [makeBlock({ id: "a", props: { content: "hi" } })];
+    const b = [makeBlock({ id: "a", props: { content: "hi" } })];
+    expect(blocksEqual(a, b)).toBe(true);
+  });
+
+  it("returns false when props differ", () => {
+    const a = [makeBlock({ props: { content: "hi" } })];
+    const b = [makeBlock({ props: { content: "bye" } })];
+    expect(blocksEqual(a, b)).toBe(false);
+  });
+
+  it("returns false when ids differ", () => {
+    const a = [makeBlock({ id: "a" })];
+    const b = [makeBlock({ id: "b" })];
+    expect(blocksEqual(a, b)).toBe(false);
+  });
+
+  it("returns false when length differs", () => {
+    const a = [makeBlock()];
+    const b = [makeBlock(), makeBlock({ id: "block-2" })];
+    expect(blocksEqual(a, b)).toBe(false);
+  });
+
+  it("handles undefined arrays", () => {
+    expect(blocksEqual(undefined, undefined)).toBe(true);
+    expect(blocksEqual([], undefined)).toBe(false);
+    expect(blocksEqual(undefined, [])).toBe(false);
+  });
+
+  it("compares children recursively", () => {
+    const a = [
+      makeBlock({
+        children: [makeBlock({ id: "child-1", props: { content: "x" } })],
+      }),
+    ];
+    const b = [
+      makeBlock({
+        children: [makeBlock({ id: "child-1", props: { content: "x" } })],
+      }),
+    ];
+    expect(blocksEqual(a, b)).toBe(true);
+  });
+
+  it("detects child differences", () => {
+    const a = [
+      makeBlock({
+        children: [makeBlock({ id: "child-1", props: { content: "x" } })],
+      }),
+    ];
+    const b = [
+      makeBlock({
+        children: [makeBlock({ id: "child-1", props: { content: "y" } })],
+      }),
+    ];
+    expect(blocksEqual(a, b)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// surfaceSpecEqual
+// ---------------------------------------------------------------------------
+
+describe("surfaceSpecEqual", () => {
+  it("returns true for identical specs", () => {
+    const s = makeSurface();
+    expect(surfaceSpecEqual(s, s)).toBe(true);
+  });
+
+  it("returns true for structurally equal specs", () => {
+    const a = makeSurface({ data: { items: [1, 2] } });
+    const b = makeSurface({ data: { items: [1, 2] } });
+    expect(surfaceSpecEqual(a, b)).toBe(true);
+  });
+
+  it("returns false when data differs", () => {
+    const a = makeSurface({ data: { items: [1] } });
+    const b = makeSurface({ data: { items: [1, 2] } });
+    expect(surfaceSpecEqual(a, b)).toBe(false);
+  });
+
+  it("returns false when title differs", () => {
+    const a = makeSurface({ title: "A" });
+    const b = makeSurface({ title: "B" });
+    expect(surfaceSpecEqual(a, b)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// diffLayouts
+// ---------------------------------------------------------------------------
+
+describe("diffLayouts", () => {
+  it("marks all surfaces as added when no previous layout", () => {
+    const s1 = makeSurface({ surfaceId: "s1" });
+    const layout = makeLayout([s1]);
+    const result = diffLayouts(null, layout);
+    expect(result.added).toEqual(["s1"]);
+    expect(result.removed).toEqual([]);
+    expect(result.changed).toEqual([]);
+    expect(result.unchanged).toEqual([]);
+  });
+
+  it("detects unchanged surfaces", () => {
+    const s1 = makeSurface({ surfaceId: "s1", data: { x: 1 } });
+    const oldLayout = makeLayout([s1]);
+    const newLayout = makeLayout([s1]);
+    const result = diffLayouts(oldLayout, newLayout);
+    expect(result.unchanged).toEqual(["s1"]);
+    expect(result.added).toEqual([]);
+    expect(result.changed).toEqual([]);
+  });
+
+  it("detects changed surfaces", () => {
+    const s1Old = makeSurface({ surfaceId: "s1", data: { x: 1 } });
+    const s1New = makeSurface({ surfaceId: "s1", data: { x: 2 } });
+    const result = diffLayouts(makeLayout([s1Old]), makeLayout([s1New]));
+    expect(result.changed).toEqual(["s1"]);
+    expect(result.unchanged).toEqual([]);
+  });
+
+  it("detects added and removed surfaces", () => {
+    const s1 = makeSurface({ surfaceId: "s1" });
+    const s2 = makeSurface({ surfaceId: "s2" });
+    const result = diffLayouts(makeLayout([s1]), makeLayout([s2]));
+    expect(result.added).toEqual(["s2"]);
+    expect(result.removed).toEqual(["s1"]);
+  });
+
+  it("handles mixed add/remove/change/unchanged", () => {
+    const s1 = makeSurface({ surfaceId: "s1", data: { x: 1 } });
+    const s2Old = makeSurface({ surfaceId: "s2", data: { y: 1 } });
+    const s2New = makeSurface({ surfaceId: "s2", data: { y: 2 } });
+    const s3 = makeSurface({ surfaceId: "s3" });
+
+    const oldLayout = makeLayout([s1, s2Old]);
+    const newLayout = makeLayout([s1, s2New, s3]);
+
+    const result = diffLayouts(oldLayout, newLayout);
+    expect(result.unchanged).toEqual(["s1"]);
+    expect(result.changed).toEqual(["s2"]);
+    expect(result.added).toEqual(["s3"]);
+    expect(result.removed).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isLayoutStale
+// ---------------------------------------------------------------------------
+
+describe("isLayoutStale", () => {
+  it("returns false for recent layout", () => {
+    const layout = makeLayout([], { timestamp: Date.now() });
+    expect(isLayoutStale(layout)).toBe(false);
+  });
+
+  it("returns true for old layout", () => {
+    const layout = makeLayout([], { timestamp: Date.now() - 60_000 });
+    expect(isLayoutStale(layout)).toBe(true);
+  });
+});

--- a/apps/frontend/src/lib/surface-diff.ts
+++ b/apps/frontend/src/lib/surface-diff.ts
@@ -1,0 +1,192 @@
+/**
+ * surface-diff — Minimal diff algorithm for SurfaceSpec / ComponentBlock trees.
+ *
+ * Compares old and new surface layouts and determines which surfaces changed,
+ * which were added/removed, and which blocks within a surface changed. This
+ * allows the renderer to skip re-rendering surfaces whose data hasn't changed,
+ * preserving component state (form inputs, scroll position, etc.).
+ */
+
+import type { ComponentBlock, SurfaceSpec } from "@waibspace/types";
+import type { ComposedLayout } from "@waibspace/ui-renderer-contract";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SurfaceDiffResult {
+  /** Surfaces that are new (not in old layout) */
+  added: string[];
+  /** Surfaces that were removed (not in new layout) */
+  removed: string[];
+  /** Surfaces whose data or blocks changed */
+  changed: string[];
+  /** Surfaces that are identical — safe to skip re-render */
+  unchanged: string[];
+  /** New layout version (timestamp) */
+  version: number;
+  /** Previous layout version */
+  previousVersion: number;
+}
+
+// ---------------------------------------------------------------------------
+// Block-level deep equality
+// ---------------------------------------------------------------------------
+
+/**
+ * Fast deep-equal for ComponentBlock trees. Returns true if the two block
+ * trees are structurally identical (same ids, types, props, children).
+ */
+export function blocksEqual(
+  a: ComponentBlock[] | undefined,
+  b: ComponentBlock[] | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return a === b;
+  if (a.length !== b.length) return false;
+
+  for (let i = 0; i < a.length; i++) {
+    if (!blockEqual(a[i], b[i])) return false;
+  }
+  return true;
+}
+
+function blockEqual(a: ComponentBlock, b: ComponentBlock): boolean {
+  if (a === b) return true;
+  if (a.id !== b.id || a.type !== b.type) return false;
+  if (!shallowObjectEqual(a.props, b.props)) return false;
+  return blocksEqual(a.children, b.children);
+}
+
+/**
+ * Shallow comparison of two plain objects. Handles primitive values and
+ * falls back to JSON comparison for nested objects/arrays.
+ */
+function shallowObjectEqual(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): boolean {
+  if (a === b) return true;
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+
+  for (const key of keysA) {
+    const valA = a[key];
+    const valB = b[key];
+    if (valA === valB) continue;
+    if (
+      typeof valA !== typeof valB ||
+      typeof valA !== "object" ||
+      valA === null ||
+      valB === null
+    ) {
+      return false;
+    }
+    // For nested objects/arrays, use JSON stringification as a last resort.
+    // This is acceptable because block props are typically small.
+    if (JSON.stringify(valA) !== JSON.stringify(valB)) return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Surface-level diff
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two SurfaceSpec objects for equality. Checks surfaceType, title,
+ * summary, priority, data (via JSON), actions, and affordances.
+ */
+export function surfaceSpecEqual(a: SurfaceSpec, b: SurfaceSpec): boolean {
+  if (a === b) return true;
+  if (a.surfaceId !== b.surfaceId) return false;
+  if (a.surfaceType !== b.surfaceType) return false;
+  if (a.title !== b.title) return false;
+  if (a.summary !== b.summary) return false;
+  if (a.priority !== b.priority) return false;
+  if (a.confidence !== b.confidence) return false;
+
+  // Data is the main payload — deep compare
+  if (JSON.stringify(a.data) !== JSON.stringify(b.data)) return false;
+
+  // Actions and affordances
+  if (JSON.stringify(a.actions) !== JSON.stringify(b.actions)) return false;
+  if (JSON.stringify(a.affordances) !== JSON.stringify(b.affordances))
+    return false;
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Layout diff
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a minimal diff between two ComposedLayouts. Returns which surfaces
+ * were added, removed, changed, or left unchanged.
+ */
+export function diffLayouts(
+  oldLayout: ComposedLayout | null,
+  newLayout: ComposedLayout,
+): SurfaceDiffResult {
+  const result: SurfaceDiffResult = {
+    added: [],
+    removed: [],
+    changed: [],
+    unchanged: [],
+    version: newLayout.timestamp,
+    previousVersion: oldLayout?.timestamp ?? 0,
+  };
+
+  if (!oldLayout) {
+    // Everything is new
+    result.added = newLayout.surfaces.map((s) => s.surfaceId);
+    return result;
+  }
+
+  const oldMap = new Map<string, SurfaceSpec>();
+  for (const s of oldLayout.surfaces) {
+    oldMap.set(s.surfaceId, s);
+  }
+
+  const newIds = new Set<string>();
+
+  for (const newSurface of newLayout.surfaces) {
+    newIds.add(newSurface.surfaceId);
+    const oldSurface = oldMap.get(newSurface.surfaceId);
+
+    if (!oldSurface) {
+      result.added.push(newSurface.surfaceId);
+    } else if (surfaceSpecEqual(oldSurface, newSurface)) {
+      result.unchanged.push(newSurface.surfaceId);
+    } else {
+      result.changed.push(newSurface.surfaceId);
+    }
+  }
+
+  // Detect removals
+  for (const oldId of oldMap.keys()) {
+    if (!newIds.has(oldId)) {
+      result.removed.push(oldId);
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Staleness detection
+// ---------------------------------------------------------------------------
+
+const STALE_THRESHOLD_MS = 30_000; // 30 seconds
+
+/**
+ * Returns true if the layout is considered stale based on its timestamp.
+ */
+export function isLayoutStale(
+  layout: ComposedLayout,
+  now: number = Date.now(),
+): boolean {
+  return now - layout.timestamp > STALE_THRESHOLD_MS;
+}


### PR DESCRIPTION
## Summary
- Add a diff algorithm (`surface-diff.ts`) that compares old and new `ComposedLayout` specs, identifying added/removed/changed/unchanged surfaces
- Introduce `useSurfaceDiff` hook that caches transformed blocks per surface and only recomputes blocks for surfaces whose data actually changed — unchanged surfaces retain stable object references
- Wrap `WaibRenderer` and `BlockNode` in `React.memo` with custom comparators so unchanged block subtrees skip re-rendering entirely
- Add staleness detection (30s threshold) with a UI banner when layout data is old

## Test plan
- [x] 19 unit tests passing for `blocksEqual`, `surfaceSpecEqual`, `diffLayouts`, and `isLayoutStale`
- [ ] Verify form inputs retain their values when other surfaces update
- [ ] Verify scroll position is preserved on surfaces that did not change
- [ ] Check dev console logs show correct diff summaries (`+added -removed ~changed =unchanged`)
- [ ] Confirm stale banner appears after 30s without a layout update

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)