### PR TITLE
feat: implement connector health monitoring dashboard

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -128,6 +128,9 @@ log.info("MCP registry loaded", {
   toolCount: mcpRegistry.getAllTools().length,
 });
 
+// Start periodic health checks for connected MCP servers (every 30s)
+mcpRegistry.startHealthChecks(30_000);
+
 // ---------- 5. Agent Registry ----------
 const agentRegistry = new AgentRegistry();
 
@@ -282,6 +285,7 @@ log.info("WaibSpace backend started", { port: PORT });
 // ---------- 13. Graceful Shutdown ----------
 function handleShutdown(signal: string) {
   log.info("Shutting down", { signal });
+  mcpRegistry.stopHealthChecks();
   scheduler.stop();
   server.stop();
   log.info("Shutdown complete");

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -142,6 +142,23 @@ export function startServer(deps: ServerDeps) {
 
       // ---------- MCP Server Registry endpoints ----------
 
+      // GET /api/mcp/health — connector health metrics
+      if (url.pathname === "/api/mcp/health" && req.method === "GET") {
+        if (!deps.mcpRegistry) {
+          return jsonResponse({ error: "MCP registry not available" }, 503);
+        }
+        return jsonResponse(deps.mcpRegistry.getHealthMetrics());
+      }
+
+      // POST /api/mcp/health/check — trigger an immediate health check
+      if (url.pathname === "/api/mcp/health/check" && req.method === "POST") {
+        if (!deps.mcpRegistry) {
+          return jsonResponse({ error: "MCP registry not available" }, 503);
+        }
+        await deps.mcpRegistry.runHealthChecks();
+        return jsonResponse(deps.mcpRegistry.getHealthMetrics());
+      }
+
       // GET /api/mcp/servers — list all servers with status
       if (url.pathname === "/api/mcp/servers" && req.method === "GET") {
         if (!deps.mcpRegistry) {

--- a/apps/frontend/src/components/ConnectorHealthDashboard.tsx
+++ b/apps/frontend/src/components/ConnectorHealthDashboard.tsx
@@ -1,0 +1,312 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+/** A single health-check entry from the backend. */
+interface HealthCheckEntry {
+  timestamp: number;
+  ok: boolean;
+  latencyMs?: number;
+  error?: string;
+}
+
+/** Aggregated health metrics for a single MCP connector. */
+interface ConnectorHealthMetrics {
+  serverId: string;
+  serverName: string;
+  transport: string;
+  connected: boolean;
+  lastChecked: string | null;
+  connectedSince: string | null;
+  uptimePercent: number;
+  latencyMs: number | null;
+  avgLatencyMs: number | null;
+  errorCount: number;
+  recentErrors: Array<{ timestamp: string; message: string }>;
+  checkHistory: HealthCheckEntry[];
+}
+
+const POLL_INTERVAL = 15_000;
+
+export function ConnectorHealthDashboard() {
+  const [metrics, setMetrics] = useState<ConnectorHealthMetrics[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [expandedErrors, setExpandedErrors] = useState<Set<string>>(new Set());
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchMetrics = useCallback(async () => {
+    try {
+      const res = await fetch("/api/mcp/health");
+      if (res.ok) {
+        const data: ConnectorHealthMetrics[] = await res.json();
+        setMetrics(data);
+      }
+    } catch {
+      // silent polling failure
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMetrics();
+    pollRef.current = setInterval(fetchMetrics, POLL_INTERVAL);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [fetchMetrics]);
+
+  const triggerHealthCheck = async () => {
+    setRefreshing(true);
+    try {
+      const res = await fetch("/api/mcp/health/check", { method: "POST" });
+      if (res.ok) {
+        const data: ConnectorHealthMetrics[] = await res.json();
+        setMetrics(data);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const toggleErrors = (serverId: string) => {
+    setExpandedErrors((prev) => {
+      const next = new Set(prev);
+      if (next.has(serverId)) {
+        next.delete(serverId);
+      } else {
+        next.add(serverId);
+      }
+      return next;
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="health-dashboard__loading">
+        <span className="health-dashboard__loading-dot" />
+        Loading health metrics...
+      </div>
+    );
+  }
+
+  return (
+    <div className="health-dashboard">
+      <div className="health-dashboard__header">
+        <h3 className="health-dashboard__title">Connector Health</h3>
+        <button
+          className={`health-dashboard__refresh-btn ${refreshing ? "health-dashboard__refresh-btn--spinning" : ""}`}
+          onClick={triggerHealthCheck}
+          disabled={refreshing}
+        >
+          <span className="health-dashboard__refresh-icon" aria-hidden="true">
+            &#x21bb;
+          </span>
+          {refreshing ? "Checking..." : "Run Health Check"}
+        </button>
+      </div>
+
+      {metrics.length === 0 && (
+        <div className="health-dashboard__empty">
+          No connectors configured. Add an MCP server to see health metrics.
+        </div>
+      )}
+
+      {metrics.map((m) => (
+        <HealthCard
+          key={m.serverId}
+          metrics={m}
+          errorsExpanded={expandedErrors.has(m.serverId)}
+          onToggleErrors={() => toggleErrors(m.serverId)}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ---- Sub-components ----
+
+function HealthCard({
+  metrics,
+  errorsExpanded,
+  onToggleErrors,
+}: {
+  metrics: ConnectorHealthMetrics;
+  errorsExpanded: boolean;
+  onToggleErrors: () => void;
+}) {
+  const statusClass = metrics.connected
+    ? "connected"
+    : metrics.errorCount > 0
+      ? "error"
+      : "disconnected";
+
+  return (
+    <div className="health-card">
+      <div className="health-card__header">
+        <span className={`health-card__status-dot health-card__status-dot--${statusClass}`} />
+        <span className="health-card__name">{metrics.serverName}</span>
+        <span className="health-card__transport-badge">{metrics.transport}</span>
+      </div>
+
+      <div className="health-card__metrics">
+        <div className="health-metric">
+          <span className="health-metric__label">Status</span>
+          <span className={`health-metric__value ${metrics.connected ? "health-metric__value--good" : "health-metric__value--bad"}`}>
+            {metrics.connected ? "Connected" : "Disconnected"}
+          </span>
+        </div>
+
+        <div className="health-metric">
+          <span className="health-metric__label">Uptime</span>
+          <span className={`health-metric__value ${uptimeClass(metrics.uptimePercent)}`}>
+            {metrics.checkHistory.length > 0 ? `${metrics.uptimePercent}%` : "--"}
+          </span>
+        </div>
+
+        <div className="health-metric">
+          <span className="health-metric__label">Latency</span>
+          <span className={`health-metric__value ${latencyClass(metrics.latencyMs)}`}>
+            {metrics.latencyMs != null ? `${metrics.latencyMs}ms` : "--"}
+          </span>
+        </div>
+
+        <div className="health-metric">
+          <span className="health-metric__label">Avg Latency</span>
+          <span className={`health-metric__value ${latencyClass(metrics.avgLatencyMs)}`}>
+            {metrics.avgLatencyMs != null ? `${metrics.avgLatencyMs}ms` : "--"}
+          </span>
+        </div>
+
+        <div className="health-metric">
+          <span className="health-metric__label">Errors</span>
+          <span className={`health-metric__value ${metrics.errorCount > 0 ? "health-metric__value--bad" : "health-metric__value--muted"}`}>
+            {metrics.errorCount}
+          </span>
+        </div>
+
+        <div className="health-metric">
+          <span className="health-metric__label">Last Checked</span>
+          <span className="health-metric__value health-metric__value--muted">
+            {metrics.lastChecked ? formatRelativeTime(metrics.lastChecked) : "--"}
+          </span>
+        </div>
+      </div>
+
+      {metrics.checkHistory.length > 0 && (
+        <div className="health-card__latency-section">
+          <div className="health-card__section-label">Recent Latency</div>
+          <LatencyChart history={metrics.checkHistory} />
+        </div>
+      )}
+
+      {metrics.errorCount > 0 && (
+        <div className="health-card__errors">
+          <button className="health-card__error-toggle" onClick={onToggleErrors}>
+            {errorsExpanded ? "Hide" : "Show"} error history ({metrics.recentErrors.length})
+          </button>
+          {errorsExpanded && (
+            <ul className="health-card__error-list">
+              {metrics.recentErrors.map((err, i) => (
+                <li key={i} className="health-card__error-item">
+                  <span className="health-card__error-time">
+                    {formatRelativeTime(err.timestamp)}
+                  </span>
+                  <span className="health-card__error-msg" title={err.message}>
+                    {err.message}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {metrics.connectedSince && (
+        <div className="health-card__connected-since">
+          Connected since {formatAbsoluteTime(metrics.connectedSince)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LatencyChart({ history }: { history: HealthCheckEntry[] }) {
+  // Show the most recent 20 entries, oldest to newest (left to right)
+  const entries = history.slice(0, 20).reverse();
+  const maxLatency = Math.max(
+    ...entries.filter((e) => e.ok && e.latencyMs != null).map((e) => e.latencyMs!),
+    1,
+  );
+
+  return (
+    <div className="health-latency-chart">
+      {entries.map((entry, i) => {
+        if (!entry.ok) {
+          return (
+            <div
+              key={i}
+              className="health-latency-chart__bar health-latency-chart__bar--error"
+              style={{ height: "100%" }}
+              title={`Error: ${entry.error ?? "unknown"}`}
+            />
+          );
+        }
+        const latency = entry.latencyMs ?? 0;
+        const heightPct = Math.max((latency / maxLatency) * 100, 8);
+        const barClass =
+          latency < 200
+            ? "health-latency-chart__bar--good"
+            : latency < 1000
+              ? "health-latency-chart__bar--warn"
+              : "health-latency-chart__bar--bad";
+
+        return (
+          <div
+            key={i}
+            className={`health-latency-chart__bar ${barClass}`}
+            style={{ height: `${heightPct}%` }}
+            title={`${latency}ms`}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+// ---- Helpers ----
+
+function uptimeClass(pct: number): string {
+  if (pct >= 95) return "health-metric__value--good";
+  if (pct >= 70) return "health-metric__value--warn";
+  return "health-metric__value--bad";
+}
+
+function latencyClass(ms: number | null): string {
+  if (ms == null) return "health-metric__value--muted";
+  if (ms < 200) return "health-metric__value--good";
+  if (ms < 1000) return "health-metric__value--warn";
+  return "health-metric__value--bad";
+}
+
+function formatRelativeTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 5) return "just now";
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) return `${diffHour}h ago`;
+  return `${Math.floor(diffHour / 24)}d ago`;
+}
+
+function formatAbsoluteTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/apps/frontend/src/pages/SettingsPage.tsx
+++ b/apps/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { ConnectionManager } from "../components/ConnectionManager";
+import { ConnectorHealthDashboard } from "../components/ConnectorHealthDashboard";
 import { useTheme, type Theme } from "../hooks/useTheme";
 
-type SettingsSection = "connections" | "preferences" | "about";
+type SettingsSection = "connections" | "health" | "preferences" | "about";
 
 export default function SettingsPage() {
   const [activeSection, setActiveSection] = useState<SettingsSection>("connections");
@@ -12,6 +13,7 @@ export default function SettingsPage() {
 
   const sections: { id: SettingsSection; label: string }[] = [
     { id: "connections", label: "Connections" },
+    { id: "health", label: "Health" },
     { id: "preferences", label: "Preferences" },
     { id: "about", label: "About" },
   ];
@@ -36,6 +38,12 @@ export default function SettingsPage() {
         {activeSection === "connections" && (
           <section className="settings-section">
             <ConnectionManager />
+          </section>
+        )}
+
+        {activeSection === "health" && (
+          <section className="settings-section">
+            <ConnectorHealthDashboard />
           </section>
         )}
 

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -1,6 +1,7 @@
 @import "./block-error.css";
 @import "./calendar-components.css";
 @import "./error-surface.css";
+@import "./health-dashboard.css";
 @import "./keyboard-nav.css";
 
 /* ================================ */

--- a/apps/frontend/src/styles/health-dashboard.css
+++ b/apps/frontend/src/styles/health-dashboard.css
@@ -1,0 +1,315 @@
+/* ================================ */
+/* Connector Health Dashboard       */
+/* ================================ */
+
+.health-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.health-dashboard__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.health-dashboard__title {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.health-dashboard__refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-accent);
+  background: var(--color-accent-subtle);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.health-dashboard__refresh-btn:hover {
+  background: var(--color-accent-muted);
+  border-color: var(--color-accent);
+}
+
+.health-dashboard__refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.health-dashboard__refresh-btn--spinning .health-dashboard__refresh-icon {
+  animation: health-spin 0.8s linear infinite;
+}
+
+@keyframes health-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.health-dashboard__empty {
+  text-align: center;
+  padding: var(--space-8);
+  color: var(--color-muted);
+  font-size: var(--text-base);
+}
+
+/* ---- Server card ---- */
+
+.health-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.health-card:hover {
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+.health-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.health-card__status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.health-card__status-dot--connected {
+  background: var(--color-success);
+  box-shadow: 0 0 6px var(--color-success);
+}
+
+.health-card__status-dot--disconnected {
+  background: var(--color-neutral);
+}
+
+.health-card__status-dot--error {
+  background: var(--color-danger);
+  box-shadow: 0 0 6px var(--color-danger);
+}
+
+.health-card__name {
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.health-card__transport-badge {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-muted);
+  background: var(--color-neutral-subtle);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* ---- Metrics grid ---- */
+
+.health-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.health-metric {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+}
+
+.health-metric__label {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.health-metric__value {
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.health-metric__value--good {
+  color: var(--color-success-text);
+}
+
+.health-metric__value--warn {
+  color: var(--color-warning-text);
+}
+
+.health-metric__value--bad {
+  color: var(--color-danger-text);
+}
+
+.health-metric__value--muted {
+  color: var(--color-muted);
+}
+
+/* ---- Latency bar chart ---- */
+
+.health-card__latency-section {
+  margin-bottom: var(--space-3);
+}
+
+.health-card__section-label {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: var(--space-2);
+}
+
+.health-latency-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 40px;
+  padding: var(--space-1) 0;
+}
+
+.health-latency-chart__bar {
+  flex: 1;
+  min-width: 4px;
+  max-width: 12px;
+  border-radius: 2px 2px 0 0;
+  transition: height 0.2s ease;
+}
+
+.health-latency-chart__bar--good {
+  background: var(--color-success);
+  opacity: 0.7;
+}
+
+.health-latency-chart__bar--warn {
+  background: var(--color-warning);
+  opacity: 0.7;
+}
+
+.health-latency-chart__bar--bad {
+  background: var(--color-danger);
+  opacity: 0.7;
+}
+
+.health-latency-chart__bar--error {
+  background: var(--color-danger);
+  opacity: 0.3;
+}
+
+/* ---- Error history ---- */
+
+.health-card__errors {
+  margin-top: var(--space-2);
+}
+
+.health-card__error-toggle {
+  font-size: var(--text-sm);
+  color: var(--color-danger-text);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--space-1) 0;
+  font-weight: var(--weight-medium);
+}
+
+.health-card__error-toggle:hover {
+  text-decoration: underline;
+}
+
+.health-card__error-list {
+  list-style: none;
+  margin: var(--space-2) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.health-card__error-item {
+  display: flex;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-danger-subtle);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+
+.health-card__error-time {
+  color: var(--color-muted);
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+}
+
+.health-card__error-msg {
+  color: var(--color-danger-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ---- Connected since ---- */
+
+.health-card__connected-since {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  margin-top: var(--space-2);
+}
+
+/* ---- Loading state ---- */
+
+.health-dashboard__loading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-6);
+  color: var(--color-muted);
+  font-size: var(--text-base);
+  justify-content: center;
+}
+
+.health-dashboard__loading-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  animation: health-pulse 1s ease-in-out infinite;
+}
+
+@keyframes health-pulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -32,7 +32,7 @@ export {
 } from "./web-fetch";
 export type { ExtractedContent } from "./web-fetch";
 export { MCPConnector, MCPServerRegistry } from "./mcp";
-export type { MCPServerConfig, MCPToolInfo, MCPCacheConfig } from "./mcp";
+export type { MCPServerConfig, MCPToolInfo, MCPCacheConfig, HealthCheckEntry, ConnectorHealthMetrics } from "./mcp";
 export { TtlCache } from "./cache";
 export type { CacheOptions, CacheEntry } from "./cache";
 export { MCP_SERVER_CATALOG, findTemplate, searchCatalog } from "./mcp";

--- a/packages/connectors/src/mcp/index.ts
+++ b/packages/connectors/src/mcp/index.ts
@@ -1,6 +1,6 @@
 export { MCPConnector } from "./mcp-connector";
 export { MCPServerRegistry } from "./registry";
-export type { MCPServerConfig, MCPToolInfo, MCPCacheConfig } from "./types";
+export type { MCPServerConfig, MCPToolInfo, MCPCacheConfig, HealthCheckEntry, ConnectorHealthMetrics } from "./types";
 export { MCP_SERVER_CATALOG, findTemplate, searchCatalog } from "./catalog";
 export type { MCPServerTemplate, MCPCredentialSpec } from "./catalog";
 export {

--- a/packages/connectors/src/mcp/registry.ts
+++ b/packages/connectors/src/mcp/registry.ts
@@ -1,11 +1,14 @@
 import { MCPConnector } from "./mcp-connector";
-import type { MCPServerConfig, MCPToolInfo } from "./types";
+import type { MCPServerConfig, MCPToolInfo, HealthCheckEntry, ConnectorHealthMetrics } from "./types";
 import type { PolicyEngine } from "@waibspace/policy";
 import type { WaibDatabase, MCPServerRow } from "@waibspace/db";
 import type { TrustLevel } from "@waibspace/types";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { existsSync, renameSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
+
+/** Maximum number of health check entries to retain per server. */
+const MAX_HEALTH_HISTORY = 50;
 
 /**
  * Classify an MCP tool name into a risk class for policy rule generation.
@@ -34,6 +37,17 @@ export class MCPServerRegistry {
   private connectionErrors = new Map<string, string>();
   private policyEngine: PolicyEngine | undefined;
   private db?: WaibDatabase;
+
+  /** Health-check history per server (ring buffer, newest first). */
+  private healthHistory = new Map<string, HealthCheckEntry[]>();
+  /** Timestamp when each server was connected in this session. */
+  private connectedSince = new Map<string, number>();
+  /** Total error count per server since tracking started. */
+  private errorCounts = new Map<string, number>();
+  /** Recent error messages per server (newest first, capped). */
+  private recentErrors = new Map<string, Array<{ timestamp: number; message: string }>>();
+  /** Handle for the periodic health-check interval. */
+  private healthInterval: ReturnType<typeof setInterval> | null = null;
 
   constructor(policyEngine?: PolicyEngine, db?: WaibDatabase) {
     this.policyEngine = policyEngine;
@@ -72,10 +86,12 @@ export class MCPServerRegistry {
       await entry.connector.connect();
       // Clear any previous connection error on success
       this.connectionErrors.delete(id);
+      this.connectedSince.set(id, Date.now());
       this.generatePolicyRules(id, entry.connector.getDiscoveredTools());
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.connectionErrors.set(id, message);
+      this.recordError(id, message);
       throw error;
     }
   }
@@ -88,6 +104,7 @@ export class MCPServerRegistry {
     }
     this.removePolicyRules(id);
     this.connectionErrors.delete(id);
+    this.connectedSince.delete(id);
     await entry.connector.disconnect();
   }
 
@@ -136,6 +153,111 @@ export class MCPServerRegistry {
   /** Get a connected MCPConnector by server ID. */
   getConnector(id: string): MCPConnector | undefined {
     return this.servers.get(id)?.connector;
+  }
+
+  // ---- Health monitoring ----
+
+  /** Record a health check result for a server. */
+  private recordHealthCheck(serverId: string, entry: HealthCheckEntry): void {
+    let history = this.healthHistory.get(serverId);
+    if (!history) {
+      history = [];
+      this.healthHistory.set(serverId, history);
+    }
+    history.unshift(entry);
+    if (history.length > MAX_HEALTH_HISTORY) {
+      history.length = MAX_HEALTH_HISTORY;
+    }
+    if (!entry.ok && entry.error) {
+      this.recordError(serverId, entry.error);
+    }
+  }
+
+  /** Record an error for a server. */
+  private recordError(serverId: string, message: string): void {
+    this.errorCounts.set(serverId, (this.errorCounts.get(serverId) ?? 0) + 1);
+    let errors = this.recentErrors.get(serverId);
+    if (!errors) {
+      errors = [];
+      this.recentErrors.set(serverId, errors);
+    }
+    errors.unshift({ timestamp: Date.now(), message });
+    if (errors.length > 20) {
+      errors.length = 20;
+    }
+  }
+
+  /** Run a health check (ping) on all connected servers and record results. */
+  async runHealthChecks(): Promise<void> {
+    const entries = Array.from(this.servers.entries());
+    await Promise.allSettled(
+      entries.map(async ([id, { connector }]) => {
+        if (!connector.isConnected()) {
+          this.recordHealthCheck(id, { timestamp: Date.now(), ok: false, error: "Not connected" });
+          return;
+        }
+        const result = await connector.ping();
+        if (result.ok) {
+          this.recordHealthCheck(id, { timestamp: Date.now(), ok: true, latencyMs: result.latencyMs });
+        } else {
+          this.recordHealthCheck(id, { timestamp: Date.now(), ok: false, error: result.error });
+        }
+      }),
+    );
+  }
+
+  /** Start periodic health checks at the given interval (default 30s). */
+  startHealthChecks(intervalMs = 30_000): void {
+    this.stopHealthChecks();
+    this.healthInterval = setInterval(() => {
+      this.runHealthChecks().catch(() => {});
+    }, intervalMs);
+    // Run an initial check immediately
+    this.runHealthChecks().catch(() => {});
+  }
+
+  /** Stop periodic health checks. */
+  stopHealthChecks(): void {
+    if (this.healthInterval) {
+      clearInterval(this.healthInterval);
+      this.healthInterval = null;
+    }
+  }
+
+  /** Get aggregated health metrics for all servers. */
+  getHealthMetrics(): ConnectorHealthMetrics[] {
+    return Array.from(this.servers.values()).map(({ config, connector }) => {
+      const id = config.id;
+      const history = this.healthHistory.get(id) ?? [];
+      const okChecks = history.filter((h) => h.ok);
+      const uptimePercent = history.length > 0 ? Math.round((okChecks.length / history.length) * 100) : 0;
+
+      const latencies = okChecks.filter((h) => h.latencyMs != null).map((h) => h.latencyMs!);
+      const latencyMs = latencies.length > 0 ? latencies[0] : null;
+      const avgLatencyMs = latencies.length > 0 ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : null;
+
+      const lastOk = okChecks[0];
+      const connSince = this.connectedSince.get(id);
+      const errors = this.recentErrors.get(id) ?? [];
+
+      return {
+        serverId: id,
+        serverName: config.name,
+        transport: config.transport,
+        connected: connector.isConnected(),
+        lastChecked: lastOk ? new Date(lastOk.timestamp).toISOString() : null,
+        connectedSince: connSince ? new Date(connSince).toISOString() : null,
+        uptimePercent,
+        latencyMs,
+        avgLatencyMs,
+        errorCount: this.errorCounts.get(id) ?? 0,
+        recentErrors: errors.map((e) => ({
+          timestamp: new Date(e.timestamp).toISOString(),
+          message: e.message,
+        })),
+        checkHistory: history.slice(0, 20),
+      };
+    });
   }
 
   private configToRow(config: MCPServerConfig): MCPServerRow {

--- a/packages/connectors/src/mcp/types.ts
+++ b/packages/connectors/src/mcp/types.ts
@@ -43,3 +43,35 @@ export interface MCPToolInfo {
   serverId: string;
   serverName: string;
 }
+
+/** A single health-check result stored in the history ring buffer. */
+export interface HealthCheckEntry {
+  timestamp: number;
+  ok: boolean;
+  latencyMs?: number;
+  error?: string;
+}
+
+/** Aggregated health metrics for a single MCP server. */
+export interface ConnectorHealthMetrics {
+  serverId: string;
+  serverName: string;
+  transport: string;
+  connected: boolean;
+  /** ISO-8601 timestamp of the last successful health check. */
+  lastChecked: string | null;
+  /** ISO-8601 timestamp of when the server first connected in this session. */
+  connectedSince: string | null;
+  /** Uptime percentage (0-100) based on recent health checks. */
+  uptimePercent: number;
+  /** Most recent ping latency in ms. */
+  latencyMs: number | null;
+  /** Average latency over recent checks. */
+  avgLatencyMs: number | null;
+  /** Total error count since tracking started. */
+  errorCount: number;
+  /** Recent error history (most recent first). */
+  recentErrors: Array<{ timestamp: string; message: string }>;
+  /** Recent health check history (most recent first). */
+  checkHistory: HealthCheckEntry[];
+}


### PR DESCRIPTION
## Summary
- Add health metric tracking to `MCPServerRegistry` with periodic pings (30s), uptime calculation, latency history, and error recording
- Add `GET /api/mcp/health` and `POST /api/mcp/health/check` backend endpoints
- Add `ConnectorHealthDashboard` React component with per-connector cards showing status, uptime %, current/avg latency, error count, latency sparkline chart, and expandable error history
- Wire dashboard into Settings page as a new "Health" tab with BEM CSS using project design tokens

Closes #224

## Test plan
- [ ] Navigate to Settings > Health tab and verify the dashboard loads
- [ ] With MCP servers connected, confirm status dots, uptime, and latency display correctly
- [ ] Click "Run Health Check" and verify metrics refresh with updated latency values
- [ ] Disconnect a server and verify it shows as disconnected with error count incrementing
- [ ] Verify the latency bar chart renders with color-coded bars (green < 200ms, yellow < 1s, red > 1s)
- [ ] Expand error history for a server with errors and verify timestamps and messages display
- [ ] Confirm the dashboard auto-polls every 15 seconds for updated metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)