### PR TITLE
feat: progressive reveal animations for new surfaces

### DIFF
--- a/apps/frontend/src/components/BlockSurfaceRenderer.tsx
+++ b/apps/frontend/src/components/BlockSurfaceRenderer.tsx
@@ -122,22 +122,40 @@ export function BlockSurfaceRenderer({
   // Staleness indicator: warn if layout data is old
   const isStale = layout ? isLayoutStale(layout) : false;
 
-  // Progressive reveal animation
+  // Progressive reveal animation — only animate surfaces that appear *after*
+  // the initial page load.  On the first render we mark all existing surfaces
+  // as already-revealed so they don't animate in.  Subsequent surfaces get a
+  // CSS-driven staggered fade-in + slide-up.
   const [revealedIds, setRevealedIds] = useState<Set<string>>(new Set());
   const prevSurfaceIdsRef = useRef<string[]>([]);
+  const isInitialLoadRef = useRef(true);
 
   useEffect(() => {
     if (!layout) return;
     const currentIds = layout.surfaces.map((s) => s.surfaceId);
     const prevIds = prevSurfaceIdsRef.current;
-    const newIds = currentIds.filter((id) => !prevIds.includes(id));
-    if (newIds.length > 0) {
-      newIds.forEach((id, i) => {
+
+    if (isInitialLoadRef.current) {
+      // First render — mark everything as revealed immediately (no animation)
+      setRevealedIds(new Set(currentIds));
+      isInitialLoadRef.current = false;
+    } else {
+      const newIds = currentIds.filter((id) => !prevIds.includes(id));
+      if (newIds.length > 0) {
+        // New surfaces enter with stagger; delay is set via CSS custom property.
+        // We still need to flip them to "revealed" after the animation ends so
+        // the class can settle.  One timeout covers the whole batch.
+        const batchDuration = newIds.length * 120 + 400; // stagger + animation
         setTimeout(() => {
-          setRevealedIds((prev) => new Set([...prev, id]));
-        }, i * 150);
-      });
+          setRevealedIds((prev) => {
+            const next = new Set(prev);
+            newIds.forEach((id) => next.add(id));
+            return next;
+          });
+        }, batchDuration);
+      }
     }
+
     prevSurfaceIdsRef.current = currentIds;
   }, [layout]);
 
@@ -283,11 +301,17 @@ export function BlockSurfaceRenderer({
       )}
       {surfaceBlocks.map((surface) => {
         const isRevealed = revealedIds.has(surface.surfaceId);
+        // Compute stagger index among currently-entering surfaces
+        const enteringSiblings = surfaceBlocks.filter((s) => !revealedIds.has(s.surfaceId));
+        const staggerIndex = enteringSiblings.indexOf(surface);
         return (
           <div
             key={surface.surfaceId}
             className={`surface-cell ${surface.width} ${surface.prominence} ${isRevealed ? "surface-revealed" : "surface-entering"}`}
-            style={{ order: surface.position }}
+            style={{
+              order: surface.position,
+              ...(!isRevealed ? { "--surface-stagger": staggerIndex } as React.CSSProperties : {}),
+            }}
           >
             <div className="surface-wrapper">
               <div className="surface">

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -2109,10 +2109,23 @@ body {
 /* ===================== */
 /* Surface Transitions    */
 /* ===================== */
+
+/*
+ * Progressive reveal for new surfaces.
+ *
+ * --surface-stagger is set per-element from React (0, 1, 2, …).
+ * Each surface fades in + slides up with a staggered delay so
+ * multiple surfaces arriving together cascade visually.
+ *
+ * Initial-load surfaces are marked .surface-revealed immediately
+ * (no animation).  Only surfaces added *after* the first render
+ * play the entrance animation.
+ */
+
 @keyframes surface-fade-in {
   from {
     opacity: 0;
-    transform: translateY(12px);
+    transform: translateY(16px);
   }
   to {
     opacity: 1;
@@ -2121,14 +2134,41 @@ body {
 }
 
 .surface-entering {
+  --surface-stagger: 0;
   opacity: 0;
-  transform: translateY(12px);
-  animation: surface-fade-in 0.4s ease-out 0.05s both;
+  transform: translateY(16px);
+  animation: surface-fade-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: calc(var(--surface-stagger) * 120ms);
 }
 
 .surface-revealed {
   opacity: 1;
   transform: translateY(0);
+}
+
+/* ===================== */
+/* Reduced Motion        */
+/* ===================== */
+@media (prefers-reduced-motion: reduce) {
+  .surface-entering {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .surface-entering [data-block-id] {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .surface-revealed [data-block-id] {
+    animation: none;
+  }
+
+  [data-block-id] {
+    animation: none;
+  }
 }
 
 /* ===================== */
@@ -3366,12 +3406,12 @@ body {
 /* Surface entering/revealed work on block wrappers too */
 .surface-entering [data-block-id] {
   opacity: 0;
-  transform: translateY(12px);
+  transform: translateY(16px);
   animation: none;
 }
 
 .surface-revealed [data-block-id] {
-  animation: block-fade-in-stagger 0.35s ease-out both;
+  animation: block-fade-in-stagger 0.3s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 /* ----------------------------- */


### PR DESCRIPTION
## Summary
- New surfaces entering after initial page load animate with fade-in + slide-up, staggered via CSS custom property (`--surface-stagger`) — no JS animation libraries
- Initial page load surfaces render instantly without animation
- Respects `prefers-reduced-motion`: disables all surface and block entrance animations

Closes #230

## Test plan
- [ ] Load the app — surfaces should appear instantly (no entrance animation)
- [ ] Trigger a new surface to appear (e.g. send a query) — new surfaces should fade-in + slide-up with staggered timing
- [ ] When multiple surfaces arrive together, they should cascade (120ms stagger between each)
- [ ] Enable `prefers-reduced-motion` in OS/browser settings — all animations should be disabled
- [ ] Verify no layout shift or flicker during the transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)