### PR TITLE
feat: add notification system for background task results

### DIFF
--- a/apps/backend/src/background/scheduler.ts
+++ b/apps/backend/src/background/scheduler.ts
@@ -114,6 +114,19 @@ export class BackgroundTaskScheduler {
       task.consecutiveFailures = 0;
       this.pushHistory(taskId, execution);
 
+      this.eventBus.emit(
+        createEvent(
+          "background.task.complete",
+          {
+            taskId: task.id,
+            taskName: task.name,
+            success: true,
+            durationMs: execution.durationMs,
+          },
+          "background-scheduler",
+        ),
+      );
+
       console.log(
         `[scheduler] Task "${task.name}" completed successfully (${execution.durationMs}ms)`,
       );
@@ -135,8 +148,25 @@ export class BackgroundTaskScheduler {
         `[scheduler] Task "${task.name}" failed (attempt ${attempt + 1}): ${errorMsg}`,
       );
 
-      // Schedule retry if within limits
+      // Emit failure notification when retries are exhausted
       const maxRetries = task.maxRetries ?? 0;
+      if (attempt >= maxRetries || !task.enabled || this.stopped) {
+        this.eventBus.emit(
+          createEvent(
+            "background.task.complete",
+            {
+              taskId: task.id,
+              taskName: task.name,
+              success: false,
+              durationMs: execution.durationMs,
+              error: errorMsg,
+            },
+            "background-scheduler",
+          ),
+        );
+      }
+
+      // Schedule retry if within limits
       if (attempt < maxRetries && task.enabled && !this.stopped) {
         const backoffMs = (task.retryBackoffMs ?? DEFAULT_RETRY_BACKOFF_MS) * Math.pow(2, attempt);
         console.log(

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -273,6 +273,26 @@ bus.on("surface.composed", (event: WaibEvent) => {
   broadcast(message);
 });
 
+// ---------- 11b. Broadcast background task completion notifications ----------
+bus.on("background.task.complete", (event: WaibEvent) => {
+  const payload = event.payload as {
+    taskId: string;
+    taskName: string;
+    success: boolean;
+    durationMs: number;
+    error?: string;
+  };
+  const message: ServerMessage = {
+    type: "task.complete",
+    payload,
+  };
+  log.child({ traceId: event.traceId }).info("Broadcasting task.complete", {
+    taskId: payload.taskId,
+    success: payload.success,
+  });
+  broadcast(message);
+});
+
 // ---------- 12. Start HTTP/WebSocket server ----------
 const server = startServer({ eventBus: bus, orchestrator, memoryStore, scheduler, mcpRegistry, connectorRegistry, db, pendingActionStore });
 

--- a/apps/frontend/src/components/NotificationToast.tsx
+++ b/apps/frontend/src/components/NotificationToast.tsx
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface Notification {
+  id: string;
+  type: "success" | "error";
+  title: string;
+  message?: string;
+  /** Timestamp when the notification was created (ms). */
+  createdAt: number;
+}
+
+interface NotificationToastProps {
+  notification: Notification;
+  onDismiss: (id: string) => void;
+  /** Auto-dismiss timeout in ms. Defaults to 6000. */
+  timeout?: number;
+}
+
+function NotificationToastItem({
+  notification,
+  onDismiss,
+  timeout = 6000,
+}: NotificationToastProps) {
+  const [exiting, setExiting] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const startDismiss = useCallback(() => {
+    setExiting(true);
+    // Wait for exit animation before removing
+    setTimeout(() => onDismiss(notification.id), 200);
+  }, [notification.id, onDismiss]);
+
+  useEffect(() => {
+    timerRef.current = setTimeout(startDismiss, timeout);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [startDismiss, timeout]);
+
+  const variant = notification.type === "success" ? "success" : "error";
+  const icon = notification.type === "success" ? "\u2713" : "\u2717";
+
+  return (
+    <div
+      className={`notification-toast notification-toast--${variant}${exiting ? " notification-toast--exiting" : ""}`}
+      role="alert"
+    >
+      <span className="notification-toast__icon" aria-hidden="true">
+        {icon}
+      </span>
+      <div className="notification-toast__body">
+        <p className="notification-toast__title">{notification.title}</p>
+        {notification.message && (
+          <p className="notification-toast__message">{notification.message}</p>
+        )}
+      </div>
+      <button
+        className="notification-toast__dismiss"
+        onClick={startDismiss}
+        aria-label="Dismiss notification"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}
+
+const MAX_VISIBLE = 5;
+
+interface NotificationStackProps {
+  notifications: Notification[];
+  onDismiss: (id: string) => void;
+}
+
+export function NotificationStack({
+  notifications,
+  onDismiss,
+}: NotificationStackProps) {
+  if (notifications.length === 0) return null;
+
+  const visible = notifications.slice(-MAX_VISIBLE);
+
+  return (
+    <div className="notification-stack">
+      {visible.map((n) => (
+        <NotificationToastItem
+          key={n.id}
+          notification={n}
+          onDismiss={onDismiss}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/hooks/useNotifications.ts
+++ b/apps/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from "react";
+import type { WebSocketMessage } from "./useWebSocket";
+import type { Notification } from "../components/NotificationToast";
+
+let nextId = 0;
+
+interface TaskCompletePayload {
+  taskId: string;
+  taskName: string;
+  success: boolean;
+  durationMs: number;
+  error?: string;
+}
+
+/**
+ * Listens to WebSocket messages and manages a stack of notifications.
+ * Currently handles `task.complete` messages from the background scheduler.
+ */
+export function useNotifications(lastMessage: WebSocketMessage | null) {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  useEffect(() => {
+    if (!lastMessage || lastMessage.type !== "task.complete") return;
+
+    const payload = lastMessage.payload as TaskCompletePayload;
+
+    const notification: Notification = {
+      id: `notif-${++nextId}`,
+      type: payload.success ? "success" : "error",
+      title: payload.success
+        ? `${payload.taskName} completed`
+        : `${payload.taskName} failed`,
+      message: payload.success
+        ? `Finished in ${(payload.durationMs / 1000).toFixed(1)}s`
+        : payload.error,
+      createdAt: Date.now(),
+    };
+
+    setNotifications((prev) => [...prev, notification]);
+  }, [lastMessage]);
+
+  const dismiss = useCallback((id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+
+  return { notifications, dismiss };
+}

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -16,6 +16,8 @@ import { ErrorSurface } from "../components/ErrorSurface";
 import { KeyboardShortcutHelp } from "../components/KeyboardShortcutHelp";
 import { BlockInspector, BlockInspectorToggle } from "../blocks/BlockInspector";
 import { composedLayoutToBlocks } from "../blocks/transformers";
+import { useNotifications } from "../hooks/useNotifications";
+import { NotificationStack } from "../components/NotificationToast";
 
 const WS_URL = `ws://${window.location.hostname}:${import.meta.env.VITE_WS_PORT || 3001}/ws`;
 const API_BASE = `http://${window.location.hostname}:${import.meta.env.VITE_WS_PORT || 3001}`;
@@ -102,6 +104,7 @@ export default function HomePage() {
   });
 
   const { helpVisible, dismissHelp } = useGlobalShortcuts();
+  const { notifications, dismiss: dismissNotification } = useNotifications(lastMessage);
 
   // On initial connection, check what services are connected
   // Show WelcomeState immediately, then trigger data fetch in background
@@ -261,6 +264,7 @@ export default function HomePage() {
 
   return (
     <div className="page home-page">
+      <NotificationStack notifications={notifications} onDismiss={dismissNotification} />
       {status !== "connected" && (
         <div className={`connection-banner ${status === "reconnecting" ? "connecting" : status}`}>
           <span className="connection-banner-icon">!</span>

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -2,6 +2,7 @@
 @import "./calendar-components.css";
 @import "./error-surface.css";
 @import "./keyboard-nav.css";
+@import "./notifications.css";
 
 /* ================================ */
 /* Design Tokens                    */

--- a/apps/frontend/src/styles/notifications.css
+++ b/apps/frontend/src/styles/notifications.css
@@ -1,0 +1,132 @@
+/* ================================ */
+/* Notification Toast System        */
+/* ================================ */
+
+.notification-stack {
+  position: fixed;
+  top: var(--space-4, 1rem);
+  right: var(--space-4, 1rem);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 0.5rem);
+  pointer-events: none;
+  max-width: 24rem;
+}
+
+/* ---- Individual toast ---- */
+
+.notification-toast {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3, 0.75rem);
+  padding: var(--space-3, 0.75rem) var(--space-4, 1rem);
+  border-radius: var(--radius-md, 0.5rem);
+  background: var(--color-bg-elevated, #1e1f2b);
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  pointer-events: auto;
+  animation: notification-toast--slide-in 0.25s ease-out;
+  font-family: var(--font-sans, system-ui, sans-serif);
+}
+
+.notification-toast--exiting {
+  animation: notification-toast--slide-out 0.2s ease-in forwards;
+}
+
+.notification-toast--success {
+  border-left: 3px solid var(--color-success, #22c55e);
+}
+
+.notification-toast--error {
+  border-left: 3px solid var(--color-danger, #ef4444);
+}
+
+/* ---- Toast icon ---- */
+
+.notification-toast__icon {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  line-height: 1.25rem;
+  text-align: center;
+  font-size: var(--text-md, 0.875rem);
+  margin-top: 0.0625rem;
+}
+
+.notification-toast--success .notification-toast__icon {
+  color: var(--color-success, #22c55e);
+}
+
+.notification-toast--error .notification-toast__icon {
+  color: var(--color-danger, #ef4444);
+}
+
+/* ---- Toast body ---- */
+
+.notification-toast__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.notification-toast__title {
+  font-size: var(--text-sm, 0.75rem);
+  font-weight: var(--weight-semibold, 600);
+  color: var(--color-text, #e5e7eb);
+  line-height: 1.4;
+  margin: 0;
+}
+
+.notification-toast__message {
+  font-size: var(--text-xs, 0.6875rem);
+  color: var(--color-muted, #8b8f9c);
+  line-height: 1.4;
+  margin-top: 0.125rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ---- Dismiss button ---- */
+
+.notification-toast__dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--color-muted, #8b8f9c);
+  cursor: pointer;
+  padding: 0.125rem;
+  font-size: var(--text-md, 0.875rem);
+  line-height: 1;
+  border-radius: var(--radius-sm, 0.25rem);
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.notification-toast__dismiss:hover {
+  color: var(--color-text, #e5e7eb);
+  background: var(--color-surface-hover, rgba(255, 255, 255, 0.06));
+}
+
+/* ---- Animations ---- */
+
+@keyframes notification-toast--slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes notification-toast--slide-out {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(1rem);
+  }
+}

--- a/packages/ui-renderer-contract/src/messages.ts
+++ b/packages/ui-renderer-contract/src/messages.ts
@@ -13,7 +13,17 @@ export type ServerMessage =
       payload: { approvalId: string; surface: SurfaceSpec };
     }
   | { type: "status"; payload: { phase: string; agents: AgentStatus[] } }
-  | { type: "error"; payload: { message: string; code: string } };
+  | { type: "error"; payload: { message: string; code: string } }
+  | {
+      type: "task.complete";
+      payload: {
+        taskId: string;
+        taskName: string;
+        success: boolean;
+        durationMs: number;
+        error?: string;
+      };
+    };
 
 // Frontend → Backend messages
 export type ClientMessage =


### PR DESCRIPTION
## Summary
- Adds a `task.complete` WebSocket message type emitted by the `BackgroundTaskScheduler` when tasks succeed or fail (after retries exhausted)
- Introduces a `NotificationStack` / `NotificationToast` React component with BEM CSS and CSS custom properties for auto-dismissing, stackable toast notifications
- Wires notifications into `HomePage` via a `useNotifications` hook that listens for `task.complete` messages

Closes #229

## Test plan
- [ ] Verify background task completion triggers a `task.complete` WebSocket message
- [ ] Confirm toast appears in top-right corner on task success (green) and failure (red)
- [ ] Verify auto-dismiss after ~6 seconds
- [ ] Verify manual dismiss via X button
- [ ] Confirm multiple notifications stack correctly (max 5 visible)
- [ ] Check light/dark theme compatibility via CSS custom properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)