### PR TITLE
feat: implement email thread view with conversation history

### DIFF
--- a/apps/frontend/src/blocks/components/domain/gmail/GmailEmailCard.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailEmailCard.tsx
@@ -3,6 +3,7 @@ import type { BlockProps } from "../../../registry";
 
 interface GmailEmailCardProps {
   emailId: string;
+  threadId?: string;
   from: string;
   subject: string;
   snippet: string;
@@ -36,6 +37,7 @@ function getInitials(name: string): string {
 export function GmailEmailCard({ block, onEvent }: BlockProps) {
   const {
     emailId,
+    threadId,
     from,
     subject,
     snippet,
@@ -67,8 +69,14 @@ export function GmailEmailCard({ block, onEvent }: BlockProps) {
     [onEvent, emailId, from, subject],
   );
 
+  const handleCardClick = useCallback(() => {
+    if (threadId) {
+      onEvent?.("open-thread", { threadId, emailId, subject, from });
+    }
+  }, [onEvent, threadId, emailId, subject, from]);
+
   return (
-    <div className={cardClass} role="listitem" tabIndex={0} aria-label={`${isUnread ? "Unread: " : ""}${subject || "No Subject"} from ${from}`}>
+    <div className={cardClass} role="listitem" tabIndex={0} aria-label={`${isUnread ? "Unread: " : ""}${subject || "No Subject"} from ${from}`} onClick={handleCardClick} onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") handleCardClick(); }}>
       <div
         className="gmail-email-card__avatar"
         style={{ backgroundColor: avatarBg }}

--- a/apps/frontend/src/blocks/components/domain/gmail/GmailThreadView.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailThreadView.tsx
@@ -1,0 +1,277 @@
+import { useState, useCallback } from "react";
+import type { BlockProps } from "../../../registry";
+
+interface ThreadMessage {
+  id: string;
+  from: string;
+  to: string;
+  date: string;
+  body: string;
+  snippet: string;
+  isUnread: boolean;
+}
+
+interface GmailThreadViewProps {
+  threadId: string;
+  subject: string;
+  messageCount: number;
+  messages: ThreadMessage[];
+}
+
+/**
+ * Derive a hue from a string so the same sender always gets the same colour.
+ */
+function senderHue(name: string): number {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return Math.abs(hash) % 360;
+}
+
+function getInitials(name: string): string {
+  // Strip email portion if present: "Alice Smith <alice@x.com>" -> "Alice Smith"
+  const clean = name.replace(/<[^>]+>/, "").trim();
+  const parts = clean.split(/\s+/);
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  }
+  return clean.slice(0, 2).toUpperCase();
+}
+
+function getDisplayName(from: string): string {
+  const match = from.match(/^([^<]+)</);
+  return match ? match[1].trim() : from;
+}
+
+/** Number of messages shown before the thread is collapsed */
+const COLLAPSE_THRESHOLD = 3;
+
+export function GmailThreadView({ block, onEvent }: BlockProps) {
+  const { threadId, subject, messageCount, messages } =
+    block.props as GmailThreadViewProps;
+
+  // Track which individual messages are expanded (show full body)
+  const [expandedMessages, setExpandedMessages] = useState<Set<string>>(() => {
+    // By default expand the last message
+    if (messages.length > 0) {
+      return new Set([messages[messages.length - 1].id]);
+    }
+    return new Set();
+  });
+
+  // Track whether the collapsed middle section is expanded
+  const [showAllMessages, setShowAllMessages] = useState(
+    messages.length <= COLLAPSE_THRESHOLD,
+  );
+
+  const toggleMessage = useCallback((messageId: string) => {
+    setExpandedMessages((prev) => {
+      const next = new Set(prev);
+      if (next.has(messageId)) {
+        next.delete(messageId);
+      } else {
+        next.add(messageId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleReply = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      const lastMessage = messages[messages.length - 1];
+      onEvent?.("reply", {
+        threadId,
+        emailId: lastMessage?.id,
+        subject,
+      });
+    },
+    [onEvent, threadId, messages, subject],
+  );
+
+  const handleBack = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onEvent?.("back", { threadId });
+    },
+    [onEvent, threadId],
+  );
+
+  // Determine which messages to render
+  const shouldCollapse =
+    !showAllMessages && messages.length > COLLAPSE_THRESHOLD;
+  const visibleMessages = shouldCollapse
+    ? [messages[0], ...messages.slice(-2)]
+    : messages;
+  const collapsedCount = shouldCollapse
+    ? messages.length - 3
+    : 0;
+
+  return (
+    <div
+      className="gmail-thread-view"
+      role="region"
+      aria-label={`Email thread: ${subject}`}
+    >
+      {/* Header */}
+      <div className="gmail-thread-view__header">
+        <button
+          type="button"
+          className="gmail-thread-view__back-btn"
+          onClick={handleBack}
+          aria-label="Back to inbox"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M10 3L5 8l5 5"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+        <div className="gmail-thread-view__header-content">
+          <h3 className="gmail-thread-view__subject">{subject}</h3>
+          <span className="gmail-thread-view__message-count">
+            {messageCount} message{messageCount !== 1 ? "s" : ""}
+          </span>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <div className="gmail-thread-view__messages" role="list">
+        {visibleMessages.map((msg, idx) => {
+          const isExpanded = expandedMessages.has(msg.id);
+          const displayName = getDisplayName(msg.from);
+          const initials = getInitials(msg.from);
+          const hue = senderHue(msg.from);
+          const avatarBg = `hsl(${hue}, 55%, 45%)`;
+
+          // Insert the collapsed section after the first message
+          const showCollapseBar =
+            shouldCollapse && idx === 0;
+
+          return (
+            <div key={msg.id}>
+              {showCollapseBar && (
+                <button
+                  type="button"
+                  className="gmail-thread-view__collapsed-bar"
+                  onClick={() => setShowAllMessages(true)}
+                  aria-label={`Show ${collapsedCount} hidden message${collapsedCount !== 1 ? "s" : ""}`}
+                >
+                  <span className="gmail-thread-view__collapsed-dots">
+                    &#8943;
+                  </span>
+                  <span className="gmail-thread-view__collapsed-text">
+                    {collapsedCount} earlier message
+                    {collapsedCount !== 1 ? "s" : ""}
+                  </span>
+                </button>
+              )}
+              <div
+                className={[
+                  "gmail-thread-view__message",
+                  isExpanded ? "gmail-thread-view__message--expanded" : "",
+                  msg.isUnread ? "gmail-thread-view__message--unread" : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
+                role="listitem"
+              >
+                <button
+                  type="button"
+                  className="gmail-thread-view__message-header"
+                  onClick={() => toggleMessage(msg.id)}
+                  aria-expanded={isExpanded}
+                  aria-label={`${isExpanded ? "Collapse" : "Expand"} message from ${displayName}`}
+                >
+                  <div
+                    className="gmail-thread-view__avatar"
+                    style={{ backgroundColor: avatarBg }}
+                    aria-hidden="true"
+                  >
+                    {initials}
+                  </div>
+                  <div className="gmail-thread-view__message-meta">
+                    <span className="gmail-thread-view__sender">
+                      {displayName}
+                    </span>
+                    <span className="gmail-thread-view__date">{msg.date}</span>
+                  </div>
+                  <svg
+                    className={`gmail-thread-view__chevron${isExpanded ? " gmail-thread-view__chevron--open" : ""}`}
+                    width="14"
+                    height="14"
+                    viewBox="0 0 14 14"
+                    fill="none"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M4 5.5L7 8.5l3-3"
+                      stroke="currentColor"
+                      strokeWidth="1.3"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+
+                {!isExpanded && (
+                  <p className="gmail-thread-view__snippet">{msg.snippet}</p>
+                )}
+
+                {isExpanded && (
+                  <div className="gmail-thread-view__body">
+                    <div className="gmail-thread-view__body-meta">
+                      <span>
+                        To: {msg.to}
+                      </span>
+                    </div>
+                    <div className="gmail-thread-view__body-text">
+                      {msg.body}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Footer actions */}
+      <div className="gmail-thread-view__footer">
+        <button
+          type="button"
+          className="gmail-thread-view__reply-btn"
+          onClick={handleReply}
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M6.5 4L2.5 8l4 4M2.5 8h7a4 4 0 014 4"
+              stroke="currentColor"
+              strokeWidth="1.3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          Reply
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/blocks/components/domain/gmail/index.ts
+++ b/apps/frontend/src/blocks/components/domain/gmail/index.ts
@@ -2,6 +2,7 @@ import { registerBlocks } from "../../../registry";
 import { GmailEmailCard } from "./GmailEmailCard";
 import { GmailInboxList } from "./GmailInboxList";
 import { GmailScanResult } from "./GmailScanResult";
+import { GmailThreadView } from "./GmailThreadView";
 
 /**
  * Register all Gmail domain block components.
@@ -37,6 +38,16 @@ export function registerGmailComponents(): void {
         category: "domain",
         source: "gmail.waib",
         description: "Summary card displayed after WaibScan analysis",
+      },
+    },
+    {
+      type: "GmailThreadView",
+      component: GmailThreadView,
+      registration: {
+        type: "GmailThreadView",
+        category: "domain",
+        source: "gmail.waib",
+        description: "Thread conversation view with expand/collapse message bubbles",
       },
     },
   ]);

--- a/apps/frontend/src/styles/gmail-components.css
+++ b/apps/frontend/src/styles/gmail-components.css
@@ -354,6 +354,306 @@
   line-height: var(--leading-normal);
 }
 
+/* ---- GmailThreadView ---- */
+
+.gmail-thread-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.gmail-thread-view__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-1);
+}
+
+.gmail-thread-view__back-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.gmail-thread-view__back-btn:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.gmail-thread-view__back-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.gmail-thread-view__header-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.gmail-thread-view__subject {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gmail-thread-view__message-count {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+}
+
+/* ---- Thread Messages List ---- */
+
+.gmail-thread-view__messages {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.gmail-thread-view__message {
+  border: 1px solid var(--color-border);
+  border-radius: var(--block-card-radius);
+  background: var(--color-surface);
+  margin-bottom: var(--space-2);
+  overflow: hidden;
+  transition: box-shadow var(--transition-fast);
+}
+
+.gmail-thread-view__message--expanded {
+  box-shadow: var(--shadow-sm);
+}
+
+.gmail-thread-view__message--unread {
+  border-left: 3px solid var(--color-accent);
+}
+
+/* ---- Message Header (clickable) ---- */
+
+.gmail-thread-view__message-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  width: 100%;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-sans);
+  transition: background var(--transition-fast);
+}
+
+.gmail-thread-view__message-header:hover {
+  background: var(--color-surface-hover);
+}
+
+.gmail-thread-view__message-header:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.gmail-thread-view__avatar {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  font-family: var(--font-sans);
+  line-height: 1;
+  user-select: none;
+}
+
+.gmail-thread-view__message-meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.gmail-thread-view__sender {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gmail-thread-view__message--unread .gmail-thread-view__sender {
+  font-weight: var(--weight-bold);
+}
+
+.gmail-thread-view__date {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.gmail-thread-view__chevron {
+  flex-shrink: 0;
+  color: var(--color-muted);
+  transition: transform var(--transition-fast);
+}
+
+.gmail-thread-view__chevron--open {
+  transform: rotate(180deg);
+}
+
+/* ---- Collapsed snippet (shown when message is not expanded) ---- */
+
+.gmail-thread-view__snippet {
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+  padding: 0 var(--space-3) var(--space-3) calc(32px + var(--space-3) + var(--space-3));
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ---- Expanded body ---- */
+
+.gmail-thread-view__body {
+  padding: 0 var(--space-3) var(--space-4) calc(32px + var(--space-3) + var(--space-3));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.gmail-thread-view__body-meta {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  display: flex;
+  gap: var(--space-2);
+}
+
+.gmail-thread-view__body-text {
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  line-height: var(--leading-relaxed, 1.65);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ---- Collapsed Messages Bar ---- */
+
+.gmail-thread-view__collapsed-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  margin-bottom: var(--space-2);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--block-card-radius);
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.gmail-thread-view__collapsed-bar:hover {
+  background: var(--color-surface-hover);
+  border-color: var(--color-text-secondary);
+}
+
+.gmail-thread-view__collapsed-bar:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.gmail-thread-view__collapsed-dots {
+  font-size: var(--text-lg);
+  color: var(--color-muted);
+  line-height: 1;
+}
+
+.gmail-thread-view__collapsed-text {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+/* ---- Thread Footer ---- */
+
+.gmail-thread-view__footer {
+  display: flex;
+  gap: var(--space-2);
+  padding: 0 var(--space-1);
+}
+
+.gmail-thread-view__reply-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-md);
+  background: var(--color-accent-subtle);
+  color: var(--color-accent-hover);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.gmail-thread-view__reply-btn:hover {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.gmail-thread-view__reply-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/* ---- GmailThreadView Mobile ---- */
+
+@media (max-width: 640px) {
+  .gmail-thread-view__subject {
+    font-size: var(--text-lg);
+  }
+
+  .gmail-thread-view__avatar {
+    width: 26px;
+    height: 26px;
+    font-size: 10px;
+  }
+
+  .gmail-thread-view__body {
+    padding-left: var(--space-3);
+  }
+
+  .gmail-thread-view__snippet {
+    padding-left: var(--space-3);
+  }
+}
+
 /* ---- GmailEmailCard Skeleton ---- */
 
 .gmail-email-card--skeleton {

--- a/packages/connectors/src/gmail/gmail-connector.ts
+++ b/packages/connectors/src/gmail/gmail-connector.ts
@@ -6,9 +6,12 @@ import type {
   EmailSummary,
   ListEmailsParams,
   GetEmailParams,
+  GetThreadParams,
   SearchEmailsParams,
   CreateDraftParams,
   SendEmailParams,
+  ThreadMessage,
+  ThreadData,
 } from "./types";
 
 function getGmailClient(): { gmail: gmail_v1.Gmail; auth: OAuth2Client } {
@@ -81,7 +84,7 @@ export class GmailConnector extends BaseConnector {
       capabilities: {
         connectorId: "gmail",
         connectorType: "api",
-        actions: ["list-emails", "get-email", "search-emails", "get-inbox-stats", "create-draft", "send-email"],
+        actions: ["list-emails", "get-email", "get-thread", "search-emails", "get-inbox-stats", "create-draft", "send-email"],
         dataTypes: ["email"],
         trustLevel: "trusted",
       },
@@ -130,6 +133,8 @@ export class GmailConnector extends BaseConnector {
         return this.listEmails(request.params as unknown as ListEmailsParams);
       case "get-email":
         return this.getEmail(request.params as unknown as GetEmailParams);
+      case "get-thread":
+        return this.getThread(request.params as unknown as GetThreadParams);
       case "search-emails":
         return this.searchEmails(request.params as unknown as SearchEmailsParams);
       case "get-inbox-stats":
@@ -286,6 +291,45 @@ export class GmailConnector extends BaseConnector {
     return {
       success: true,
       result: { messageId: res.data.id, threadId: res.data.threadId },
+    };
+  }
+
+  private async getThread(params: GetThreadParams): Promise<ConnectorResponse> {
+    const res = await this.gmail!.users.threads.get({
+      userId: "me",
+      id: params.threadId,
+      format: "full",
+    });
+
+    const thread = res.data;
+    const messages: ThreadMessage[] = (thread.messages ?? []).map((msg) => {
+      const headers = msg.payload?.headers;
+      return {
+        id: msg.id ?? "",
+        from: getHeader(headers, "From"),
+        to: getHeader(headers, "To"),
+        date: getHeader(headers, "Date"),
+        body: this.extractBody(msg),
+        snippet: msg.snippet ?? "",
+        isUnread: msg.labelIds?.includes("UNREAD") ?? false,
+      };
+    });
+
+    const subject = messages.length > 0
+      ? getHeader(thread.messages?.[0]?.payload?.headers, "Subject")
+      : "";
+
+    const threadData: ThreadData = {
+      threadId: params.threadId,
+      subject,
+      messageCount: messages.length,
+      messages,
+    };
+
+    return {
+      data: threadData,
+      provenance: this.createProvenance(),
+      raw: res.data,
     };
   }
 

--- a/packages/connectors/src/gmail/index.ts
+++ b/packages/connectors/src/gmail/index.ts
@@ -4,7 +4,10 @@ export type {
   EmailSummary,
   ListEmailsParams,
   GetEmailParams,
+  GetThreadParams,
   SearchEmailsParams,
   CreateDraftParams,
   SendEmailParams,
+  ThreadMessage,
+  ThreadData,
 } from "./types";

--- a/packages/connectors/src/gmail/mock-gmail-connector.ts
+++ b/packages/connectors/src/gmail/mock-gmail-connector.ts
@@ -4,7 +4,10 @@ import type {
   EmailSummary,
   ListEmailsParams,
   GetEmailParams,
+  GetThreadParams,
   SearchEmailsParams,
+  ThreadMessage,
+  ThreadData,
 } from "./types";
 import { FIXTURE_EMAILS, FIXTURE_BODIES } from "./fixtures";
 
@@ -24,7 +27,7 @@ export class MockGmailConnector extends BaseConnector {
       capabilities: {
         connectorId: "gmail",
         connectorType: "api",
-        actions: ["list-emails", "get-email", "search-emails", "get-inbox-stats", "create-draft", "send-email"],
+        actions: ["list-emails", "get-email", "get-thread", "search-emails", "get-inbox-stats", "create-draft", "send-email"],
         dataTypes: ["email"],
         trustLevel: "trusted",
       },
@@ -59,6 +62,8 @@ export class MockGmailConnector extends BaseConnector {
         return this.listEmails(request.params as unknown as ListEmailsParams);
       case "get-email":
         return this.getEmail(request.params as unknown as GetEmailParams);
+      case "get-thread":
+        return this.getThread(request.params as unknown as GetThreadParams);
       case "search-emails":
         return this.searchEmails(request.params as unknown as SearchEmailsParams);
       case "get-inbox-stats":
@@ -145,6 +150,38 @@ export class MockGmailConnector extends BaseConnector {
       query: params.query,
       maxResults: params.maxResults,
     });
+  }
+
+  private async getThread(params: GetThreadParams): Promise<ConnectorResponse> {
+    const threadEmails = this.emails.filter((e) => e.threadId === params.threadId);
+    if (threadEmails.length === 0) {
+      throw new Error(`Thread not found: ${params.threadId}`);
+    }
+
+    const subject = threadEmails[0].subject;
+
+    // Build thread messages — use fixture body if available, otherwise snippet
+    const messages: ThreadMessage[] = threadEmails.map((e) => ({
+      id: e.id,
+      from: e.from,
+      to: e.to,
+      date: e.date,
+      body: FIXTURE_BODIES[e.id] ?? e.snippet,
+      snippet: e.snippet,
+      isUnread: e.isUnread,
+    }));
+
+    const threadData: ThreadData = {
+      threadId: params.threadId,
+      subject,
+      messageCount: messages.length,
+      messages,
+    };
+
+    return {
+      data: threadData,
+      provenance: this.createProvenance(),
+    };
   }
 
   private async getInboxStats(): Promise<ConnectorResponse> {

--- a/packages/connectors/src/gmail/types.ts
+++ b/packages/connectors/src/gmail/types.ts
@@ -38,3 +38,24 @@ export interface SendEmailParams {
   body?: string;
   draftId?: string;
 }
+
+export interface GetThreadParams {
+  threadId: string;
+}
+
+export interface ThreadMessage {
+  id: string;
+  from: string;
+  to: string;
+  date: string;
+  body: string;
+  snippet: string;
+  isUnread: boolean;
+}
+
+export interface ThreadData {
+  threadId: string;
+  subject: string;
+  messageCount: number;
+  messages: ThreadMessage[];
+}


### PR DESCRIPTION
## Summary
- Add `GmailThreadView` component that renders thread messages in chronological order with per-message expand/collapse and sender avatars
- Auto-collapse middle messages when thread has more than 3 messages, with a "show N earlier messages" bar to expand
- Wire `GmailEmailCard` click to emit `open-thread` event using `threadId`
- Add `get-thread` operation to `GmailConnector` (uses `users.threads.get`) and `MockGmailConnector` with new types (`GetThreadParams`, `ThreadMessage`, `ThreadData`)
- CSS follows existing BEM naming and CSS custom properties conventions with mobile responsive breakpoints

## Test plan
- [ ] Verify `GmailThreadView` renders with mock data by providing a block with `type: "GmailThreadView"` and thread props
- [ ] Click an email card and confirm `open-thread` event fires with correct `threadId`
- [ ] Expand/collapse individual messages in the thread view
- [ ] For threads with >3 messages, verify the collapsed bar shows and expands correctly
- [ ] Check mobile layout at 640px breakpoint
- [ ] Verify `MockGmailConnector.doFetch("get-thread", ...)` returns expected `ThreadData`

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)