### PR TITLE
feat: implement undo/redo for user actions

### DIFF
--- a/apps/frontend/src/components/UndoToast.tsx
+++ b/apps/frontend/src/components/UndoToast.tsx
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ReversibleAction } from "../hooks/useActionHistory";
+
+interface UndoToastProps {
+  /** The action that was just undone, or null to hide the toast. */
+  action: ReversibleAction | null;
+  /** Called when the user clicks the Redo button. */
+  onRedo: () => void;
+  /** Called when the toast is dismissed (timeout or manual). */
+  onDismiss: () => void;
+  /** Auto-dismiss timeout in ms. Defaults to 5000. */
+  timeout?: number;
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  archive: "Archive",
+  mark_read: "Mark as read",
+  snooze: "Snooze",
+};
+
+export function UndoToast({
+  action,
+  onRedo,
+  onDismiss,
+  timeout = 5000,
+}: UndoToastProps) {
+  const [exiting, setExiting] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevActionIdRef = useRef<string | null>(null);
+
+  const startDismiss = useCallback(() => {
+    setExiting(true);
+    setTimeout(onDismiss, 200);
+  }, [onDismiss]);
+
+  // Reset animation state when a new action arrives.
+  useEffect(() => {
+    if (!action) {
+      setExiting(false);
+      prevActionIdRef.current = null;
+      return;
+    }
+
+    if (action.id !== prevActionIdRef.current) {
+      setExiting(false);
+      prevActionIdRef.current = action.id;
+    }
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(startDismiss, timeout);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [action, startDismiss, timeout]);
+
+  if (!action) return null;
+
+  const typeLabel = ACTION_LABELS[action.type] || action.type;
+
+  return (
+    <div
+      className={`undo-toast${exiting ? " undo-toast--exiting" : ""}`}
+      role="alert"
+    >
+      <span className="undo-toast__icon" aria-hidden="true">
+        &#x21B6;
+      </span>
+      <div className="undo-toast__body">
+        <p className="undo-toast__title">{typeLabel} undone</p>
+        <p className="undo-toast__message">{action.label}</p>
+      </div>
+      <button className="undo-toast__redo" onClick={onRedo}>
+        Redo
+      </button>
+      <button
+        className="undo-toast__dismiss"
+        onClick={startDismiss}
+        aria-label="Dismiss"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}

--- a/apps/frontend/src/hooks/useActionHistory.ts
+++ b/apps/frontend/src/hooks/useActionHistory.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Actions that support undo/redo. */
+export type ReversibleActionType = "archive" | "mark_read" | "snooze";
+
+export interface ReversibleAction {
+  id: string;
+  type: ReversibleActionType;
+  /** Human-readable label, e.g. "Archived email from Alice" */
+  label: string;
+  /** Payload sent with the original action so it can be re-dispatched on redo. */
+  forwardPayload: unknown;
+  /** Payload to send when undoing this action. */
+  undoPayload: unknown;
+  /** Timestamp when the action was executed. */
+  timestamp: number;
+}
+
+export interface ActionHistoryState {
+  /** Whether an undo is available. */
+  canUndo: boolean;
+  /** Whether a redo is available. */
+  canRedo: boolean;
+  /** The most recent undone action (shown in the toast). */
+  lastUndone: ReversibleAction | null;
+  /** Push a new action onto the history stack. */
+  push: (action: Omit<ReversibleAction, "id" | "timestamp">) => void;
+  /** Undo the most recent action. Returns the action that was undone, or null. */
+  undo: () => ReversibleAction | null;
+  /** Redo the most recently undone action. Returns the action, or null. */
+  redo: () => ReversibleAction | null;
+  /** Dismiss the lastUndone notification. */
+  dismissUndo: () => void;
+}
+
+let nextActionId = 0;
+
+const MAX_HISTORY = 50;
+
+/**
+ * Hook that maintains an undo/redo stack for reversible user actions.
+ *
+ * Registers Ctrl+Z (undo) and Ctrl+Shift+Z / Ctrl+Y (redo) keyboard shortcuts.
+ *
+ * @param onUndo - Called when an action is undone, with the undo payload.
+ * @param onRedo - Called when an action is redone, with the forward payload.
+ */
+export function useActionHistory(
+  onUndo: (action: ReversibleAction) => void,
+  onRedo: (action: ReversibleAction) => void,
+): ActionHistoryState {
+  const [undoStack, setUndoStack] = useState<ReversibleAction[]>([]);
+  const [redoStack, setRedoStack] = useState<ReversibleAction[]>([]);
+  const [lastUndone, setLastUndone] = useState<ReversibleAction | null>(null);
+
+  // Keep stable refs so the keyboard handler doesn't re-bind on every render.
+  const undoStackRef = useRef(undoStack);
+  const redoStackRef = useRef(redoStack);
+  undoStackRef.current = undoStack;
+  redoStackRef.current = redoStack;
+
+  const onUndoRef = useRef(onUndo);
+  const onRedoRef = useRef(onRedo);
+  onUndoRef.current = onUndo;
+  onRedoRef.current = onRedo;
+
+  const push = useCallback(
+    (partial: Omit<ReversibleAction, "id" | "timestamp">) => {
+      const action: ReversibleAction = {
+        ...partial,
+        id: `action-${++nextActionId}`,
+        timestamp: Date.now(),
+      };
+      setUndoStack((prev) => [...prev.slice(-(MAX_HISTORY - 1)), action]);
+      // New action clears the redo stack.
+      setRedoStack([]);
+      setLastUndone(null);
+    },
+    [],
+  );
+
+  const undo = useCallback((): ReversibleAction | null => {
+    const stack = undoStackRef.current;
+    if (stack.length === 0) return null;
+
+    const action = stack[stack.length - 1];
+    setUndoStack((prev) => prev.slice(0, -1));
+    setRedoStack((prev) => [...prev, action]);
+    setLastUndone(action);
+    onUndoRef.current(action);
+    return action;
+  }, []);
+
+  const redo = useCallback((): ReversibleAction | null => {
+    const stack = redoStackRef.current;
+    if (stack.length === 0) return null;
+
+    const action = stack[stack.length - 1];
+    setRedoStack((prev) => prev.slice(0, -1));
+    setUndoStack((prev) => [...prev, action]);
+    setLastUndone(null);
+    onRedoRef.current(action);
+    return action;
+  }, []);
+
+  const dismissUndo = useCallback(() => {
+    setLastUndone(null);
+  }, []);
+
+  // Register keyboard shortcuts.
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName;
+      const isInput =
+        tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+      const isEditable = (e.target as HTMLElement).isContentEditable;
+
+      // Don't intercept when typing in an input.
+      if (isInput || isEditable) return;
+
+      const isMac = navigator.platform.toUpperCase().includes("MAC");
+      const modifier = isMac ? e.metaKey : e.ctrlKey;
+
+      if (!modifier || e.altKey) return;
+
+      if (e.key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        undo();
+        return;
+      }
+
+      if ((e.key === "z" && e.shiftKey) || e.key === "y") {
+        e.preventDefault();
+        redo();
+        return;
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [undo, redo]);
+
+  return {
+    canUndo: undoStack.length > 0,
+    canRedo: redoStack.length > 0,
+    lastUndone,
+    push,
+    undo,
+    redo,
+    dismissUndo,
+  };
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import App from "./App";
 import "./styles/global.css";
 import "./styles/theme.css";
 import "./styles/gmail-components.css";
+import "./styles/undo-toast.css";
 import { initTheme } from "./hooks/useTheme";
 
 // Apply saved theme before first paint to avoid flash

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -18,6 +18,9 @@ import { BlockInspector, BlockInspectorToggle } from "../blocks/BlockInspector";
 import { composedLayoutToBlocks } from "../blocks/transformers";
 import { useNotifications } from "../hooks/useNotifications";
 import { NotificationStack } from "../components/NotificationToast";
+import { useActionHistory } from "../hooks/useActionHistory";
+import type { ReversibleAction } from "../hooks/useActionHistory";
+import { UndoToast } from "../components/UndoToast";
 
 const WS_URL = `ws://${window.location.hostname}:${import.meta.env.VITE_WS_PORT || 3001}/ws`;
 const API_BASE = `http://${window.location.hostname}:${import.meta.env.VITE_WS_PORT || 3001}`;
@@ -32,6 +35,14 @@ interface FailedService {
   name: string;
   error: string;
 }
+
+const REVERSIBLE_INTERACTIONS = new Set(["archive", "mark_read", "snooze"]);
+
+const UNDO_MAP: Record<string, string> = {
+  archive: "unarchive",
+  mark_read: "mark_unread",
+  snooze: "unsnooze",
+};
 
 export default function HomePage() {
   const { send, lastMessage, status, pendingCount } = useWebSocket(WS_URL);
@@ -55,6 +66,33 @@ export default function HomePage() {
     return composedLayoutToBlocks(layout);
   }, [layout]);
 
+  // Undo/redo action history
+  const handleUndoAction = useCallback(
+    (action: ReversibleAction) => {
+      send("user.interaction", {
+        interaction: "undo",
+        target: action.id,
+        context: action.undoPayload,
+        timestamp: Date.now(),
+      });
+    },
+    [send],
+  );
+
+  const handleRedoAction = useCallback(
+    (action: ReversibleAction) => {
+      send("user.interaction", {
+        interaction: "action",
+        target: action.id,
+        context: action.forwardPayload,
+        timestamp: Date.now(),
+      });
+    },
+    [send],
+  );
+
+  const actionHistory = useActionHistory(handleUndoAction, handleRedoAction);
+
   // Keyboard navigation for email lists
   const hasSurfaces = layout && layout.surfaces.length > 0;
 
@@ -68,16 +106,23 @@ export default function HomePage() {
 
   const handleEmailArchive = useCallback(
     (_index: number, _element: HTMLElement) => {
-      send("user.interaction", {
+      const payload = {
         interaction: "archive",
         target: "keyboard-shortcut",
         surfaceId: "gmail-inbox",
         surfaceType: "gmail",
         context: { source: "keyboard" },
         timestamp: Date.now(),
+      };
+      send("user.interaction", payload);
+      actionHistory.push({
+        type: "archive",
+        label: "archive on gmail",
+        forwardPayload: payload,
+        undoPayload: { ...payload, interaction: "unarchive" },
       });
     },
-    [send],
+    [send, actionHistory],
   );
 
   const handleEmailReply = useCallback(
@@ -242,16 +287,31 @@ export default function HomePage() {
         return;
       }
 
-      send("user.interaction", {
+      const payload = {
         interaction,
         target,
         surfaceId,
         surfaceType,
         context,
         timestamp: Date.now(),
-      });
+      };
+
+      send("user.interaction", payload);
+
+      // Track reversible actions for undo/redo.
+      if (REVERSIBLE_INTERACTIONS.has(interaction)) {
+        actionHistory.push({
+          type: interaction as "archive" | "mark_read" | "snooze",
+          label: `${interaction} on ${surfaceType}`,
+          forwardPayload: payload,
+          undoPayload: {
+            ...payload,
+            interaction: UNDO_MAP[interaction] || `undo_${interaction}`,
+          },
+        });
+      }
     },
-    [send],
+    [send, actionHistory],
   );
 
   const handleSend = useCallback(
@@ -337,6 +397,12 @@ export default function HomePage() {
         observations={observations}
         isOpen={inspectorOpen}
         onToggle={() => setInspectorOpen((o) => !o)}
+      />
+
+      <UndoToast
+        action={actionHistory.lastUndone}
+        onRedo={actionHistory.redo}
+        onDismiss={actionHistory.dismissUndo}
       />
 
       <KeyboardShortcutHelp visible={helpVisible} onDismiss={dismissHelp} />

--- a/apps/frontend/src/styles/undo-toast.css
+++ b/apps/frontend/src/styles/undo-toast.css
@@ -1,0 +1,128 @@
+/* ================================ */
+/* Undo Toast                       */
+/* ================================ */
+
+.undo-toast {
+  position: fixed;
+  bottom: 5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3, 0.75rem);
+  padding: var(--space-3, 0.75rem) var(--space-4, 1rem);
+  border-radius: var(--radius-md, 0.5rem);
+  background: var(--color-bg-elevated, #1e1f2b);
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
+  border-left: 3px solid var(--color-accent, #6366f1);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  font-family: var(--font-sans, system-ui, sans-serif);
+  animation: undo-toast--slide-up 0.25s ease-out;
+  max-width: 28rem;
+}
+
+.undo-toast--exiting {
+  animation: undo-toast--slide-down 0.2s ease-in forwards;
+}
+
+/* ---- Icon ---- */
+
+.undo-toast__icon {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  line-height: 1.25rem;
+  text-align: center;
+  font-size: var(--text-md, 0.875rem);
+  color: var(--color-accent, #6366f1);
+}
+
+/* ---- Body ---- */
+
+.undo-toast__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.undo-toast__title {
+  font-size: var(--text-sm, 0.75rem);
+  font-weight: var(--weight-semibold, 600);
+  color: var(--color-text, #e5e7eb);
+  line-height: 1.4;
+  margin: 0;
+}
+
+.undo-toast__message {
+  font-size: var(--text-xs, 0.6875rem);
+  color: var(--color-muted, #8b8f9c);
+  line-height: 1.4;
+  margin: 0;
+  margin-top: 0.125rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ---- Redo button ---- */
+
+.undo-toast__redo {
+  flex-shrink: 0;
+  background: var(--color-accent, #6366f1);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm, 0.25rem);
+  padding: 0.25rem 0.625rem;
+  font-size: var(--text-xs, 0.6875rem);
+  font-weight: var(--weight-semibold, 600);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.undo-toast__redo:hover {
+  background: var(--color-accent-hover, #4f46e5);
+}
+
+/* ---- Dismiss button ---- */
+
+.undo-toast__dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--color-muted, #8b8f9c);
+  cursor: pointer;
+  padding: 0.125rem;
+  font-size: var(--text-md, 0.875rem);
+  line-height: 1;
+  border-radius: var(--radius-sm, 0.25rem);
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.undo-toast__dismiss:hover {
+  color: var(--color-text, #e5e7eb);
+  background: var(--color-surface-hover, rgba(255, 255, 255, 0.06));
+}
+
+/* ---- Animations ---- */
+
+@keyframes undo-toast--slide-up {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+@keyframes undo-toast--slide-down {
+  from {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(-50%) translateY(1rem);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `useActionHistory` hook with undo/redo stack (max 50 entries) for reversible user actions (archive, mark_read, snooze)
- Register Ctrl+Z / Ctrl+Shift+Z (Cmd on Mac) keyboard shortcuts for undo/redo, skipping when focus is in text inputs
- Add `UndoToast` component that appears on undo with action label and a Redo button, auto-dismisses after 5 seconds
- Wire into `HomePage.tsx` so both keyboard-triggered and surface-interaction-triggered actions are tracked

Closes #228

## Test plan
- [ ] Archive an email, verify undo toast appears at bottom center
- [ ] Press Ctrl+Z while not in a text field, verify the archive is undone and toast shows
- [ ] Click the Redo button on the toast, verify the action is re-applied
- [ ] Press Ctrl+Shift+Z to redo via keyboard
- [ ] Verify shortcuts are ignored when typing in the chat input
- [ ] Verify toast auto-dismisses after ~5 seconds
- [ ] Mark as read / snooze actions also appear in undo history

🤖 Generated with [Claude Code](https://claude.com/claude-code)