### PR TITLE
feat: add MCP tool marketplace discovery

### DIFF
--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -290,6 +290,23 @@ export function startServer(deps: ServerDeps) {
         );
       }
 
+      // GET /api/mcp/catalog/:id — get full template details (including credential specs)
+      const catalogDetailMatch = url.pathname.match(/^\/api\/mcp\/catalog\/([^/]+)$/);
+      if (catalogDetailMatch && req.method === "GET") {
+        const template = findTemplate(catalogDetailMatch[1]);
+        if (!template) {
+          return jsonResponse({ error: "Template not found" }, 404);
+        }
+        return jsonResponse({
+          id: template.id,
+          name: template.name,
+          description: template.description,
+          icon: template.icon,
+          categories: template.categories,
+          requiredCredentials: template.requiredCredentials,
+        });
+      }
+
       // POST /api/mcp/setup — set up an MCP server from catalog template
       if (url.pathname === "/api/mcp/setup" && req.method === "POST") {
         if (!deps.mcpRegistry) {

--- a/apps/frontend/src/components/MCPMarketplace.tsx
+++ b/apps/frontend/src/components/MCPMarketplace.tsx
@@ -1,0 +1,399 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface CatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  categories: string[];
+  credentialCount: number;
+}
+
+interface CredentialSpec {
+  key: string;
+  label: string;
+  helpText: string;
+  helpUrl?: string;
+  sensitive: boolean;
+}
+
+interface CatalogDetail {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  categories: string[];
+  requiredCredentials: CredentialSpec[];
+}
+
+const ALL_CATEGORIES = [
+  "all",
+  "communication",
+  "development",
+  "productivity",
+  "search",
+  "system",
+];
+
+export function MCPMarketplace() {
+  const [catalog, setCatalog] = useState<CatalogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState("all");
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Setup flow state
+  const [setupTarget, setSetupTarget] = useState<CatalogDetail | null>(null);
+  const [credentials, setCredentials] = useState<Record<string, string>>({});
+  const [setupLoading, setSetupLoading] = useState(false);
+  const [setupError, setSetupError] = useState<string | null>(null);
+  const [setupSuccess, setSetupSuccess] = useState<{
+    name: string;
+    toolCount: number;
+  } | null>(null);
+
+  // Track which servers are already installed
+  const [installedIds, setInstalledIds] = useState<Set<string>>(new Set());
+
+  const fetchCatalog = useCallback(async () => {
+    try {
+      const res = await fetch("/api/mcp/catalog");
+      if (res.ok) {
+        const data: CatalogEntry[] = await res.json();
+        setCatalog(data);
+      } else {
+        setError("Failed to load marketplace catalog");
+      }
+    } catch {
+      setError("Could not connect to backend");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchInstalled = useCallback(async () => {
+    try {
+      const res = await fetch("/api/mcp/servers");
+      if (res.ok) {
+        const servers: Array<{ config: { id: string } }> = await res.json();
+        setInstalledIds(
+          new Set(
+            servers
+              .map((s) => s.config.id)
+              .filter((id) => id.startsWith("catalog-"))
+              .map((id) => id.replace("catalog-", "")),
+          ),
+        );
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCatalog();
+    fetchInstalled();
+  }, [fetchCatalog, fetchInstalled]);
+
+  const openSetup = async (entry: CatalogEntry) => {
+    // If no credentials needed, install directly
+    if (entry.credentialCount === 0) {
+      await installServer(entry.id, {});
+      return;
+    }
+
+    // Fetch full template details for credential specs
+    // We use the catalog endpoint — the full detail comes from /api/mcp/catalog/:id
+    // But since that endpoint doesn't exist, we fetch the full catalog and find the template
+    // Actually, let's just show a credential form based on what we know
+    setSetupError(null);
+    setSetupSuccess(null);
+    setCredentials({});
+
+    // Fetch full template details from a detail endpoint or use a trick
+    try {
+      const res = await fetch(`/api/mcp/catalog/${entry.id}`);
+      if (res.ok) {
+        const detail: CatalogDetail = await res.json();
+        setSetupTarget(detail);
+      } else {
+        // Fallback: just set a minimal target
+        setSetupTarget({
+          id: entry.id,
+          name: entry.name,
+          description: entry.description,
+          icon: entry.icon,
+          categories: entry.categories,
+          requiredCredentials: [],
+        });
+      }
+    } catch {
+      // Fallback
+      setSetupTarget({
+        id: entry.id,
+        name: entry.name,
+        description: entry.description,
+        icon: entry.icon,
+        categories: entry.categories,
+        requiredCredentials: [],
+      });
+    }
+  };
+
+  const installServer = async (
+    templateId: string,
+    creds: Record<string, string>,
+  ) => {
+    setSetupLoading(true);
+    setSetupError(null);
+    try {
+      const res = await fetch("/api/mcp/setup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ templateId, credentials: creds }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setSetupError(data.error ?? "Setup failed");
+        return;
+      }
+      setSetupSuccess({
+        name: data.name,
+        toolCount: data.tools?.length ?? 0,
+      });
+      setInstalledIds((prev) => new Set([...prev, templateId]));
+      // Close the setup dialog after a short delay
+      setTimeout(() => {
+        setSetupTarget(null);
+        setSetupSuccess(null);
+      }, 2000);
+    } catch {
+      setSetupError("Network error — could not reach backend");
+    } finally {
+      setSetupLoading(false);
+    }
+  };
+
+  const handleSetupSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!setupTarget) return;
+    installServer(setupTarget.id, credentials);
+  };
+
+  const filteredCatalog = catalog.filter((entry) => {
+    const matchesCategory =
+      selectedCategory === "all" ||
+      entry.categories.some((c) => c === selectedCategory);
+    const matchesSearch =
+      !searchQuery ||
+      entry.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      entry.description.toLowerCase().includes(searchQuery.toLowerCase());
+    return matchesCategory && matchesSearch;
+  });
+
+  if (loading) {
+    return (
+      <div className="marketplace__loading">
+        <span className="marketplace__loading-dot" />
+        Loading marketplace...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="marketplace__error">
+        <span className="marketplace__error-icon">!</span>
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="marketplace">
+      <div className="marketplace__header">
+        <div className="marketplace__header-text">
+          <h3 className="marketplace__title">MCP Marketplace</h3>
+          <p className="marketplace__subtitle">
+            Browse and install MCP tool servers with one click
+          </p>
+        </div>
+      </div>
+
+      <div className="marketplace__controls">
+        <input
+          className="marketplace__search"
+          type="text"
+          placeholder="Search tools..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+        <div className="marketplace__categories">
+          {ALL_CATEGORIES.map((cat) => (
+            <button
+              key={cat}
+              className={`marketplace__category-btn ${selectedCategory === cat ? "marketplace__category-btn--active" : ""}`}
+              onClick={() => setSelectedCategory(cat)}
+            >
+              {cat.charAt(0).toUpperCase() + cat.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="marketplace__grid">
+        {filteredCatalog.length === 0 && (
+          <div className="marketplace__empty">
+            No tools match your search.
+          </div>
+        )}
+        {filteredCatalog.map((entry) => {
+          const isInstalled = installedIds.has(entry.id);
+          return (
+            <div key={entry.id} className="marketplace__card">
+              <div className="marketplace__card-header">
+                <span className="marketplace__card-icon">{entry.icon}</span>
+                <div className="marketplace__card-info">
+                  <span className="marketplace__card-name">{entry.name}</span>
+                  <div className="marketplace__card-tags">
+                    {entry.categories.map((cat) => (
+                      <span key={cat} className="marketplace__tag">
+                        {cat}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <p className="marketplace__card-desc">{entry.description}</p>
+              <div className="marketplace__card-footer">
+                {entry.credentialCount > 0 && (
+                  <span className="marketplace__card-cred-hint">
+                    {entry.credentialCount} credential
+                    {entry.credentialCount !== 1 ? "s" : ""} required
+                  </span>
+                )}
+                {isInstalled ? (
+                  <span className="marketplace__card-installed">
+                    Installed
+                  </span>
+                ) : (
+                  <button
+                    className="marketplace__card-add-btn"
+                    onClick={() => openSetup(entry)}
+                  >
+                    {entry.credentialCount > 0 ? "Set Up" : "Add"}
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Setup dialog (credential input) */}
+      {setupTarget && (
+        <div className="marketplace__overlay" onClick={() => !setupLoading && setSetupTarget(null)}>
+          <div
+            className="marketplace__dialog"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="marketplace__dialog-header">
+              <span className="marketplace__dialog-icon">
+                {setupTarget.icon}
+              </span>
+              <h4 className="marketplace__dialog-title">
+                Set up {setupTarget.name}
+              </h4>
+            </div>
+
+            {setupSuccess ? (
+              <div className="marketplace__dialog-success">
+                <span className="marketplace__dialog-success-icon">
+                  &#10003;
+                </span>
+                <p>
+                  {setupSuccess.name} connected with {setupSuccess.toolCount}{" "}
+                  tool{setupSuccess.toolCount !== 1 ? "s" : ""} available.
+                </p>
+              </div>
+            ) : (
+              <form
+                className="marketplace__dialog-form"
+                onSubmit={handleSetupSubmit}
+              >
+                {setupTarget.requiredCredentials.length === 0 ? (
+                  <p className="marketplace__dialog-note">
+                    No credentials required. Click Install to continue.
+                  </p>
+                ) : (
+                  setupTarget.requiredCredentials.map((cred) => (
+                    <div key={cred.key} className="marketplace__dialog-field">
+                      <label
+                        className="marketplace__dialog-label"
+                        htmlFor={`cred-${cred.key}`}
+                      >
+                        {cred.label}
+                      </label>
+                      <input
+                        id={`cred-${cred.key}`}
+                        className="marketplace__dialog-input"
+                        type={cred.sensitive ? "password" : "text"}
+                        value={credentials[cred.key] ?? ""}
+                        onChange={(e) =>
+                          setCredentials((prev) => ({
+                            ...prev,
+                            [cred.key]: e.target.value,
+                          }))
+                        }
+                        placeholder={cred.helpText.slice(0, 60) + "..."}
+                        required
+                      />
+                      <span className="marketplace__dialog-help">
+                        {cred.helpText}
+                        {cred.helpUrl && (
+                          <>
+                            {" "}
+                            <a
+                              href={cred.helpUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="marketplace__dialog-help-link"
+                            >
+                              Get one here
+                            </a>
+                          </>
+                        )}
+                      </span>
+                    </div>
+                  ))
+                )}
+
+                {setupError && (
+                  <div className="marketplace__dialog-error">{setupError}</div>
+                )}
+
+                <div className="marketplace__dialog-actions">
+                  <button
+                    type="button"
+                    className="marketplace__dialog-cancel-btn"
+                    onClick={() => setSetupTarget(null)}
+                    disabled={setupLoading}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    className="marketplace__dialog-install-btn"
+                    disabled={setupLoading}
+                  >
+                    {setupLoading ? "Installing..." : "Install"}
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/SettingsPage.tsx
+++ b/apps/frontend/src/pages/SettingsPage.tsx
@@ -1,17 +1,19 @@
 import { useState } from "react";
 import { ConnectionManager } from "../components/ConnectionManager";
 import { ConnectorHealthDashboard } from "../components/ConnectorHealthDashboard";
+import { MCPMarketplace } from "../components/MCPMarketplace";
 import { useTheme, type Theme } from "../hooks/useTheme";
 
-type SettingsSection = "connections" | "health" | "preferences" | "about";
+type SettingsSection = "marketplace" | "connections" | "health" | "preferences" | "about";
 
 export default function SettingsPage() {
-  const [activeSection, setActiveSection] = useState<SettingsSection>("connections");
+  const [activeSection, setActiveSection] = useState<SettingsSection>("marketplace");
   const { theme, setTheme } = useTheme();
   const [notifyErrors, setNotifyErrors] = useState(true);
   const [notifyTaskComplete, setNotifyTaskComplete] = useState(true);
 
   const sections: { id: SettingsSection; label: string }[] = [
+    { id: "marketplace", label: "Marketplace" },
     { id: "connections", label: "Connections" },
     { id: "health", label: "Health" },
     { id: "preferences", label: "Preferences" },
@@ -35,6 +37,12 @@ export default function SettingsPage() {
       </nav>
 
       <div className="settings-content">
+        {activeSection === "marketplace" && (
+          <section className="settings-section">
+            <MCPMarketplace />
+          </section>
+        )}
+
         {activeSection === "connections" && (
           <section className="settings-section">
             <ConnectionManager />

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -3,6 +3,7 @@
 @import "./error-surface.css";
 @import "./health-dashboard.css";
 @import "./keyboard-nav.css";
+@import "./marketplace.css";
 @import "./notifications.css";
 
 /* ================================ */

--- a/apps/frontend/src/styles/marketplace.css
+++ b/apps/frontend/src/styles/marketplace.css
@@ -1,0 +1,442 @@
+/* ================================ */
+/* MCP Marketplace                  */
+/* ================================ */
+
+.marketplace {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.marketplace__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.marketplace__title {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.marketplace__subtitle {
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+  margin: var(--space-1) 0 0;
+}
+
+/* Loading */
+.marketplace__loading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-muted);
+  font-size: var(--text-md);
+  padding: var(--space-6) 0;
+}
+
+.marketplace__loading-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  animation: conn-pulse 1s infinite alternate;
+}
+
+/* Error */
+.marketplace__error {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-danger);
+  font-size: var(--text-md);
+  padding: var(--space-4);
+  background: var(--color-danger-subtle);
+  border-radius: var(--radius-md);
+}
+
+.marketplace__error-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-danger);
+  color: white;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  flex-shrink: 0;
+}
+
+/* Controls (search + filter) */
+.marketplace__controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.marketplace__search {
+  padding: 0.625rem var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: var(--text-md);
+  font-family: inherit;
+  outline: none;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.marketplace__search::placeholder {
+  color: var(--color-muted);
+}
+
+.marketplace__search:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-subtle);
+}
+
+.marketplace__categories {
+  display: flex;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+
+.marketplace__category-btn {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.marketplace__category-btn:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.marketplace__category-btn--active {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: white;
+}
+
+.marketplace__category-btn--active:hover {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+  color: white;
+}
+
+/* Grid of cards */
+.marketplace__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-4);
+}
+
+.marketplace__empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: var(--text-md);
+  padding: var(--space-6) 0;
+}
+
+/* Card */
+.marketplace__card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.marketplace__card:hover {
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+.marketplace__card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+
+.marketplace__card-icon {
+  font-size: 1.75rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.marketplace__card-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.marketplace__card-name {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+}
+
+.marketplace__card-tags {
+  display: flex;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+
+.marketplace__tag {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  background: var(--color-surface-hover);
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-full);
+}
+
+.marketplace__card-desc {
+  font-size: var(--text-base);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  margin: 0;
+  flex: 1;
+}
+
+.marketplace__card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-top: auto;
+}
+
+.marketplace__card-cred-hint {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+}
+
+.marketplace__card-add-btn {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-md);
+  background: var(--color-accent);
+  color: white;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  margin-left: auto;
+}
+
+.marketplace__card-add-btn:hover {
+  background: var(--color-accent-hover);
+}
+
+.marketplace__card-installed {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-success);
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.marketplace__card-installed::before {
+  content: "\2713";
+}
+
+/* Overlay / Dialog */
+.marketplace__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--space-4);
+}
+
+.marketplace__dialog {
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: var(--space-6);
+  width: 100%;
+  max-width: 480px;
+  box-shadow: var(--shadow-lg);
+}
+
+.marketplace__dialog-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+}
+
+.marketplace__dialog-icon {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.marketplace__dialog-title {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.marketplace__dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.marketplace__dialog-note {
+  font-size: var(--text-md);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.marketplace__dialog-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.marketplace__dialog-label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.marketplace__dialog-input {
+  padding: 0.625rem var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: var(--text-md);
+  font-family: inherit;
+  outline: none;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.marketplace__dialog-input::placeholder {
+  color: var(--color-muted);
+  font-size: var(--text-sm);
+}
+
+.marketplace__dialog-input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-subtle);
+}
+
+.marketplace__dialog-help {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  line-height: 1.4;
+}
+
+.marketplace__dialog-help-link {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.marketplace__dialog-help-link:hover {
+  text-decoration: underline;
+}
+
+.marketplace__dialog-error {
+  font-size: var(--text-sm);
+  color: var(--color-danger);
+  background: var(--color-danger-subtle);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+}
+
+.marketplace__dialog-actions {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
+  margin-top: var(--space-2);
+}
+
+.marketplace__dialog-cancel-btn {
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text);
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.marketplace__dialog-cancel-btn:hover {
+  background: var(--color-surface-hover);
+}
+
+.marketplace__dialog-cancel-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.marketplace__dialog-install-btn {
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-md);
+  background: var(--color-accent);
+  color: white;
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.marketplace__dialog-install-btn:hover {
+  background: var(--color-accent-hover);
+}
+
+.marketplace__dialog-install-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Success state */
+.marketplace__dialog-success {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--color-success-subtle);
+  border-radius: var(--radius-md);
+}
+
+.marketplace__dialog-success-icon {
+  font-size: var(--text-2xl);
+  color: var(--color-success);
+  font-weight: var(--weight-bold);
+}
+
+.marketplace__dialog-success p {
+  font-size: var(--text-md);
+  color: var(--color-success-text, var(--color-success));
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- Adds a **Marketplace** tab to the Settings page where users can browse available MCP server templates from the curated catalog
- Cards display server name, icon, description, and categories with search and category filtering
- One-click **Add** for servers with no credentials, or a setup dialog with credential inputs for servers that need auth (e.g. GitHub token, Slack bot token)
- New backend `GET /api/mcp/catalog/:id` endpoint returns full template details including credential specs
- All CSS uses BEM naming with existing design system tokens (no Tailwind)

Closes #235

## Test plan
- [ ] Navigate to Settings > Marketplace tab and verify the catalog loads
- [ ] Filter by category (e.g. "Development") and confirm filtering works
- [ ] Use the search box to filter by name/description
- [ ] Click "Add" on a no-credential server (e.g. Filesystem) and verify it installs
- [ ] Click "Set Up" on a credential server (e.g. GitHub) and verify the dialog shows credential fields with help text
- [ ] Verify installed servers show a green "Installed" badge
- [ ] Confirm the dialog dismisses after successful install
- [ ] Check light and dark themes for visual consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)