### PR TITLE
feat: add search functionality across all connected services

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -26,6 +26,7 @@ import {
   ApprovalSurfaceAgent,
   ConnectionSurfaceAgent,
   GenericDataSurfaceAgent,
+  SearchSurfaceAgent,
   LayoutComposerAgent,
   // Safety agents
   ProvenanceAnnotatorAgent,
@@ -159,6 +160,7 @@ agentRegistry.register(new DiscoverySurfaceAgent());
 agentRegistry.register(new ApprovalSurfaceAgent());
 agentRegistry.register(new ConnectionSurfaceAgent());
 agentRegistry.register(new GenericDataSurfaceAgent());
+agentRegistry.register(new SearchSurfaceAgent());
 agentRegistry.register(new LayoutComposerAgent());
 
 // Safety agents

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -430,6 +430,78 @@ export function startServer(deps: ServerDeps) {
         }
       }
 
+      // ---------- Search endpoint ----------
+
+      // GET /api/search?q=query — search across all connected services
+      if (url.pathname === "/api/search" && req.method === "GET") {
+        const query = url.searchParams.get("q");
+        if (!query || !query.trim()) {
+          return jsonResponse({ error: "Missing search query parameter 'q'" }, 400);
+        }
+
+        if (!deps.connectorRegistry) {
+          return jsonResponse({ error: "Connector registry not available" }, 503);
+        }
+
+        const connectors = deps.connectorRegistry.getAll();
+        const connectedConnectors = connectors.filter(
+          (c: { isConnected(): boolean }) => c.isConnected(),
+        );
+
+        if (connectedConnectors.length === 0) {
+          return jsonResponse({
+            query: query.trim(),
+            results: [],
+            sources: [],
+            totalResults: 0,
+          });
+        }
+
+        const traceId = crypto.randomUUID();
+        const searchResults: Array<{
+          connectorId: string;
+          data: unknown;
+          error?: string;
+        }> = [];
+
+        // Query each connector in parallel with search-compatible operations
+        const settlements = await Promise.allSettled(
+          connectedConnectors.map(async (connector: { id: string; fetch(req: { operation: string; params: Record<string, unknown>; traceId: string }): Promise<{ data: unknown }> }) => {
+            try {
+              // Use "search" operation — connectors that don't support it will error
+              const response = await connector.fetch({
+                operation: "search",
+                params: { query: query.trim(), maxResults: 10 },
+                traceId,
+              });
+              return {
+                connectorId: connector.id,
+                data: response.data,
+              };
+            } catch {
+              // Connector doesn't support search, skip silently
+              return {
+                connectorId: connector.id,
+                data: null,
+              };
+            }
+          }),
+        );
+
+        for (const settlement of settlements) {
+          if (settlement.status === "fulfilled" && settlement.value.data) {
+            searchResults.push(settlement.value);
+          }
+        }
+
+        return jsonResponse({
+          query: query.trim(),
+          results: searchResults,
+          sources: searchResults.map((r) => r.connectorId),
+          totalResults: searchResults.length,
+        });
+      }
+
       return jsonResponse({ error: "Not found" }, 404);
     },
 

--- a/apps/frontend/src/blocks/transformers/index.ts
+++ b/apps/frontend/src/blocks/transformers/index.ts
@@ -7,6 +7,7 @@ import { discoveryToBlocks } from "./discovery";
 import { approvalToBlocks } from "./approval";
 import { connectionGuideToBlocks } from "./connection-guide";
 import { genericToBlocks } from "./generic";
+import { searchToBlocks } from "./search";
 
 export {
   inboxToBlocks,
@@ -15,6 +16,7 @@ export {
   approvalToBlocks,
   connectionGuideToBlocks,
   genericToBlocks,
+  searchToBlocks,
 };
 
 const transformerMap: Record<
@@ -26,6 +28,7 @@ const transformerMap: Record<
   discovery: discoveryToBlocks,
   approval: approvalToBlocks,
   "connection-guide": connectionGuideToBlocks,
+  search: searchToBlocks,
 };
 
 /**

--- a/apps/frontend/src/blocks/transformers/search.ts
+++ b/apps/frontend/src/blocks/transformers/search.ts
@@ -1,0 +1,150 @@
+import type { ComponentBlock, SurfaceSpec } from "@waibspace/types";
+import type { SearchSurfaceData } from "@waibspace/surfaces";
+
+export function searchToBlocks(spec: SurfaceSpec): ComponentBlock[] {
+  const data = spec.data as SearchSurfaceData;
+  const sid = spec.surfaceId;
+
+  const children: ComponentBlock[] = [];
+
+  // Header with query and result count
+  children.push({
+    id: `${sid}-header`,
+    type: "Text",
+    props: { content: `Search: "${data.query}"`, variant: "h3" },
+  });
+
+  children.push({
+    id: `${sid}-summary`,
+    type: "Text",
+    props: {
+      content: `${data.totalResults} result${data.totalResults !== 1 ? "s" : ""} across ${data.sources.join(", ")}`,
+      variant: "caption",
+    },
+  });
+
+  // Results list
+  if (data.results && data.results.length > 0) {
+    const resultItems: ComponentBlock[] = data.results.map((result, i) => {
+      const itemChildren: ComponentBlock[] = [
+        {
+          id: `${sid}-result-stack-${i}`,
+          type: "Stack",
+          props: { gap: "4px" },
+          children: [
+            {
+              id: `${sid}-result-title-${i}`,
+              type: "Text",
+              props: { content: result.title, variant: "h3" },
+            },
+            {
+              id: `${sid}-result-snippet-${i}`,
+              type: "Text",
+              props: { content: result.snippet, variant: "body" },
+            },
+            {
+              id: `${sid}-result-meta-${i}`,
+              type: "Row",
+              props: { gap: "8px" },
+              children: [
+                {
+                  id: `${sid}-result-source-${i}`,
+                  type: "Badge",
+                  props: {
+                    label: result.source,
+                    color: getSourceColor(result.sourceType),
+                  },
+                },
+                ...(result.date
+                  ? [
+                      {
+                        id: `${sid}-result-date-${i}`,
+                        type: "Text",
+                        props: { content: result.date, variant: "caption" },
+                      } satisfies ComponentBlock,
+                    ]
+                  : []),
+                {
+                  id: `${sid}-result-score-${i}`,
+                  type: "Badge",
+                  props: {
+                    label: `${Math.round(result.relevanceScore * 100)}%`,
+                    color: "blue",
+                  },
+                },
+              ],
+            },
+            // Metadata tags
+            ...(result.metadata
+              ? Object.entries(result.metadata).map(
+                  ([key, value], mi) =>
+                    ({
+                      id: `${sid}-result-tag-${i}-${mi}`,
+                      type: "Badge",
+                      props: {
+                        label: `${key}: ${value}`,
+                        color: "gray",
+                      },
+                    }) satisfies ComponentBlock,
+                )
+              : []),
+          ],
+        },
+      ];
+
+      return {
+        id: `${sid}-result-item-${i}`,
+        type: "ListItem",
+        props: {},
+        children: itemChildren,
+      } satisfies ComponentBlock;
+    });
+
+    children.push({
+      id: `${sid}-result-list`,
+      type: "List",
+      props: {},
+      children: resultItems,
+    });
+  } else {
+    children.push({
+      id: `${sid}-no-results`,
+      type: "Text",
+      props: {
+        content: `No results found for "${data.query}". Try a different search term.`,
+        variant: "body",
+      },
+    });
+  }
+
+  return [
+    {
+      id: `${sid}-root`,
+      type: "Container",
+      props: { direction: "column", gap: "12px", padding: "var(--space-5)" },
+      children,
+      meta: {
+        surfaceId: spec.surfaceId,
+        surfaceType: "search",
+        provenance: spec.provenance,
+        layoutHints: spec.layoutHints,
+      },
+    },
+  ];
+}
+
+function getSourceColor(sourceType: string): string {
+  switch (sourceType) {
+    case "email":
+      return "red";
+    case "calendar-event":
+      return "green";
+    case "message":
+      return "purple";
+    case "issue":
+    case "pull-request":
+      return "orange";
+    default:
+      return "blue";
+  }
+}

--- a/apps/frontend/src/components/ChatInput.tsx
+++ b/apps/frontend/src/components/ChatInput.tsx
@@ -1,16 +1,29 @@
-import { useState } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 
-export function ChatInput({ onSend }: { onSend: (text: string) => void }) {
+interface ChatInputProps {
+  onSend: (text: string) => void;
+  placeholder?: string;
+}
+
+export function ChatInput({ onSend, placeholder }: ChatInputProps) {
   const [text, setText] = useState("");
   const [history, setHistory] = useState<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
+  const [searchMode, setSearchMode] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleSubmit = () => {
     if (!text.trim()) return;
-    onSend(text.trim());
+    const message = searchMode
+      ? `Search across all services for: ${text.trim()}`
+      : text.trim();
+    onSend(message);
     setHistory((prev) => [text.trim(), ...prev]);
     setText("");
     setHistoryIndex(-1);
+    if (searchMode) {
+      setSearchMode(false);
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -23,19 +36,58 @@ export function ChatInput({ onSend }: { onSend: (text: string) => void }) {
       setHistoryIndex(next);
       if (history[next]) setText(history[next]);
     }
+    if (e.key === "Escape" && searchMode) {
+      setSearchMode(false);
+    }
   };
 
+  const toggleSearchMode = useCallback(() => {
+    setSearchMode((prev) => !prev);
+    textareaRef.current?.focus();
+  }, []);
+
+  // Global Cmd/Ctrl+K shortcut to toggle search mode
+  useEffect(() => {
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        toggleSearchMode();
+      }
+    };
+    window.addEventListener("keydown", handleGlobalKeyDown);
+    return () => window.removeEventListener("keydown", handleGlobalKeyDown);
+  }, [toggleSearchMode]);
+
+  const activePlaceholder = searchMode
+    ? "Search emails, calendar, and all connected services..."
+    : placeholder ?? "Ask WaibSpace anything...";
+
   return (
-    <div className="chat-input">
+    <div className={`chat-input${searchMode ? " chat-input--search" : ""}`}>
+      {searchMode && (
+        <span className="chat-input__search-icon" aria-hidden="true">
+          &#x1F50D;
+        </span>
+      )}
       <textarea
+        ref={textareaRef}
         value={text}
         onChange={(e) => setText(e.target.value)}
         onKeyDown={handleKeyDown}
-        placeholder="Ask WaibSpace anything..."
+        placeholder={activePlaceholder}
         rows={1}
       />
+      <button
+        className="chat-input__search-toggle"
+        onClick={toggleSearchMode}
+        type="button"
+        title="Toggle search mode (Cmd+K)"
+        aria-pressed={searchMode}
+      >
+        {searchMode ? "Chat" : "Search"}
+      </button>
       <button onClick={handleSubmit} disabled={!text.trim()}>
-        Send
+        {searchMode ? "Search" : "Send"}
       </button>
     </div>
   );

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -797,6 +797,128 @@ body {
   transform: translateY(0) scale(0.97);
 }
 
+/* Search mode toggle button */
+.chat-input__search-toggle {
+  padding: 0.5rem var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast),
+    border-color var(--transition-fast);
+  white-space: nowrap;
+}
+
+.chat-input__search-toggle:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.chat-input__search-toggle[aria-pressed="true"] {
+  background: var(--color-accent-subtle);
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+/* Search mode styling */
+.chat-input--search {
+  position: relative;
+}
+
+.chat-input--search textarea {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-subtle);
+  padding-left: 2.25rem;
+}
+
+.chat-input__search-icon {
+  position: absolute;
+  left: var(--space-3);
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: var(--text-md);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* ================================ */
+/* Search Surface                   */
+/* ================================ */
+.search-surface {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.search-surface__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.search-surface__query {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+}
+
+.search-surface__summary {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.search-surface__results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.search-surface__result {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  transition: border-color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.search-surface__result:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-surface-hover);
+}
+
+.search-surface__result-title {
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+}
+
+.search-surface__result-snippet {
+  font-size: var(--text-base);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+}
+
+.search-surface__result-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.search-surface__no-results {
+  text-align: center;
+  padding: var(--space-8);
+  color: var(--color-muted);
+  font-size: var(--text-md);
+}
+
 /* ================================ */
 /* Welcome State                    */
 /* ================================ */

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -43,6 +43,7 @@ export {
   ConnectionSurfaceAgent,
   GenericDataSurfaceAgent,
   MorningDigestAgent,
+  SearchSurfaceAgent,
   LayoutComposerAgent,
   extractSurfaces,
 } from "./ui";

--- a/packages/agents/src/reasoning/intent-agent.ts
+++ b/packages/agents/src/reasoning/intent-agent.ts
@@ -22,6 +22,7 @@ WaibSpace has the following built-in capabilities:
 - **Email management**: check inbox, summarize emails, reply to emails, search emails
 - **Calendar management**: view upcoming events, check availability, schedule meetings
 - **Discovery**: find information, movies, restaurants, services, recommendations
+- **Search**: search across all connected services (emails, calendar events, etc.) for specific content
 - **Task management**: create tasks, list tasks, complete/update tasks
 - **Service connection**: connect Gmail, connect Google Calendar, link accounts, set up integrations`;
 
@@ -29,7 +30,9 @@ const CLASSIFICATION_INSTRUCTIONS = `
 
 For each input, determine:
 1. The primary intent (e.g., "check_email", "find_movie", "schedule_meeting", "create_task", "connect_service", "query_data")
-2. The intent category (one of: "email", "calendar", "discovery", "task", "connection", "data", "general")
+2. The intent category (one of: "email", "calendar", "discovery", "search", "task", "connection", "data", "general")
+   - Use "search" when the user wants to search/find specific content across their connected services (e.g., "search for emails about project X", "find calendar events with Alice")
+   - Use "discovery" for general information discovery (movies, restaurants, web lookups)
    - Use "data" when the request relates to a connected service that doesn't fit the standard categories
 3. Any entities mentioned (e.g., genre, date, time, person, subject, service name)
 4. Which downstream agents should handle this (e.g., "context.email", "context.calendar", "ui.discovery", "ui.connection-surface")

--- a/packages/agents/src/ui/index.ts
+++ b/packages/agents/src/ui/index.ts
@@ -5,4 +5,5 @@ export { ApprovalSurfaceAgent } from "./approval-surface";
 export { ConnectionSurfaceAgent } from "./connection-surface";
 export { GenericDataSurfaceAgent } from "./generic-data-surface";
 export { MorningDigestAgent } from "./morning-digest-surface";
+export { SearchSurfaceAgent } from "./search-surface";
 export { LayoutComposerAgent, extractSurfaces } from "./layout-composer";

--- a/packages/agents/src/ui/search-surface.ts
+++ b/packages/agents/src/ui/search-surface.ts
@@ -1,0 +1,285 @@
+import type { AgentOutput } from "@waibspace/types";
+import {
+  SurfaceFactory,
+  type SearchSurfaceData,
+} from "@waibspace/surfaces";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+import type { DataRetrievalOutput } from "../context/data-retrieval";
+import type { IntentClassification } from "../reasoning/intent-agent";
+
+/**
+ * Structured search result the LLM produces from raw connector data.
+ */
+interface SearchAnalysis {
+  query: string;
+  results: Array<{
+    id: string;
+    title: string;
+    snippet: string;
+    source: string;
+    sourceType: string;
+    date?: string;
+    url?: string;
+    relevanceScore: number;
+    metadata?: Record<string, string>;
+  }>;
+}
+
+const SYSTEM_PROMPT = `You are a unified search agent for WaibSpace, an AI-powered personal assistant.
+
+Given raw data from multiple services (email, calendar, etc.) and a search query, analyze the data and return unified search results ranked by relevance.
+
+For each result:
+1. Generate a concise title
+2. Write a brief snippet summarizing the content
+3. Identify the source service (e.g., "Gmail", "Google Calendar")
+4. Identify the source type (e.g., "email", "calendar-event")
+5. Extract relevant dates
+6. Score relevance from 0 to 1
+7. Extract metadata tags (e.g., {"from": "alice@example.com", "status": "unread"})
+
+Return a JSON object with:
+- query: the original search query
+- results: array of results sorted by relevance (highest first)`;
+
+const SEARCH_ANALYSIS_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    query: { type: "string" },
+    results: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          title: { type: "string" },
+          snippet: { type: "string" },
+          source: { type: "string" },
+          sourceType: { type: "string" },
+          date: { type: "string" },
+          url: { type: "string" },
+          relevanceScore: { type: "number", minimum: 0, maximum: 1 },
+          metadata: { type: "object", additionalProperties: { type: "string" } },
+        },
+        required: ["id", "title", "snippet", "source", "sourceType", "relevanceScore"],
+      },
+    },
+  },
+  required: ["query", "results"],
+};
+
+export class SearchSurfaceAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "ui.search-surface",
+      name: "SearchSurfaceAgent",
+      type: "surface-builder",
+      category: "ui",
+    });
+  }
+
+  async execute(
+    input: AgentInput,
+    context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+
+    // Only activate for search intents
+    const intent = this.findIntentClassification(input);
+    if (!intent || !this.isSearchIntent(intent)) {
+      return this.createOutput(null, 0, {
+        dataState: "raw",
+        timestamp: startMs,
+      });
+    }
+
+    const retrievalOutput = this.findDataRetrieval(input);
+    if (!retrievalOutput) {
+      return this.createOutput(null, 0, {
+        dataState: "raw",
+        timestamp: startMs,
+      });
+    }
+
+    // Gather all fulfilled results from any connector
+    const allResults = retrievalOutput.results.filter(
+      (r) => r.status === "fulfilled" && r.data,
+    );
+
+    if (allResults.length === 0) {
+      return this.createOutput(null, 0, {
+        dataState: "raw",
+        timestamp: startMs,
+      });
+    }
+
+    this.log("Building search surface", {
+      query: intent.primaryIntent,
+      resultSources: allResults.map((r) => `${r.connectorId}:${r.operation}`),
+    });
+
+    // Parse MCP content and combine data
+    const parsedResults: Array<{
+      connectorId: string;
+      operation: string;
+      data: unknown;
+    }> = [];
+    for (const result of allResults) {
+      const parsed = this.parseMCPContent(result.data);
+      parsedResults.push({
+        connectorId: result.connectorId,
+        operation: result.operation,
+        data: parsed ?? result.data,
+      });
+    }
+
+    // Truncate data to keep within token limits
+    const truncatedData = this.truncateData(parsedResults);
+
+    const userQuery = this.extractUserQuery(input);
+    const userMessage = JSON.stringify({
+      searchQuery: userQuery,
+      intent: intent.primaryIntent,
+      data: truncatedData,
+    });
+
+    const analysis = await this.completeStructured<SearchAnalysis>(
+      context,
+      "summarization",
+      [{ role: "user", content: userMessage }],
+      SEARCH_ANALYSIS_SCHEMA,
+      SYSTEM_PROMPT,
+    );
+
+    const sources = [
+      ...new Set(allResults.map((r) => r.connectorId)),
+    ];
+
+    const surfaceData: SearchSurfaceData = {
+      query: analysis.query,
+      results: analysis.results,
+      totalResults: analysis.results.length,
+      sources,
+    };
+
+    const endMs = Date.now();
+
+    const provenance = {
+      sourceType: "agent" as const,
+      sourceId: this.id,
+      trustLevel: "trusted" as const,
+      timestamp: startMs,
+      freshness: "realtime" as const,
+      dataState: "transformed" as const,
+      transformations: ["search-ranking", "snippet-generation"],
+    };
+
+    const surfaceSpec = SurfaceFactory.search(surfaceData, provenance);
+
+    return {
+      ...this.createOutput(
+        { surfaceSpec, summary: `${analysis.results.length} results for "${analysis.query}"` },
+        0.9,
+        provenance,
+      ),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+
+  private isSearchIntent(intent: IntentClassification): boolean {
+    const searchKeywords = ["search", "find", "look for", "look up", "query", "where is", "locate"];
+    const intentLower = intent.primaryIntent.toLowerCase();
+    return (
+      intent.intentCategory === "search" ||
+      searchKeywords.some((kw) => intentLower.includes(kw))
+    );
+  }
+
+  private findIntentClassification(
+    input: AgentInput,
+  ): IntentClassification | undefined {
+    for (const prior of input.priorOutputs) {
+      if (prior.category === "reasoning" && prior.output) {
+        const output = prior.output as Record<string, unknown>;
+        if ("primaryIntent" in output && "intentCategory" in output) {
+          return output as unknown as IntentClassification;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private findDataRetrieval(
+    input: AgentInput,
+  ): DataRetrievalOutput | undefined {
+    for (const prior of input.priorOutputs) {
+      if (prior.category === "context" && prior.output) {
+        const output = prior.output as Record<string, unknown>;
+        if ("results" in output && "totalAttempted" in output) {
+          return output as unknown as DataRetrievalOutput;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private extractUserQuery(input: AgentInput): string {
+    const payload = input.event.payload as Record<string, unknown> | undefined;
+    if (payload && typeof payload["text"] === "string") {
+      return payload["text"];
+    }
+    for (const prior of input.priorOutputs) {
+      if (prior.category === "reasoning" && prior.output) {
+        const output = prior.output as Record<string, unknown>;
+        if ("primaryIntent" in output) {
+          return String(output.primaryIntent);
+        }
+      }
+    }
+    return "search";
+  }
+
+  /**
+   * Parse MCP tool response format: [{type: "text", text: "...json..."}]
+   */
+  private parseMCPContent(data: unknown): unknown | undefined {
+    if (!Array.isArray(data)) return undefined;
+    const textBlock = data.find(
+      (item: unknown) =>
+        typeof item === "object" &&
+        item !== null &&
+        (item as Record<string, unknown>).type === "text",
+    );
+    if (!textBlock) return undefined;
+    const text = (textBlock as Record<string, unknown>).text;
+    if (typeof text !== "string") return undefined;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  /**
+   * Truncate data to keep within LLM token limits.
+   */
+  private truncateData(data: unknown[]): unknown[] {
+    const MAX_TOTAL_LENGTH = 40_000;
+    const serialized = JSON.stringify(data);
+    if (serialized.length <= MAX_TOTAL_LENGTH) return data;
+
+    return data.map((item) => {
+      const entry = item as Record<string, unknown>;
+      const entryData = entry.data;
+      if (Array.isArray(entryData)) {
+        return { ...entry, data: entryData.slice(0, 15) };
+      }
+      return entry;
+    });
+  }
+}

--- a/packages/orchestrator/src/execution-planner.ts
+++ b/packages/orchestrator/src/execution-planner.ts
@@ -59,7 +59,7 @@ const AGENT_ORDERINGS: Record<string, AgentOrdering[]> = {
       category: "ui",
       groups: [
         // All surface agents run in parallel, then layout composer
-        ["ui.inbox-surface", "ui.calendar-surface", "ui.discovery-surface", "ui.connection-surface", "ui.generic-data-surface"],
+        ["ui.inbox-surface", "ui.calendar-surface", "ui.discovery-surface", "ui.search-surface", "ui.connection-surface", "ui.generic-data-surface"],
         ["layout-composer"],
       ],
     },

--- a/packages/surfaces/src/factories.ts
+++ b/packages/surfaces/src/factories.ts
@@ -7,6 +7,7 @@ import type {
   ApprovalSurfaceData,
   ConnectionGuideSurfaceData,
   MorningDigestSurfaceData,
+  SearchSurfaceData,
 } from "./surface-data";
 
 export class SurfaceFactory {
@@ -155,7 +156,7 @@ export class SurfaceFactory {
     return new SurfaceSpecBuilder("morning-digest")
       .setTitle(data.greeting)
       .setSummary(summary)
-      .setPriority(95) // high priority — show at top of dashboard
+      .setPriority(95)
       .setData(data)
       .setLayout({
         position: "primary",
@@ -172,6 +173,25 @@ export class SurfaceFactory {
         label: "Open Inbox",
         actionType: "navigate.inbox",
         riskClass: "A",
+      })
+      .setProvenance(provenance)
+      .build();
+  }
+
+  static search(
+    data: SearchSurfaceData,
+    provenance: ProvenanceMetadata,
+  ): SurfaceSpec {
+    return new SurfaceSpecBuilder("search")
+      .setTitle(`Search: "${data.query}"`)
+      .setSummary(
+        `${data.totalResults} result${data.totalResults !== 1 ? "s" : ""} across ${data.sources.length} service${data.sources.length !== 1 ? "s" : ""}`,
+      )
+      .setPriority(85)
+      .setData(data)
+      .setLayout({
+        position: "primary",
+        prominence: "hero",
       })
       .setProvenance(provenance)
       .build();

--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -8,4 +8,5 @@ export type {
   ApprovalSurfaceData,
   ConnectionGuideSurfaceData,
   MorningDigestSurfaceData,
+  SearchSurfaceData,
 } from "./surface-data";

--- a/packages/surfaces/src/surface-data.ts
+++ b/packages/surfaces/src/surface-data.ts
@@ -119,3 +119,20 @@ export interface ConnectionGuideSurfaceData {
   discoveredTools?: Array<{ name: string; description?: string }>;
   errorDetail?: string;
 }
+
+export interface SearchSurfaceData {
+  query: string;
+  results: Array<{
+    id: string;
+    title: string;
+    snippet: string;
+    source: string;
+    sourceType: string;
+    date?: string;
+    url?: string;
+    relevanceScore: number;
+    metadata?: Record<string, string>;
+  }>;
+  totalResults: number;
+  sources: string[];
+}


### PR DESCRIPTION
## Summary
- Adds unified search across all connected services (Gmail, Calendar, MCP connectors) via a new **SearchSurfaceAgent** and `/api/search` REST endpoint
- Enhances the **ChatInput** with a Cmd+K search mode toggle that prefixes queries with search intent
- Updates the **IntentAgent** to classify "search" as a distinct category, routing queries through the existing pipeline to produce ranked, unified results in a dedicated search surface

## Changes
- **`packages/agents/src/ui/search-surface.ts`** — New SearchSurfaceAgent that uses LLM to rank and unify results from multiple connectors
- **`packages/surfaces/src/surface-data.ts`** — New `SearchSurfaceData` interface
- **`packages/surfaces/src/factories.ts`** — New `SurfaceFactory.search()` builder
- **`apps/frontend/src/blocks/transformers/search.ts`** — Block transformer for rendering search results
- **`apps/backend/src/server.ts`** — `GET /api/search?q=` endpoint for direct REST-based search
- **`apps/frontend/src/components/ChatInput.tsx`** — Cmd+K search mode toggle, placeholder swap, search prefix
- **`apps/frontend/src/styles/global.css`** — BEM-styled CSS for search surface + search mode UI
- **`packages/agents/src/reasoning/intent-agent.ts`** — Added "search" intent category
- **`packages/orchestrator/src/execution-planner.ts`** — Registered `ui.search-surface` in UI phase

## Test plan
- [ ] Type "search for meeting notes" in chat input — should produce a search surface with results from connected services
- [ ] Press Cmd+K to toggle search mode — input should show search icon and accent border
- [ ] Press Escape in search mode to exit back to chat mode
- [ ] Test `/api/search?q=test` REST endpoint returns unified results
- [ ] Verify search surface renders with source badges, relevance scores, and metadata tags
- [ ] Verify that non-search queries (e.g., "show my inbox") do NOT activate the search surface

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)