### PR TITLE
feat: implement conversation context memory for multi-turn interactions

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -17,6 +17,7 @@ import {
   ConnectorSelectionAgent,
   DataRetrievalAgent,
   MemoryRetrievalAgent,
+  ConversationContextAgent,
   PolicyGateAgent,
   // UI agents
   InboxSurfaceAgent,
@@ -44,7 +45,7 @@ import {
   ModelProviderRegistry,
   AnthropicProvider,
 } from "@waibspace/model-provider";
-import { MemoryStore, MemoryUpdatePipeline, ObservationProcessor } from "@waibspace/memory";
+import { MemoryStore, MemoryUpdatePipeline, ObservationProcessor, ConversationContextStore } from "@waibspace/memory";
 import { WaibDatabase } from "@waibspace/db";
 import { BackgroundTaskScheduler, MVP_BACKGROUND_TASKS } from "./background";
 import { startServer } from "./server";
@@ -142,6 +143,7 @@ agentRegistry.register(new InteractionSemanticsAgent());
 
 // Context agents
 agentRegistry.register(new MemoryRetrievalAgent());
+agentRegistry.register(new ConversationContextAgent());
 agentRegistry.register(new ContextPlannerAgent());
 agentRegistry.register(new ConnectorSelectionAgent());
 agentRegistry.register(new DataRetrievalAgent());
@@ -170,6 +172,11 @@ log.info("Agent registry initialized", {
 // ---------- 6. Memory Store ----------
 const memoryStore = new MemoryStore(db, bus);
 
+// ---------- 6a. Conversation Context Store ----------
+const conversationContextStore = new ConversationContextStore();
+conversationContextStore.startCleanup();
+log.info("Conversation context store initialized");
+
 // ---------- 6b. Pending Action Store ----------
 const pendingActionStore = new InMemoryPendingActionStore();
 log.info("Pending action store initialized");
@@ -178,6 +185,7 @@ log.info("Pending action store initialized");
 const orchestrator = new Orchestrator(bus, agentRegistry, {
   modelProvider: modelRegistry,
   memoryStore,
+  conversationContextStore,
   connectorRegistry,
   policyEngine,
   pendingActionStore,
@@ -283,6 +291,7 @@ log.info("WaibSpace backend started", { port: PORT });
 function handleShutdown(signal: string) {
   log.info("Shutting down", { signal });
   scheduler.stop();
+  conversationContextStore.stopCleanup();
   server.stop();
   log.info("Shutdown complete");
   process.exit(0);

--- a/packages/agents/src/context/conversation-context.ts
+++ b/packages/agents/src/context/conversation-context.ts
@@ -1,0 +1,135 @@
+import type { AgentOutput, ConversationTurn } from "@waibspace/types";
+import type { ConversationContextStore } from "@waibspace/memory";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+
+/** Maximum number of recent turns to include in agent output. */
+const MAX_CONTEXT_TURNS = 10;
+
+export interface ConversationContextOutput {
+  /** Recent conversation turns for this session. */
+  conversationHistory: ConversationTurn[];
+  /** The session ID the history belongs to. */
+  sessionId: string;
+  /** Total number of turns stored (may be larger than returned history). */
+  totalTurns: number;
+}
+
+/**
+ * Context agent that injects recent conversation history into the pipeline.
+ *
+ * It reads from the ConversationContextStore (passed via `context.config`)
+ * and exposes the last N turns so downstream agents (context-planner,
+ * intent agent, surface agents) can resolve multi-turn references like
+ * "Reply to her latest" after "Show me emails from Alice".
+ *
+ * This agent also records the current user message as a new turn before
+ * returning, so it is available in subsequent pipeline runs.
+ */
+export class ConversationContextAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "context.conversation",
+      name: "ConversationContextAgent",
+      type: "context.conversation",
+      category: "context",
+    });
+  }
+
+  async execute(
+    input: AgentInput,
+    context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+
+    const store = context.config?.["conversationContextStore"] as
+      | ConversationContextStore
+      | undefined;
+
+    if (!store) {
+      this.log("No ConversationContextStore in context — skipping");
+      return this.buildOutput([], "unknown", 0, startMs);
+    }
+
+    // Derive session ID from event metadata or traceId prefix.
+    // The frontend should pass a stable sessionId in event.metadata;
+    // fall back to traceId (unique per request, so no cross-turn context).
+    const sessionId = this.resolveSessionId(input);
+
+    // Record the current user message as a turn
+    const userMessage = this.extractUserMessage(input);
+    if (userMessage) {
+      store.addTurn(sessionId, {
+        role: "user",
+        content: userMessage,
+        timestamp: input.event.timestamp,
+        traceId: input.event.traceId,
+      });
+    }
+
+    // Retrieve recent history (excluding the turn we just added, plus it)
+    const history = store.getHistory(sessionId, MAX_CONTEXT_TURNS);
+    const totalTurns = store.getHistory(sessionId).length;
+
+    this.log("Retrieved conversation context", {
+      sessionId,
+      returnedTurns: history.length,
+      totalTurns,
+    });
+
+    return this.buildOutput(history, sessionId, totalTurns, startMs);
+  }
+
+  private resolveSessionId(input: AgentInput): string {
+    const meta = input.event.metadata as Record<string, unknown> | undefined;
+    if (meta?.sessionId && typeof meta.sessionId === "string") {
+      return meta.sessionId;
+    }
+    // Fall back: use "default" so all requests without explicit session
+    // share a single conversation context (simple single-user case).
+    return "default";
+  }
+
+  private extractUserMessage(input: AgentInput): string | undefined {
+    const payload = input.event.payload as Record<string, unknown> | null;
+    if (!payload) return undefined;
+
+    // user.message.received events carry the text in payload.message
+    if (typeof payload.message === "string") {
+      return payload.message;
+    }
+    // Normalized input from perception agents
+    if (typeof payload.text === "string") {
+      return payload.text;
+    }
+    return undefined;
+  }
+
+  private buildOutput(
+    history: ConversationTurn[],
+    sessionId: string,
+    totalTurns: number,
+    startMs: number,
+  ): AgentOutput {
+    const endMs = Date.now();
+    const output: ConversationContextOutput = {
+      conversationHistory: history,
+      sessionId,
+      totalTurns,
+    };
+
+    return {
+      ...this.createOutput(output, history.length > 0 ? 1.0 : 0.5, {
+        sourceType: "memory",
+        dataState: "raw",
+        freshness: "realtime",
+        timestamp: startMs,
+      }),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+}

--- a/packages/agents/src/context/index.ts
+++ b/packages/agents/src/context/index.ts
@@ -14,4 +14,8 @@ export {
   MemoryRetrievalAgent,
   type MemoryRetrievalOutput,
 } from "./memory-retrieval";
+export {
+  ConversationContextAgent,
+  type ConversationContextOutput,
+} from "./conversation-context";
 export { PolicyGateAgent } from "./policy-gate";

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -31,6 +31,8 @@ export {
   type DataRetrievalOutput,
   MemoryRetrievalAgent,
   type MemoryRetrievalOutput,
+  ConversationContextAgent,
+  type ConversationContextOutput,
   PolicyGateAgent,
 } from "./context";
 export {

--- a/packages/memory/src/__tests__/conversation-context-store.test.ts
+++ b/packages/memory/src/__tests__/conversation-context-store.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { ConversationContextStore } from "../conversation-context-store";
+import type { ConversationTurn } from "@waibspace/types";
+
+function makeTurn(
+  role: "user" | "assistant",
+  content: string,
+  timestamp = Date.now(),
+): ConversationTurn {
+  return { role, content, timestamp, traceId: `trace-${timestamp}` };
+}
+
+describe("ConversationContextStore", () => {
+  let store: ConversationContextStore;
+
+  beforeEach(() => {
+    store = new ConversationContextStore({ maxTurns: 5 });
+  });
+
+  it("stores and retrieves turns for a session", () => {
+    store.addTurn("s1", makeTurn("user", "Show me emails from Alice"));
+    store.addTurn("s1", makeTurn("assistant", "Here are Alice's emails"));
+
+    const history = store.getHistory("s1");
+    expect(history).toHaveLength(2);
+    expect(history[0].content).toBe("Show me emails from Alice");
+    expect(history[1].content).toBe("Here are Alice's emails");
+  });
+
+  it("returns empty array for unknown session", () => {
+    expect(store.getHistory("nonexistent")).toEqual([]);
+  });
+
+  it("enforces sliding window (maxTurns)", () => {
+    for (let i = 0; i < 8; i++) {
+      store.addTurn("s1", makeTurn("user", `message ${i}`));
+    }
+    const history = store.getHistory("s1");
+    expect(history).toHaveLength(5);
+    expect(history[0].content).toBe("message 3");
+    expect(history[4].content).toBe("message 7");
+  });
+
+  it("respects limit parameter on getHistory", () => {
+    for (let i = 0; i < 5; i++) {
+      store.addTurn("s1", makeTurn("user", `msg ${i}`));
+    }
+    const last2 = store.getHistory("s1", 2);
+    expect(last2).toHaveLength(2);
+    expect(last2[0].content).toBe("msg 3");
+    expect(last2[1].content).toBe("msg 4");
+  });
+
+  it("isolates sessions", () => {
+    store.addTurn("s1", makeTurn("user", "hello from s1"));
+    store.addTurn("s2", makeTurn("user", "hello from s2"));
+
+    expect(store.getHistory("s1")).toHaveLength(1);
+    expect(store.getHistory("s2")).toHaveLength(1);
+    expect(store.getHistory("s1")[0].content).toBe("hello from s1");
+    expect(store.getHistory("s2")[0].content).toBe("hello from s2");
+  });
+
+  it("clears a session", () => {
+    store.addTurn("s1", makeTurn("user", "test"));
+    store.clearSession("s1");
+    expect(store.getHistory("s1")).toEqual([]);
+    expect(store.sessionCount()).toBe(0);
+  });
+
+  it("reports session count", () => {
+    expect(store.sessionCount()).toBe(0);
+    store.addTurn("s1", makeTurn("user", "a"));
+    store.addTurn("s2", makeTurn("user", "b"));
+    expect(store.sessionCount()).toBe(2);
+  });
+
+  it("returns a copy of history (not a reference)", () => {
+    store.addTurn("s1", makeTurn("user", "original"));
+    const history = store.getHistory("s1");
+    history.push(makeTurn("user", "injected"));
+    expect(store.getHistory("s1")).toHaveLength(1);
+  });
+});

--- a/packages/memory/src/conversation-context-store.ts
+++ b/packages/memory/src/conversation-context-store.ts
@@ -1,0 +1,112 @@
+import type { ConversationTurn } from "@waibspace/types";
+
+/**
+ * Default maximum number of turns retained per session.
+ * Keeps context bounded while providing enough history for
+ * multi-turn reference resolution ("Reply to her latest").
+ */
+const DEFAULT_MAX_TURNS = 20;
+
+export interface ConversationContextStoreOptions {
+  /** Maximum number of turns to retain per session (sliding window). */
+  maxTurns?: number;
+  /** Time-to-live in ms for idle sessions before they are pruned. Default: 30 minutes. */
+  sessionTtlMs?: number;
+}
+
+/**
+ * In-memory conversation context store.
+ *
+ * Tracks recent user messages and assistant responses per session so
+ * downstream agents can resolve anaphoric references ("her", "that email")
+ * across turns.
+ *
+ * Uses a sliding window to prevent unbounded growth.
+ */
+export class ConversationContextStore {
+  private sessions = new Map<string, ConversationTurn[]>();
+  private readonly maxTurns: number;
+  private readonly sessionTtlMs: number;
+  private cleanupInterval?: ReturnType<typeof setInterval>;
+
+  constructor(options?: ConversationContextStoreOptions) {
+    this.maxTurns = options?.maxTurns ?? DEFAULT_MAX_TURNS;
+    this.sessionTtlMs = options?.sessionTtlMs ?? 30 * 60 * 1000; // 30 min
+  }
+
+  /**
+   * Append a turn to a session's history.
+   * If the window exceeds `maxTurns`, the oldest turn is dropped.
+   */
+  addTurn(sessionId: string, turn: ConversationTurn): void {
+    let history = this.sessions.get(sessionId);
+    if (!history) {
+      history = [];
+      this.sessions.set(sessionId, history);
+    }
+    history.push(turn);
+
+    // Sliding window: trim from the front
+    if (history.length > this.maxTurns) {
+      const excess = history.length - this.maxTurns;
+      history.splice(0, excess);
+    }
+  }
+
+  /**
+   * Retrieve the conversation history for a session.
+   * Returns an empty array if the session doesn't exist.
+   *
+   * @param limit - Optional cap on the number of most-recent turns to return.
+   */
+  getHistory(sessionId: string, limit?: number): ConversationTurn[] {
+    const history = this.sessions.get(sessionId) ?? [];
+    if (limit !== undefined && limit < history.length) {
+      return history.slice(-limit);
+    }
+    return [...history];
+  }
+
+  /**
+   * Clear conversation history for a specific session.
+   */
+  clearSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+
+  /**
+   * Return the number of active sessions.
+   */
+  sessionCount(): number {
+    return this.sessions.size;
+  }
+
+  /**
+   * Start a periodic cleanup that prunes sessions whose last activity
+   * is older than `sessionTtlMs`.
+   */
+  startCleanup(intervalMs = 60_000): void {
+    this.cleanupInterval = setInterval(() => this.pruneStale(), intervalMs);
+  }
+
+  stopCleanup(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = undefined;
+    }
+  }
+
+  private pruneStale(): void {
+    const now = Date.now();
+    for (const [sessionId, history] of this.sessions) {
+      if (history.length === 0) {
+        this.sessions.delete(sessionId);
+        continue;
+      }
+      const lastTurn = history[history.length - 1];
+      if (now - lastTurn.timestamp > this.sessionTtlMs) {
+        this.sessions.delete(sessionId);
+      }
+    }
+  }
+}

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -2,3 +2,5 @@ export { MemoryStore } from "./memory-store";
 export { MemoryUpdatePipeline } from "./update-pipeline";
 export { ObservationProcessor } from "./observation-processor";
 export type { ObservationProcessorOptions } from "./observation-processor";
+export { ConversationContextStore } from "./conversation-context-store";
+export type { ConversationContextStoreOptions } from "./conversation-context-store";

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2,7 +2,7 @@ import type { WaibEvent, AgentOutput, AgentCategory, IPendingActionStore } from 
 import { EventBus, createEvent } from "@waibspace/event-bus";
 import { executeAgent } from "@waibspace/agents";
 import type { ModelProviderRegistry } from "@waibspace/model-provider";
-import type { MemoryStore } from "@waibspace/memory";
+import type { MemoryStore, ConversationContextStore } from "@waibspace/memory";
 import type { ConnectorRegistry } from "@waibspace/connectors";
 import type { PolicyEngine } from "@waibspace/policy";
 import type { WaibDatabase } from "@waibspace/db";
@@ -15,6 +15,7 @@ export interface OrchestratorOptions {
   timeoutMs?: number;
   modelProvider?: ModelProviderRegistry;
   memoryStore?: MemoryStore;
+  conversationContextStore?: ConversationContextStore;
   connectorRegistry?: ConnectorRegistry;
   policyEngine?: PolicyEngine;
   pendingActionStore?: IPendingActionStore;
@@ -98,6 +99,9 @@ export class Orchestrator {
             : {}),
           ...(this.options?.pendingActionStore
             ? { pendingActionStore: this.options.pendingActionStore }
+            : {}),
+          ...(this.options?.conversationContextStore
+            ? { conversationContextStore: this.options.conversationContextStore }
             : {}),
         },
       };
@@ -269,6 +273,20 @@ export class Orchestrator {
         traceId,
       );
       this.eventBus.emit(errorEvent);
+    }
+
+    // Record assistant response in conversation context
+    if (this.options?.conversationContextStore && surfaceOutputs.length > 0) {
+      const sessionId =
+        (event.metadata as Record<string, unknown> | undefined)?.sessionId as string | undefined
+        ?? "default";
+      const surfaceSummary = surfaceOutputs.map((o) => o.agentId).join(", ");
+      this.options.conversationContextStore.addTurn(sessionId, {
+        role: "assistant",
+        content: `[Rendered surfaces: ${surfaceSummary}]`,
+        timestamp: Date.now(),
+        traceId,
+      });
     }
 
     // Log trace summary

--- a/packages/types/src/memory.ts
+++ b/packages/types/src/memory.ts
@@ -3,7 +3,18 @@ export type MemoryCategory =
   | "interaction"
   | "task"
   | "relationship"
-  | "system";
+  | "system"
+  | "conversation";
+
+/**
+ * A single turn in a conversation history.
+ */
+export interface ConversationTurn {
+  role: "user" | "assistant";
+  content: string;
+  timestamp: number;
+  traceId: string;
+}
 
 export interface MemoryEntry {
   id: string;


### PR DESCRIPTION
## Summary
- Adds `ConversationContextStore` in `packages/memory/` — an in-memory sliding-window store that tracks recent user messages and assistant responses per session, with automatic stale session cleanup
- Adds `ConversationContextAgent` in `packages/agents/src/context/` — a context-phase agent that records the current user message and exposes conversation history to downstream agents for multi-turn reference resolution (e.g. "Show me emails from Alice" then "Reply to her latest")
- Wires the store through the orchestrator pipeline so assistant responses are also recorded after surface composition
- Adds `ConversationTurn` type and `"conversation"` memory category to `@waibspace/types`

## Test plan
- [x] Unit tests for `ConversationContextStore` (8 passing): sliding window, session isolation, limit parameter, copy semantics
- [ ] Manual: send "Show me emails from Alice" then "Reply to her latest" and verify the second request has conversation context available
- [ ] Verify no regressions in existing pipeline (TypeScript compiles clean, existing tests unaffected)

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)