### PR TITLE
feat: implement agent performance benchmarking

### DIFF
--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -104,6 +104,19 @@ export function startServer(deps: ServerDeps) {
         }
       }
 
+      // ---------- Agent benchmark endpoints ----------
+
+      // GET /api/benchmarks — agent performance metrics summary
+      if (url.pathname === "/api/benchmarks" && req.method === "GET") {
+        return jsonResponse(deps.orchestrator.benchmarks.getSummary());
+      }
+
+      // POST /api/benchmarks/reset — clear collected benchmark data
+      if (url.pathname === "/api/benchmarks/reset" && req.method === "POST") {
+        deps.orchestrator.benchmarks.reset();
+        return jsonResponse({ ok: true });
+      }
+
       // Task management endpoints
       if (url.pathname === "/api/tasks" && req.method === "GET") {
         if (!deps.scheduler) {

--- a/packages/orchestrator/src/__tests__/benchmark.test.ts
+++ b/packages/orchestrator/src/__tests__/benchmark.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { BenchmarkCollector } from "../benchmark";
+import type { PipelineTrace } from "../trace";
+
+function makeTrace(overrides?: Partial<PipelineTrace>): PipelineTrace {
+  return {
+    traceId: "test-trace",
+    eventType: "user.query",
+    startMs: 1000,
+    endMs: 1500,
+    phases: [
+      {
+        category: "perception",
+        startMs: 1000,
+        endMs: 1100,
+        durationMs: 100,
+        agents: [
+          {
+            agentId: "input-normalizer",
+            agentType: "perception",
+            durationMs: 50,
+            status: "success",
+            confidence: 0.9,
+          },
+          {
+            agentId: "url-parser",
+            agentType: "perception",
+            durationMs: 80,
+            status: "success",
+            confidence: 0.95,
+          },
+        ],
+      },
+      {
+        category: "reasoning",
+        startMs: 1100,
+        endMs: 1500,
+        durationMs: 400,
+        agents: [
+          {
+            agentId: "intent-agent",
+            agentType: "reasoning",
+            durationMs: 350,
+            status: "success",
+            confidence: 0.85,
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("BenchmarkCollector", () => {
+  let collector: BenchmarkCollector;
+
+  beforeEach(() => {
+    collector = new BenchmarkCollector();
+  });
+
+  it("returns empty summary when no data recorded", () => {
+    const summary = collector.getSummary();
+    expect(summary.agents).toHaveLength(0);
+    expect(summary.pipelineStats.totalTraces).toBe(0);
+    expect(summary.pipelineStats.avg).toBe(0);
+  });
+
+  it("records a single trace and computes stats", () => {
+    collector.record(makeTrace());
+    const summary = collector.getSummary();
+
+    expect(summary.pipelineStats.totalTraces).toBe(1);
+    expect(summary.pipelineStats.avg).toBe(500); // endMs - startMs = 500
+    expect(summary.agents).toHaveLength(3);
+
+    const intent = summary.agents.find((a) => a.agentId === "intent-agent");
+    expect(intent).toBeDefined();
+    expect(intent!.avg).toBe(350);
+    expect(intent!.count).toBe(1);
+    expect(intent!.errorRate).toBe(0);
+  });
+
+  it("aggregates multiple traces correctly", () => {
+    // Record 3 traces with varying durations
+    collector.record(makeTrace({ startMs: 0, endMs: 100 }));
+    collector.record(makeTrace({ startMs: 0, endMs: 200 }));
+    collector.record(makeTrace({ startMs: 0, endMs: 300 }));
+
+    const summary = collector.getSummary();
+    expect(summary.pipelineStats.totalTraces).toBe(3);
+    expect(summary.pipelineStats.avg).toBe(200);
+    expect(summary.pipelineStats.min).toBe(100);
+    expect(summary.pipelineStats.max).toBe(300);
+  });
+
+  it("tracks error rate per agent", () => {
+    const errorTrace = makeTrace();
+    errorTrace.phases[0].agents[0].status = "error";
+    collector.record(errorTrace);
+    collector.record(makeTrace()); // success
+
+    const summary = collector.getSummary();
+    const normalizer = summary.agents.find(
+      (a) => a.agentId === "input-normalizer",
+    );
+    expect(normalizer).toBeDefined();
+    expect(normalizer!.count).toBe(2);
+    expect(normalizer!.errorRate).toBe(0.5);
+  });
+
+  it("sorts agents by avg descending (slowest first)", () => {
+    collector.record(makeTrace());
+    const summary = collector.getSummary();
+    const avgs = summary.agents.map((a) => a.avg);
+    for (let i = 1; i < avgs.length; i++) {
+      expect(avgs[i]).toBeLessThanOrEqual(avgs[i - 1]);
+    }
+  });
+
+  it("respects maxSamples limit", () => {
+    const small = new BenchmarkCollector({ maxSamples: 5 });
+    for (let i = 0; i < 10; i++) {
+      small.record(makeTrace({ startMs: 0, endMs: (i + 1) * 100 }));
+    }
+    const summary = small.getSummary();
+    // Pipeline should only keep last 5 samples
+    expect(summary.pipelineStats.count).toBe(5);
+  });
+
+  it("reset clears all data", () => {
+    collector.record(makeTrace());
+    expect(collector.getSummary().pipelineStats.totalTraces).toBe(1);
+
+    collector.reset();
+    const summary = collector.getSummary();
+    expect(summary.pipelineStats.totalTraces).toBe(0);
+    expect(summary.agents).toHaveLength(0);
+  });
+
+  it("computes p50/p95/p99 correctly with many samples", () => {
+    // Record 100 traces with pipeline durations 1..100
+    for (let i = 1; i <= 100; i++) {
+      collector.record(makeTrace({ startMs: 0, endMs: i }));
+    }
+    const summary = collector.getSummary();
+    expect(summary.pipelineStats.p50).toBe(50);
+    expect(summary.pipelineStats.p95).toBe(95);
+    expect(summary.pipelineStats.p99).toBe(99);
+  });
+});

--- a/packages/orchestrator/src/benchmark.ts
+++ b/packages/orchestrator/src/benchmark.ts
@@ -1,0 +1,184 @@
+import { createLogger } from "@waibspace/logger";
+import type { PipelineTrace } from "./trace";
+
+const log = createLogger("agent-benchmark");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PercentileStats {
+  count: number;
+  avg: number;
+  p50: number;
+  p95: number;
+  p99: number;
+  min: number;
+  max: number;
+}
+
+export interface AgentBenchmark extends PercentileStats {
+  agentId: string;
+  errorRate: number;
+  lastRecordedAt: number;
+}
+
+export interface BenchmarkSummary {
+  agents: AgentBenchmark[];
+  pipelineStats: PercentileStats & { totalTraces: number };
+  collectedSince: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal storage
+// ---------------------------------------------------------------------------
+
+interface AgentSamples {
+  durations: number[];
+  errors: number;
+  lastRecordedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Percentile helpers
+// ---------------------------------------------------------------------------
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+function computeStats(values: number[]): PercentileStats {
+  if (values.length === 0) {
+    return { count: 0, avg: 0, p50: 0, p95: 0, p99: 0, min: 0, max: 0 };
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const sum = sorted.reduce((s, v) => s + v, 0);
+  return {
+    count: sorted.length,
+    avg: Math.round(sum / sorted.length),
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    p99: percentile(sorted, 99),
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// BenchmarkCollector — singleton that accumulates trace data
+// ---------------------------------------------------------------------------
+
+export class BenchmarkCollector {
+  private agents = new Map<string, AgentSamples>();
+  private pipelineDurations: number[] = [];
+  private collectedSince = Date.now();
+
+  /** Maximum number of duration samples to retain per agent. */
+  private readonly maxSamples: number;
+
+  constructor(opts?: { maxSamples?: number }) {
+    this.maxSamples = opts?.maxSamples ?? 1000;
+  }
+
+  /**
+   * Record metrics from a completed pipeline trace.
+   * Call this from the orchestrator after `logTrace()`.
+   */
+  record(trace: PipelineTrace): void {
+    const pipelineDuration = trace.endMs - trace.startMs;
+    this.pushSample(this.pipelineDurations, pipelineDuration);
+
+    for (const phase of trace.phases) {
+      for (const agent of phase.agents) {
+        let samples = this.agents.get(agent.agentId);
+        if (!samples) {
+          samples = { durations: [], errors: 0, lastRecordedAt: 0 };
+          this.agents.set(agent.agentId, samples);
+        }
+        this.pushSample(samples.durations, agent.durationMs);
+        if (agent.status !== "success") {
+          samples.errors++;
+        }
+        samples.lastRecordedAt = Date.now();
+      }
+    }
+  }
+
+  /**
+   * Return aggregate benchmark stats for all agents and the pipeline overall.
+   */
+  getSummary(): BenchmarkSummary {
+    const agents: AgentBenchmark[] = [];
+
+    for (const [agentId, samples] of this.agents) {
+      const stats = computeStats(samples.durations);
+      agents.push({
+        agentId,
+        ...stats,
+        errorRate:
+          samples.durations.length > 0
+            ? Math.round((samples.errors / samples.durations.length) * 10000) / 10000
+            : 0,
+        lastRecordedAt: samples.lastRecordedAt,
+      });
+    }
+
+    // Sort by avg descending so slowest agents appear first
+    agents.sort((a, b) => b.avg - a.avg);
+
+    const pipelineStats = computeStats(this.pipelineDurations);
+
+    return {
+      agents,
+      pipelineStats: { ...pipelineStats, totalTraces: this.pipelineDurations.length },
+      collectedSince: this.collectedSince,
+    };
+  }
+
+  /**
+   * Log a human-readable benchmark summary.
+   */
+  logSummary(): void {
+    const summary = this.getSummary();
+    if (summary.pipelineStats.totalTraces === 0) {
+      log.info("No benchmark data collected yet");
+      return;
+    }
+
+    log.info("Agent benchmark summary", {
+      totalTraces: summary.pipelineStats.totalTraces,
+      pipeline: {
+        avg: `${summary.pipelineStats.avg}ms`,
+        p50: `${summary.pipelineStats.p50}ms`,
+        p95: `${summary.pipelineStats.p95}ms`,
+        p99: `${summary.pipelineStats.p99}ms`,
+      },
+      agents: summary.agents.map((a) => ({
+        id: a.agentId,
+        avg: `${a.avg}ms`,
+        p95: `${a.p95}ms`,
+        errorRate: `${(a.errorRate * 100).toFixed(1)}%`,
+        count: a.count,
+      })),
+    });
+  }
+
+  /**
+   * Reset all collected data.
+   */
+  reset(): void {
+    this.agents.clear();
+    this.pipelineDurations = [];
+    this.collectedSince = Date.now();
+  }
+
+  // Keep arrays bounded
+  private pushSample(arr: number[], value: number): void {
+    arr.push(value);
+    if (arr.length > this.maxSamples) {
+      arr.shift();
+    }
+  }
+}

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -7,3 +7,9 @@ export {
 } from "./execution-planner";
 export { type PipelineTrace, type PhaseTrace } from "./trace";
 export { InMemoryPendingActionStore } from "./pending-action-store";
+export {
+  BenchmarkCollector,
+  type AgentBenchmark,
+  type BenchmarkSummary,
+  type PercentileStats,
+} from "./benchmark";

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -10,6 +10,7 @@ import { createLogger, type Logger } from "@waibspace/logger";
 import { AgentRegistry } from "./agent-registry";
 import { buildExecutionPlan } from "./execution-planner";
 import { createPipelineTrace, logTrace } from "./trace";
+import { BenchmarkCollector } from "./benchmark";
 
 export interface OrchestratorOptions {
   timeoutMs?: number;
@@ -26,6 +27,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 
 export class Orchestrator {
   private readonly log: Logger;
+  readonly benchmarks: BenchmarkCollector;
 
   constructor(
     private eventBus: EventBus,
@@ -33,6 +35,7 @@ export class Orchestrator {
     private options?: OrchestratorOptions,
   ) {
     this.log = createLogger("orchestrator");
+    this.benchmarks = new BenchmarkCollector();
   }
 
   private logToDb(
@@ -298,6 +301,7 @@ export class Orchestrator {
       phaseResults,
     );
     logTrace(trace);
+    this.benchmarks.record(trace);
 
     this.logToDb("pipeline.complete", "orchestrator", traceId, {
       eventType: event.type,


### PR DESCRIPTION
## Summary
- Add `BenchmarkCollector` class in `packages/orchestrator/src/benchmark.ts` that hooks into the existing `PipelineTrace` system to accumulate per-agent execution timing samples
- Compute aggregate stats: avg, p50, p95, p99, min, max, error rate per agent, sorted slowest-first
- Wire into orchestrator — `benchmarks.record(trace)` called after every `logTrace()`, zero overhead when not queried
- Add `GET /api/benchmarks` endpoint returning full summary and `POST /api/benchmarks/reset` to clear data
- Export `BenchmarkCollector`, `AgentBenchmark`, `BenchmarkSummary`, `PercentileStats` from `@waibspace/orchestrator`
- Add 8 unit tests covering empty state, single/multi trace aggregation, error rates, percentile accuracy, maxSamples bounding, and reset

Closes #234

## Test plan
- [x] `bun test packages/orchestrator/src/__tests__/benchmark.test.ts` — 8/8 pass
- [ ] Manual: start backend, send queries, hit `GET /api/benchmarks` to verify live stats
- [ ] Manual: hit `POST /api/benchmarks/reset` and confirm data clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)