### PR TITLE
feat: build proactive morning digest summary agent

### DIFF
--- a/apps/backend/src/background/tasks.ts
+++ b/apps/backend/src/background/tasks.ts
@@ -2,6 +2,19 @@ import type { BackgroundTask } from "./types";
 
 export const MVP_BACKGROUND_TASKS: BackgroundTask[] = [
   {
+    id: "morning-digest",
+    name: "Morning Digest",
+    description:
+      "Proactive daily summary combining unread email highlights, urgent items, and today's calendar events. Runs once in the morning to prepare the dashboard digest card.",
+    intervalMs: 24 * 60 * 60 * 1000, // every 24 hours (scheduled at ~7 AM via initial delay)
+    enabled: true,
+    allowedConnectors: ["gmail", "google-calendar"],
+    actionClass: "A",
+    outputTarget: "surface",
+    maxRetries: 2,
+    retryBackoffMs: 30_000,
+  },
+  {
     id: "inbox-summary",
     name: "Inbox Summary",
     description:

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -40,6 +40,7 @@ export {
   ApprovalSurfaceAgent,
   ConnectionSurfaceAgent,
   GenericDataSurfaceAgent,
+  MorningDigestAgent,
   LayoutComposerAgent,
   extractSurfaces,
 } from "./ui";

--- a/packages/agents/src/ui/index.ts
+++ b/packages/agents/src/ui/index.ts
@@ -4,4 +4,5 @@ export { DiscoverySurfaceAgent } from "./discovery-surface";
 export { ApprovalSurfaceAgent } from "./approval-surface";
 export { ConnectionSurfaceAgent } from "./connection-surface";
 export { GenericDataSurfaceAgent } from "./generic-data-surface";
+export { MorningDigestAgent } from "./morning-digest-surface";
 export { LayoutComposerAgent, extractSurfaces } from "./layout-composer";

--- a/packages/agents/src/ui/morning-digest-surface.test.ts
+++ b/packages/agents/src/ui/morning-digest-surface.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import { MorningDigestAgent } from "./morning-digest-surface";
+import type { AgentInput, AgentContext } from "../types";
+import type { WaibEvent, AgentOutput } from "@waibspace/types";
+
+function makeEvent(payload: Record<string, unknown> = {}): WaibEvent {
+  return {
+    id: "test-event",
+    type: "background.task.triggered",
+    payload,
+    source: "test",
+    timestamp: Date.now(),
+  } as WaibEvent;
+}
+
+function makeRetrievalOutput(
+  emails: Record<string, unknown>[],
+  calendarEvents: unknown[] = [],
+): AgentOutput {
+  const results = [];
+
+  if (emails.length > 0) {
+    results.push({
+      connectorId: "gmail",
+      operation: "get-recent-emails",
+      status: "fulfilled" as const,
+      data: emails,
+    });
+  }
+
+  if (calendarEvents.length > 0) {
+    results.push({
+      connectorId: "google-calendar",
+      operation: "get-today-events",
+      status: "fulfilled" as const,
+      data: calendarEvents,
+    });
+  }
+
+  return {
+    agentId: "context.data-retrieval",
+    agentType: "data-retrieval",
+    category: "context",
+    output: {
+      results,
+      totalAttempted: results.length,
+      totalFulfilled: results.length,
+    },
+    confidence: 1,
+    provenance: {
+      sourceType: "agent",
+      sourceId: "context.data-retrieval",
+      trustLevel: "trusted",
+      timestamp: Date.now(),
+      freshness: "realtime",
+      dataState: "raw",
+    },
+    timing: { startMs: 0, endMs: 0, durationMs: 0 },
+  };
+}
+
+function makeInput(
+  emails: Record<string, unknown>[],
+  calendarEvents: unknown[] = [],
+): AgentInput {
+  return {
+    event: makeEvent({ taskId: "morning-digest" }),
+    priorOutputs: [makeRetrievalOutput(emails, calendarEvents)],
+  };
+}
+
+const context: AgentContext = { traceId: "test-trace" };
+
+describe("MorningDigestAgent", () => {
+  const agent = new MorningDigestAgent();
+
+  it("produces a morning-digest surface with email and calendar data", async () => {
+    const input = makeInput(
+      [
+        {
+          id: "e1",
+          from: "boss@co.com",
+          subject: "URGENT: Need this ASAP",
+          snippet: "Please respond immediately",
+          date: new Date().toISOString(),
+          isUnread: true,
+        },
+        {
+          id: "e2",
+          from: "noreply@store.com",
+          subject: "50% off sale",
+          snippet: "Unsubscribe from newsletter",
+          date: new Date().toISOString(),
+          isUnread: true,
+        },
+      ],
+      [
+        {
+          id: "cal1",
+          title: "Team standup",
+          start: new Date(Date.now() + 3600000).toISOString(),
+          end: new Date(Date.now() + 5400000).toISOString(),
+          location: "Zoom",
+        },
+      ],
+    );
+
+    const result = await agent.execute(input, context);
+    const { surfaceSpec } = result.output as Record<string, unknown>;
+    const spec = surfaceSpec as Record<string, unknown>;
+
+    expect(spec.surfaceType).toBe("morning-digest");
+    expect(spec.priority).toBe(95);
+
+    const data = spec.data as Record<string, unknown>;
+    expect(data.date).toBeDefined();
+    expect(data.greeting).toContain("digest for");
+
+    const inbox = data.inbox as Record<string, unknown>;
+    expect(inbox.unreadCount).toBe(2);
+
+    const urgentEmails = inbox.urgentEmails as unknown[];
+    // The urgent email should be included
+    expect(urgentEmails.length).toBeGreaterThanOrEqual(1);
+
+    const calendar = data.calendar as Record<string, unknown>;
+    expect(calendar.eventCount).toBe(1);
+
+    const events = calendar.events as unknown[];
+    expect(events).toHaveLength(1);
+
+    const actions = data.suggestedActions as unknown[];
+    // Should suggest reviewing urgent emails and preparing for meeting
+    expect(actions.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("handles empty data gracefully", async () => {
+    const input: AgentInput = {
+      event: makeEvent({ taskId: "morning-digest" }),
+      priorOutputs: [],
+    };
+
+    const result = await agent.execute(input, context);
+    const { surfaceSpec } = result.output as Record<string, unknown>;
+    const spec = surfaceSpec as Record<string, unknown>;
+
+    expect(spec.surfaceType).toBe("morning-digest");
+
+    const data = spec.data as Record<string, unknown>;
+    const inbox = data.inbox as Record<string, unknown>;
+    expect(inbox.unreadCount).toBe(0);
+    expect((inbox.urgentEmails as unknown[]).length).toBe(0);
+
+    const calendar = data.calendar as Record<string, unknown>;
+    expect(calendar.eventCount).toBe(0);
+  });
+
+  it("caps urgent emails at 5", async () => {
+    const urgentEmails = Array.from({ length: 10 }, (_, i) => ({
+      id: `e${i}`,
+      from: "boss@co.com",
+      subject: `URGENT: action required item ${i}`,
+      snippet: "Respond ASAP immediately",
+      date: new Date().toISOString(),
+      isUnread: true,
+    }));
+
+    const input = makeInput(urgentEmails);
+    const result = await agent.execute(input, context);
+    const { surfaceSpec } = result.output as Record<string, unknown>;
+    const data = (surfaceSpec as Record<string, unknown>).data as Record<
+      string,
+      unknown
+    >;
+    const inbox = data.inbox as Record<string, unknown>;
+    expect((inbox.urgentEmails as unknown[]).length).toBeLessThanOrEqual(5);
+  });
+
+  it("suggests inbox triage when many unread emails", async () => {
+    const emails = Array.from({ length: 15 }, (_, i) => ({
+      id: `e${i}`,
+      from: `person${i}@co.com`,
+      subject: `Email ${i}`,
+      snippet: "Some content",
+      date: new Date().toISOString(),
+      isUnread: true,
+    }));
+
+    const input = makeInput(emails);
+    const result = await agent.execute(input, context);
+    const { surfaceSpec } = result.output as Record<string, unknown>;
+    const data = (surfaceSpec as Record<string, unknown>).data as Record<
+      string,
+      unknown
+    >;
+    const actions = data.suggestedActions as Array<{ id: string }>;
+    const triageAction = actions.find((a) => a.id === "inbox-triage");
+    expect(triageAction).toBeDefined();
+  });
+});

--- a/packages/agents/src/ui/morning-digest-surface.ts
+++ b/packages/agents/src/ui/morning-digest-surface.ts
@@ -1,0 +1,314 @@
+import type { AgentOutput } from "@waibspace/types";
+import {
+  SurfaceFactory,
+  type MorningDigestSurfaceData,
+} from "@waibspace/surfaces";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+import type { DataRetrievalOutput } from "../context/data-retrieval";
+import { classifyEmailUrgency } from "./email-urgency";
+
+/**
+ * MorningDigestAgent — produces a proactive summary surface combining inbox
+ * highlights and today's calendar events.
+ *
+ * This agent runs as a scheduled background task (default 7 AM) and uses
+ * heuristics only — no LLM dependency.
+ */
+export class MorningDigestAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "ui.morning-digest",
+      name: "MorningDigestAgent",
+      type: "surface-builder",
+      category: "ui",
+    });
+  }
+
+  async execute(
+    input: AgentInput,
+    _context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+    const today = new Date();
+    const dateStr = today.toISOString().slice(0, 10);
+
+    this.log("Building morning digest", { date: dateStr });
+
+    // Extract data from prior retrieval outputs
+    const retrieval = this.findDataRetrieval(input);
+    const emails = retrieval ? this.extractEmails(retrieval) : [];
+    const calendarEvents = retrieval
+      ? this.extractCalendarEvents(retrieval)
+      : [];
+
+    // Classify urgency on emails using heuristics
+    const classifiedEmails = emails.map((email, i) => {
+      const { urgency } = classifyEmailUrgency(email);
+      return {
+        id: String(email.id ?? email.messageId ?? `email-${i}`),
+        from: String(email.from || email.sender || "Unknown"),
+        subject: String(email.subject || "No Subject"),
+        snippet: String(
+          email.snippet ?? email.text ?? email.body ?? "",
+        ).slice(0, 200),
+        isUnread: Boolean(email.isUnread ?? email.unread ?? true),
+        urgency,
+      };
+    });
+
+    const unreadCount = classifiedEmails.filter((e) => e.isUnread).length;
+    const urgentEmails = classifiedEmails.filter(
+      (e) => e.urgency === "high" || e.urgency === "medium",
+    );
+
+    // Map calendar events
+    const todayEvents = calendarEvents.map((event, i) => ({
+      id: String(
+        (event as Record<string, unknown>).id ??
+          (event as Record<string, unknown>).eventId ??
+          `event-${i}`,
+      ),
+      title: String(
+        (event as Record<string, unknown>).title ??
+          (event as Record<string, unknown>).summary ??
+          "Untitled Event",
+      ),
+      start: String(
+        (event as Record<string, unknown>).start ??
+          (event as Record<string, unknown>).startTime ??
+          "",
+      ),
+      end: String(
+        (event as Record<string, unknown>).end ??
+          (event as Record<string, unknown>).endTime ??
+          "",
+      ),
+      location:
+        ((event as Record<string, unknown>).location as string) ?? undefined,
+    }));
+
+    // Build suggested actions based on heuristics
+    const suggestedActions = this.buildSuggestedActions(
+      unreadCount,
+      urgentEmails,
+      todayEvents,
+    );
+
+    // Generate greeting
+    const hour = today.getHours();
+    const timeOfDay =
+      hour < 12 ? "morning" : hour < 17 ? "afternoon" : "evening";
+    const greeting = `Good ${timeOfDay} — here's your digest for ${this.formatDate(today)}`;
+
+    const digestData: MorningDigestSurfaceData = {
+      date: dateStr,
+      greeting,
+      inbox: {
+        unreadCount,
+        urgentEmails: urgentEmails.slice(0, 5), // cap at 5 urgent items
+      },
+      calendar: {
+        eventCount: todayEvents.length,
+        events: todayEvents,
+      },
+      suggestedActions,
+      generatedAt: new Date().toISOString(),
+    };
+
+    const provenance = {
+      sourceType: "agent" as const,
+      sourceId: this.id,
+      trustLevel: "trusted" as const,
+      timestamp: startMs,
+      freshness: "realtime" as const,
+      dataState: "transformed" as const,
+    };
+
+    const surfaceSpec = SurfaceFactory.morningDigest(digestData, provenance);
+
+    const endMs = Date.now();
+
+    const summary = [
+      `${unreadCount} unread email${unreadCount !== 1 ? "s" : ""}`,
+      urgentEmails.length > 0 ? `${urgentEmails.length} urgent` : null,
+      `${todayEvents.length} event${todayEvents.length !== 1 ? "s" : ""} today`,
+    ]
+      .filter(Boolean)
+      .join(", ");
+
+    return {
+      ...this.createOutput({ surfaceSpec, summary }, 0.9, provenance),
+      timing: { startMs, endMs, durationMs: endMs - startMs },
+    };
+  }
+
+  // ── Private helpers ────────────────────────────────────────────
+
+  private findDataRetrieval(
+    input: AgentInput,
+  ): DataRetrievalOutput | undefined {
+    for (const prior of input.priorOutputs) {
+      if (prior.category === "context" && prior.output) {
+        const output = prior.output as Record<string, unknown>;
+        if ("results" in output && "totalAttempted" in output) {
+          return output as unknown as DataRetrievalOutput;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private extractEmails(
+    retrieval: DataRetrievalOutput,
+  ): Record<string, unknown>[] {
+    const emailResults = retrieval.results.filter(
+      (r) =>
+        r.status === "fulfilled" &&
+        (r.connectorId.includes("gmail") ||
+          r.connectorId.includes("mail") ||
+          r.operation.includes("email") ||
+          r.operation.includes("inbox") ||
+          r.operation.includes("unseen") ||
+          r.operation.includes("recent")),
+    );
+
+    const NON_EMAIL_OPERATIONS = [
+      "get_message_count",
+      "get-inbox-stats",
+      "get_connection_status",
+      "connect_all",
+      "disconnect_all",
+      "list_mailboxes",
+      "open_mailbox",
+    ];
+
+    const allEmails: Record<string, unknown>[] = [];
+    for (const result of emailResults) {
+      if (NON_EMAIL_OPERATIONS.includes(result.operation)) continue;
+      const data = this.parseMCPContent(result.data) ?? result.data;
+      if (Array.isArray(data)) {
+        allEmails.push(...(data as Record<string, unknown>[]));
+      } else if (data !== null && data !== undefined) {
+        allEmails.push(data as Record<string, unknown>);
+      }
+    }
+    return allEmails;
+  }
+
+  private extractCalendarEvents(retrieval: DataRetrievalOutput): unknown[] {
+    const calendarResults = retrieval.results.filter(
+      (r) =>
+        r.status === "fulfilled" &&
+        (r.connectorId.includes("calendar") ||
+          r.operation.includes("calendar") ||
+          r.operation.includes("events")),
+    );
+
+    const allEvents: unknown[] = [];
+    for (const result of calendarResults) {
+      const data = this.parseMCPContent(result.data) ?? result.data;
+      if (Array.isArray(data)) {
+        allEvents.push(...data);
+      } else if (data !== null && data !== undefined) {
+        allEvents.push(data);
+      }
+    }
+    return allEvents;
+  }
+
+  private parseMCPContent(data: unknown): unknown | undefined {
+    if (!Array.isArray(data)) return undefined;
+    const textBlock = data.find(
+      (item: unknown) =>
+        typeof item === "object" &&
+        item !== null &&
+        (item as Record<string, unknown>).type === "text",
+    );
+    if (!textBlock) return undefined;
+    const text = (textBlock as Record<string, unknown>).text;
+    if (typeof text !== "string") return undefined;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  private buildSuggestedActions(
+    unreadCount: number,
+    urgentEmails: Array<{
+      id: string;
+      from: string;
+      subject: string;
+      urgency: "high" | "medium";
+    }>,
+    todayEvents: Array<{ id: string; title: string; start: string }>,
+  ): MorningDigestSurfaceData["suggestedActions"] {
+    const actions: MorningDigestSurfaceData["suggestedActions"] = [];
+
+    // Suggest reviewing urgent emails
+    if (urgentEmails.length > 0) {
+      const highOnly = urgentEmails.filter((e) => e.urgency === "high");
+      const count = highOnly.length || urgentEmails.length;
+      actions.push({
+        id: "review-urgent",
+        label: `Review ${count} urgent email${count !== 1 ? "s" : ""}`,
+        reason: `You have ${count} email${count !== 1 ? "s" : ""} that may need immediate attention`,
+        actionType: "navigate.inbox",
+        payload: { filter: "urgent" },
+      });
+    }
+
+    // Suggest inbox zero if many unread
+    if (unreadCount > 10) {
+      actions.push({
+        id: "inbox-triage",
+        label: "Triage your inbox",
+        reason: `${unreadCount} unread emails — consider archiving or bulk-marking`,
+        actionType: "navigate.inbox",
+      });
+    }
+
+    // Suggest preparing for the next upcoming meeting
+    const now = new Date();
+    const upcomingEvents = todayEvents.filter((e) => {
+      try {
+        return new Date(e.start) > now;
+      } catch {
+        return false;
+      }
+    });
+    if (upcomingEvents.length > 0) {
+      const next = upcomingEvents[0];
+      actions.push({
+        id: "prepare-meeting",
+        label: `Prepare for "${next.title}"`,
+        reason: `Your next event starts at ${this.formatTime(next.start)}`,
+        actionType: "navigate.calendar",
+        payload: { eventId: next.id },
+      });
+    }
+
+    return actions;
+  }
+
+  private formatDate(d: Date): string {
+    return d.toLocaleDateString("en-US", {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+    });
+  }
+
+  private formatTime(isoStr: string): string {
+    try {
+      return new Date(isoStr).toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+      });
+    } catch {
+      return isoStr;
+    }
+  }
+}

--- a/packages/surfaces/src/factories.ts
+++ b/packages/surfaces/src/factories.ts
@@ -6,6 +6,7 @@ import type {
   DiscoverySurfaceData,
   ApprovalSurfaceData,
   ConnectionGuideSurfaceData,
+  MorningDigestSurfaceData,
 } from "./surface-data";
 
 export class SurfaceFactory {
@@ -132,6 +133,45 @@ export class SurfaceFactory {
       .setLayout({
         position: "primary",
         prominence: "hero",
+      })
+      .setProvenance(provenance)
+      .build();
+  }
+
+  static morningDigest(
+    data: MorningDigestSurfaceData,
+    provenance: ProvenanceMetadata
+  ): SurfaceSpec {
+    const urgentCount = data.inbox.urgentEmails.length;
+    const eventCount = data.calendar.eventCount;
+    const summary = [
+      `${data.inbox.unreadCount} unread`,
+      urgentCount > 0 ? `${urgentCount} urgent` : null,
+      `${eventCount} event${eventCount !== 1 ? "s" : ""} today`,
+    ]
+      .filter(Boolean)
+      .join(", ");
+
+    return new SurfaceSpecBuilder("morning-digest")
+      .setTitle(data.greeting)
+      .setSummary(summary)
+      .setPriority(95) // high priority — show at top of dashboard
+      .setData(data)
+      .setLayout({
+        position: "primary",
+        prominence: "hero",
+      })
+      .addAction({
+        id: "dismiss-digest",
+        label: "Dismiss",
+        actionType: "digest.dismiss",
+        riskClass: "A",
+      })
+      .addAction({
+        id: "open-inbox",
+        label: "Open Inbox",
+        actionType: "navigate.inbox",
+        riskClass: "A",
       })
       .setProvenance(provenance)
       .build();

--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -7,4 +7,5 @@ export type {
   DiscoverySurfaceData,
   ApprovalSurfaceData,
   ConnectionGuideSurfaceData,
+  MorningDigestSurfaceData,
 } from "./surface-data";

--- a/packages/surfaces/src/surface-data.ts
+++ b/packages/surfaces/src/surface-data.ts
@@ -57,6 +57,42 @@ export interface ApprovalSurfaceData {
   consequences: string[];
 }
 
+export interface MorningDigestSurfaceData {
+  /** ISO date string for the digest (e.g. "2026-03-09") */
+  date: string;
+  /** Summary line for the digest card header */
+  greeting: string;
+  inbox: {
+    unreadCount: number;
+    urgentEmails: Array<{
+      id: string;
+      from: string;
+      subject: string;
+      snippet: string;
+      urgency: "high" | "medium";
+    }>;
+  };
+  calendar: {
+    eventCount: number;
+    events: Array<{
+      id: string;
+      title: string;
+      start: string;
+      end: string;
+      location?: string;
+    }>;
+  };
+  suggestedActions: Array<{
+    id: string;
+    label: string;
+    reason: string;
+    actionType: string;
+    payload?: Record<string, unknown>;
+  }>;
+  /** When the digest was generated (ISO timestamp) */
+  generatedAt: string;
+}
+
 export interface ConnectionGuideSurfaceData {
   step: "browse" | "credentials" | "connecting" | "success" | "error";
   message: string;


### PR DESCRIPTION
## Summary
- Adds a **MorningDigestAgent** that aggregates inbox highlights and calendar events into a single digest surface card, shown at the top of the dashboard
- Uses heuristic-based urgency classification (no LLM dependency) via the existing `classifyEmailUrgency` utility
- Generates contextual **suggested actions** (review urgent emails, triage inbox, prepare for next meeting) based on the digest data
- Registered as a **background task** (`morning-digest`, 24h interval) in `MVP_BACKGROUND_TASKS` alongside existing inbox-summary and calendar-conflict tasks

### New files
- `packages/agents/src/ui/morning-digest-surface.ts` — the agent implementation
- `packages/agents/src/ui/morning-digest-surface.test.ts` — unit tests (4 passing)

### Modified files
- `packages/surfaces/src/surface-data.ts` — new `MorningDigestSurfaceData` interface
- `packages/surfaces/src/factories.ts` — new `SurfaceFactory.morningDigest()` factory method
- `packages/surfaces/src/index.ts` — re-export new type
- `packages/agents/src/ui/index.ts` — export `MorningDigestAgent`
- `packages/agents/src/index.ts` — re-export `MorningDigestAgent`
- `apps/backend/src/background/tasks.ts` — add morning-digest background task

Closes #197

## Test plan
- [x] Unit tests pass (`vitest run packages/agents/src/ui/morning-digest-surface.test.ts` — 4/4)
- [ ] Verify digest surface renders correctly on frontend BlockSurfaceRenderer
- [ ] Test with real Gmail + Google Calendar MCP data
- [ ] Confirm background scheduler triggers the task on interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)