### PR TITLE
feat: add drag-and-drop reordering for email priority

### DIFF
--- a/apps/frontend/src/blocks/components/domain/gmail/GmailInboxList.tsx
+++ b/apps/frontend/src/blocks/components/domain/gmail/GmailInboxList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback, useRef, Children, type DragEvent } from "react";
 import type { BlockProps } from "../../../registry";
 
 interface GmailInboxListProps {
@@ -10,14 +10,209 @@ interface GmailInboxListProps {
   fullCount?: number;
 }
 
+// ---------------------------------------------------------------------------
+// Drag-and-drop reorder wrapper for individual email cards
+// ---------------------------------------------------------------------------
+
+interface DragItemProps {
+  index: number;
+  totalCount: number;
+  dragSourceIndex: number | null;
+  dropTargetIndex: number | null;
+  onDragStart: (index: number) => void;
+  onDragOver: (e: DragEvent<HTMLDivElement>, index: number) => void;
+  onDragEnd: () => void;
+  onDrop: (e: DragEvent<HTMLDivElement>) => void;
+  onMoveByKeyboard: (fromIndex: number, direction: "up" | "down") => void;
+  children: React.ReactNode;
+}
+
+function DragItem({
+  index,
+  totalCount,
+  dragSourceIndex,
+  dropTargetIndex,
+  onDragStart,
+  onDragOver,
+  onDragEnd,
+  onDrop,
+  onMoveByKeyboard,
+  children,
+}: DragItemProps) {
+  const isDragSource = dragSourceIndex === index;
+  const isDropTarget = dropTargetIndex === index;
+  const isDragging = dragSourceIndex !== null;
+
+  const wrapperClass = [
+    "gmail-inbox-list__drag-item",
+    isDragSource ? "gmail-inbox-list__drag-item--dragging" : "",
+    isDropTarget ? "gmail-inbox-list__drag-item--drop-target" : "",
+    isDragging && !isDragSource ? "gmail-inbox-list__drag-item--drag-active" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const handleDragStart = useCallback(
+    (e: DragEvent<HTMLDivElement>) => {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", String(index));
+      onDragStart(index);
+    },
+    [index, onDragStart],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === "ArrowUp" && index > 0) {
+        e.preventDefault();
+        onMoveByKeyboard(index, "up");
+      } else if (e.key === "ArrowDown" && index < totalCount - 1) {
+        e.preventDefault();
+        onMoveByKeyboard(index, "down");
+      }
+    },
+    [index, totalCount, onMoveByKeyboard],
+  );
+
+  return (
+    <div
+      className={wrapperClass}
+      draggable
+      onDragStart={handleDragStart}
+      onDragOver={(e) => onDragOver(e, index)}
+      onDragEnd={onDragEnd}
+      onDrop={onDrop}
+    >
+      <div className="gmail-inbox-list__drag-handle" aria-hidden="true">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+          <circle cx="4" cy="2.5" r="1" fill="currentColor" />
+          <circle cx="8" cy="2.5" r="1" fill="currentColor" />
+          <circle cx="4" cy="6" r="1" fill="currentColor" />
+          <circle cx="8" cy="6" r="1" fill="currentColor" />
+          <circle cx="4" cy="9.5" r="1" fill="currentColor" />
+          <circle cx="8" cy="9.5" r="1" fill="currentColor" />
+        </svg>
+      </div>
+      <div className="gmail-inbox-list__drag-content">{children}</div>
+      <div className="gmail-inbox-list__reorder-btns" role="group" aria-label="Reorder email">
+        <button
+          type="button"
+          className="gmail-inbox-list__reorder-btn"
+          aria-label="Move up"
+          disabled={index === 0}
+          onClick={(e) => { e.stopPropagation(); onMoveByKeyboard(index, "up"); }}
+          onKeyDown={handleKeyDown}
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <path d="M2 8l4-4 4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          className="gmail-inbox-list__reorder-btn"
+          aria-label="Move down"
+          disabled={index === totalCount - 1}
+          onClick={(e) => { e.stopPropagation(); onMoveByKeyboard(index, "down"); }}
+          onKeyDown={handleKeyDown}
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GmailInboxList
+// ---------------------------------------------------------------------------
+
 export function GmailInboxList({ block, children, onEvent }: BlockProps) {
   const { unreadCount, totalCount, isScanned, error, isTruncated, fullCount } = block.props as GmailInboxListProps;
   const [isScanning, setIsScanning] = useState(false);
+
+  // Drag-and-drop state
+  const [dragSourceIndex, setDragSourceIndex] = useState<number | null>(null);
+  const [dropTargetIndex, setDropTargetIndex] = useState<number | null>(null);
+  const [orderedIndices, setOrderedIndices] = useState<number[] | null>(null);
+
+  const childArray = Children.toArray(children);
+  const childCount = childArray.length;
+
+  // Build the display order: if user has reordered, use that; otherwise natural order
+  const displayOrder = orderedIndices && orderedIndices.length === childCount
+    ? orderedIndices
+    : childArray.map((_, i) => i);
+
+  // Reset ordered indices when child count changes (new data arrived)
+  const prevCountRef = useRef(childCount);
+  if (prevCountRef.current !== childCount) {
+    prevCountRef.current = childCount;
+    if (orderedIndices !== null) {
+      setOrderedIndices(null);
+    }
+  }
 
   const handleScan = () => {
     setIsScanning(true);
     onEvent?.("waib-scan", { scope: "all" });
   };
+
+  const handleDragStart = useCallback((index: number) => {
+    setDragSourceIndex(index);
+  }, []);
+
+  const handleDragOver = useCallback((e: DragEvent<HTMLDivElement>, index: number) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setDropTargetIndex(index);
+  }, []);
+
+  const handleDragEnd = useCallback(() => {
+    setDragSourceIndex(null);
+    setDropTargetIndex(null);
+  }, []);
+
+  const reorder = useCallback(
+    (fromDisplayIdx: number, toDisplayIdx: number) => {
+      if (fromDisplayIdx === toDisplayIdx) return;
+
+      const current = [...displayOrder];
+      const [moved] = current.splice(fromDisplayIdx, 1);
+      current.splice(toDisplayIdx, 0, moved);
+      setOrderedIndices(current);
+
+      // Emit reorder event so orchestration layer can persist ordering
+      onEvent?.("reorder-emails", {
+        fromIndex: fromDisplayIdx,
+        toIndex: toDisplayIdx,
+        order: current,
+      });
+    },
+    [displayOrder, onEvent],
+  );
+
+  const handleDrop = useCallback(
+    (e: DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      if (dragSourceIndex !== null && dropTargetIndex !== null) {
+        reorder(dragSourceIndex, dropTargetIndex);
+      }
+      setDragSourceIndex(null);
+      setDropTargetIndex(null);
+    },
+    [dragSourceIndex, dropTargetIndex, reorder],
+  );
+
+  const handleMoveByKeyboard = useCallback(
+    (fromDisplayIdx: number, direction: "up" | "down") => {
+      const toDisplayIdx = direction === "up" ? fromDisplayIdx - 1 : fromDisplayIdx + 1;
+      if (toDisplayIdx < 0 || toDisplayIdx >= childCount) return;
+      reorder(fromDisplayIdx, toDisplayIdx);
+    },
+    [childCount, reorder],
+  );
 
   return (
     <div className="gmail-inbox-list" role="region" aria-label="Gmail Inbox">
@@ -50,7 +245,28 @@ export function GmailInboxList({ block, children, onEvent }: BlockProps) {
           <p className="gmail-inbox-list__error-text">{error}</p>
         </div>
       ) : (
-        <div className="gmail-inbox-list__cards" role="list" aria-label="Email messages">{children}</div>
+        <div
+          className="gmail-inbox-list__cards"
+          role="list"
+          aria-label="Email messages — drag to reorder priority"
+        >
+          {displayOrder.map((childIdx, displayIdx) => (
+            <DragItem
+              key={childIdx}
+              index={displayIdx}
+              totalCount={childCount}
+              dragSourceIndex={dragSourceIndex}
+              dropTargetIndex={dropTargetIndex}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDragEnd={handleDragEnd}
+              onDrop={handleDrop}
+              onMoveByKeyboard={handleMoveByKeyboard}
+            >
+              {childArray[childIdx]}
+            </DragItem>
+          ))}
+        </div>
       )}
       {isTruncated && fullCount && (
         <p className="gmail-inbox-list__truncated">

--- a/apps/frontend/src/styles/gmail-components.css
+++ b/apps/frontend/src/styles/gmail-components.css
@@ -284,6 +284,122 @@
   gap: 8px;
 }
 
+/* ---- Drag-and-Drop Reorder ---- */
+
+.gmail-inbox-list__drag-item {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  border-radius: var(--block-card-radius);
+  transition:
+    opacity var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+  cursor: grab;
+  position: relative;
+}
+
+.gmail-inbox-list__drag-item:active {
+  cursor: grabbing;
+}
+
+.gmail-inbox-list__drag-item--dragging {
+  opacity: 0.4;
+  transform: scale(0.98);
+}
+
+.gmail-inbox-list__drag-item--drop-target {
+  box-shadow: 0 -2px 0 0 var(--color-accent);
+}
+
+.gmail-inbox-list__drag-item--drag-active {
+  transition:
+    opacity var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform 0.15s ease;
+}
+
+.gmail-inbox-list__drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  flex-shrink: 0;
+  color: var(--color-muted);
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+  cursor: grab;
+}
+
+.gmail-inbox-list__drag-item:hover .gmail-inbox-list__drag-handle,
+.gmail-inbox-list__drag-item:focus-within .gmail-inbox-list__drag-handle {
+  opacity: 1;
+}
+
+.gmail-inbox-list__drag-handle:active {
+  cursor: grabbing;
+}
+
+.gmail-inbox-list__drag-content {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ---- Keyboard Reorder Buttons ---- */
+
+.gmail-inbox-list__reorder-btns {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  flex-shrink: 0;
+  padding: 0 var(--space-1);
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.gmail-inbox-list__drag-item:hover .gmail-inbox-list__reorder-btns,
+.gmail-inbox-list__drag-item:focus-within .gmail-inbox-list__reorder-btns {
+  opacity: 1;
+}
+
+.gmail-inbox-list__reorder-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+  font-family: var(--font-sans);
+  line-height: 1;
+}
+
+.gmail-inbox-list__reorder-btn:hover:not(:disabled) {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+  border-color: var(--color-text-secondary);
+}
+
+.gmail-inbox-list__reorder-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.gmail-inbox-list__reorder-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
 /* ---- GmailInboxList Error State ---- */
 
 .gmail-inbox-list__error {
@@ -749,5 +865,13 @@
 
   .gmail-inbox-list__title {
     font-size: var(--text-lg);
+  }
+
+  .gmail-inbox-list__drag-handle {
+    display: none;
+  }
+
+  .gmail-inbox-list__reorder-btns {
+    opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary
- Adds native HTML5 drag-and-drop reordering to `GmailInboxList` email cards for manual priority ordering
- Each card is wrapped in a `DragItem` component with a 6-dot drag handle, opacity/scale feedback on the dragged card, and an accent-colored top-border highlight on the drop target
- Keyboard-accessible move up/down buttons appear on hover/focus for users who cannot use drag gestures
- Reorder dispatches an `onEvent("reorder-emails", { fromIndex, toIndex, order })` callback for persistence and behavioral learning
- All CSS follows BEM naming under `gmail-inbox-list__drag-*` and `gmail-inbox-list__reorder-*`; mobile responsive rules hide drag handles and always show reorder buttons

Closes #227

## Test plan
- [ ] Verify drag handle appears on hover over email cards
- [ ] Drag an email card and confirm ghost opacity + drop target highlight
- [ ] Drop on a different position and confirm reorder persists in the list
- [ ] Use keyboard move up/down buttons to reorder; confirm correct aria-labels
- [ ] Check mobile viewport: drag handle hidden, reorder buttons always visible
- [ ] Confirm `reorder-emails` event fires with correct `fromIndex`, `toIndex`, and `order` payload
- [ ] Verify no regressions on existing email card click, quick actions, and WaibScan

🤖 Generated with [Claude Code](https://claude.com/claude-code)