### PR TITLE
feat: add visual regression testing for block components

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,10 @@
     "dev": "bunx --bun vite",
     "build": "bunx --bun vite build",
     "preview": "bunx --bun vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:update": "vitest run --update"
   },
   "dependencies": {
     "@waibspace/surfaces": "workspace:*",
@@ -17,9 +20,13 @@
     "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
-    "vite": "^7.3.1"
+    "happy-dom": "^20.8.3",
+    "vite": "^7.3.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/frontend/src/blocks/components/__tests__/CalendarDayTimeline.test.tsx
+++ b/apps/frontend/src/blocks/components/__tests__/CalendarDayTimeline.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { CalendarDayTimeline } from "../domain/gcal/CalendarDayTimeline";
+import { makeBlock } from "./test-utils";
+import { calendarDayTimeline as fixtures } from "./fixtures";
+
+function renderTimeline(props: Record<string, unknown>) {
+  const block = makeBlock("CalendarDayTimeline", props);
+  return render(<CalendarDayTimeline block={block} onEvent={vi.fn()} />);
+}
+
+describe("CalendarDayTimeline", () => {
+  // -----------------------------------------------------------------------
+  // Snapshot tests
+  // -----------------------------------------------------------------------
+
+  it("matches snapshot: workday with events and free slots", () => {
+    // Mock Date.now so the "now" line is deterministic
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T14:30:00"));
+    const { container } = renderTimeline(fixtures.workday);
+    expect(container.firstElementChild).toMatchSnapshot();
+    vi.useRealTimers();
+  });
+
+  it("matches snapshot: empty day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-15T10:00:00"));
+    const { container } = renderTimeline(fixtures.empty);
+    expect(container.firstElementChild).toMatchSnapshot();
+    vi.useRealTimers();
+  });
+
+  // -----------------------------------------------------------------------
+  // Structural assertions
+  // -----------------------------------------------------------------------
+
+  it("renders hour marker labels for each hour in the range", () => {
+    renderTimeline(fixtures.workday);
+    const labels = document.querySelectorAll(
+      ".gcal-day-timeline__hour-label",
+    );
+    // dayStart=08:00 dayEnd=18:00 -> hours 8..18 inclusive = 11 labels
+    expect(labels.length).toBe(11);
+    expect(labels[0].textContent).toBe("8 AM");
+    expect(labels[labels.length - 1].textContent).toBe("6 PM");
+  });
+
+  it("renders one event block per event", () => {
+    renderTimeline(fixtures.workday);
+    const events = document.querySelectorAll(".gcal-day-timeline__event");
+    expect(events.length).toBe(4);
+  });
+
+  it("renders event titles and times", () => {
+    renderTimeline(fixtures.workday);
+    const titles = document.querySelectorAll(
+      ".gcal-day-timeline__event-title",
+    );
+    expect(titles[0].textContent).toBe("Stand-up");
+    expect(titles[1].textContent).toBe("Sprint Planning");
+  });
+
+  it("renders free-slot blocks", () => {
+    renderTimeline(fixtures.workday);
+    const freeSlots = document.querySelectorAll(
+      ".gcal-day-timeline__free-slot",
+    );
+    expect(freeSlots.length).toBe(3);
+  });
+
+  it("renders no events for an empty day", () => {
+    renderTimeline(fixtures.empty);
+    const events = document.querySelectorAll(".gcal-day-timeline__event");
+    expect(events.length).toBe(0);
+  });
+
+  it("renders the now-line when current time is within range", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T14:30:00"));
+    renderTimeline(fixtures.workday);
+    const nowLine = document.querySelector(".gcal-day-timeline__now-line");
+    expect(nowLine).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it("does not render now-line when current time is outside range", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T06:00:00")); // before 8 AM
+    renderTimeline(fixtures.workday);
+    const nowLine = document.querySelector(".gcal-day-timeline__now-line");
+    expect(nowLine).not.toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it("applies custom border-left color to events", () => {
+    renderTimeline(fixtures.workday);
+    const events = document.querySelectorAll(".gcal-day-timeline__event");
+    // Third event (Lunch) has explicit color="#4caf50"
+    const lunchEvent = events[2] as HTMLElement;
+    expect(lunchEvent.style.borderLeftColor).toBe("#4caf50");
+  });
+});

--- a/apps/frontend/src/blocks/components/__tests__/CalendarEventCard.test.tsx
+++ b/apps/frontend/src/blocks/components/__tests__/CalendarEventCard.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { CalendarEventCard } from "../domain/gcal/CalendarEventCard";
+import { makeBlock } from "./test-utils";
+import { calendarEventCard as fixtures } from "./fixtures";
+
+function renderCard(props: Record<string, unknown>) {
+  const block = makeBlock("CalendarEventCard", props);
+  return render(<CalendarEventCard block={block} onEvent={vi.fn()} />);
+}
+
+describe("CalendarEventCard", () => {
+  // -----------------------------------------------------------------------
+  // Snapshot tests
+  // -----------------------------------------------------------------------
+
+  it("matches snapshot: standard meeting", () => {
+    const { container } = renderCard(fixtures.meeting);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  it("matches snapshot: all-day event", () => {
+    const { container } = renderCard(fixtures.allDay);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  it("matches snapshot: tentative event", () => {
+    const { container } = renderCard(fixtures.tentative);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  it("matches snapshot: cancelled event", () => {
+    const { container } = renderCard(fixtures.cancelled);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  it("matches snapshot: conflicting event", () => {
+    const { container } = renderCard(fixtures.conflict);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  // -----------------------------------------------------------------------
+  // Structural assertions
+  // -----------------------------------------------------------------------
+
+  it("displays event title", () => {
+    renderCard(fixtures.meeting);
+    const title = document.querySelector(".gcal-event-card__title");
+    expect(title?.textContent).toBe("Sprint Planning");
+  });
+
+  it("displays location when provided", () => {
+    renderCard(fixtures.meeting);
+    const loc = document.querySelector(".gcal-event-card__location");
+    expect(loc).toBeInTheDocument();
+    expect(loc?.textContent).toBe("Conference Room B");
+  });
+
+  it("does not render location when absent", () => {
+    renderCard(fixtures.tentative);
+    const loc = document.querySelector(".gcal-event-card__location");
+    expect(loc).not.toBeInTheDocument();
+  });
+
+  it("shows 'All Day' for all-day events", () => {
+    renderCard(fixtures.allDay);
+    const time = document.querySelector(".gcal-event-card__time");
+    expect(time?.textContent).toBe("All Day");
+  });
+
+  it("shows attendee count", () => {
+    renderCard(fixtures.meeting);
+    const attendees = document.querySelector(".gcal-event-card__attendees");
+    expect(attendees?.textContent).toMatch(/\+3 attendees/);
+  });
+
+  it("applies --cancelled modifier class", () => {
+    const { container } = renderCard(fixtures.cancelled);
+    expect(container.firstElementChild).toHaveClass(
+      "gcal-event-card--cancelled",
+    );
+  });
+
+  it("applies --tentative modifier class", () => {
+    const { container } = renderCard(fixtures.tentative);
+    expect(container.firstElementChild).toHaveClass(
+      "gcal-event-card--tentative",
+    );
+  });
+
+  it("applies --conflict modifier and shows conflict badge", () => {
+    const { container } = renderCard(fixtures.conflict);
+    expect(container.firstElementChild).toHaveClass(
+      "gcal-event-card--conflict",
+    );
+    const badge = document.querySelector(".gcal-event-card__conflict-badge");
+    expect(badge?.textContent).toBe("Conflict");
+  });
+
+  it("has a colored left border derived from title", () => {
+    const { container } = renderCard(fixtures.meeting);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.borderLeftColor).toMatch(/^hsl\(/);
+  });
+});

--- a/apps/frontend/src/blocks/components/__tests__/GmailEmailCard.test.tsx
+++ b/apps/frontend/src/blocks/components/__tests__/GmailEmailCard.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GmailEmailCard } from "../domain/gmail/GmailEmailCard";
+import { makeBlock } from "./test-utils";
+import { gmailEmailCard as fixtures } from "./fixtures";
+
+function renderCard(props: Record<string, unknown>, onEvent = vi.fn()) {
+  const block = makeBlock("GmailEmailCard", props);
+  return render(<GmailEmailCard block={block} onEvent={onEvent} />);
+}
+
+describe("GmailEmailCard", () => {
+  // -----------------------------------------------------------------------
+  // Snapshot tests — catch unintended DOM structure changes
+  // -----------------------------------------------------------------------
+
+  it("matches snapshot: unread email with urgency", () => {
+    const { container } = renderCard(fixtures.unread);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  it("matches snapshot: read email", () => {
+    const { container } = renderCard(fixtures.read);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  it("matches snapshot: starred email", () => {
+    const { container } = renderCard(fixtures.starred);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  it("matches snapshot: minimal email (no subject, no labels)", () => {
+    const { container } = renderCard(fixtures.minimal);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  // -----------------------------------------------------------------------
+  // Structural assertions — verify key DOM elements exist
+  // -----------------------------------------------------------------------
+
+  it("renders avatar with sender initials", () => {
+    renderCard(fixtures.unread);
+    const avatar = document.querySelector(".gmail-email-card__avatar");
+    expect(avatar).toBeInTheDocument();
+    expect(avatar?.textContent).toBe("AJ"); // Alice Johnson
+  });
+
+  it("applies --unread modifier class for unread emails", () => {
+    const { container } = renderCard(fixtures.unread);
+    expect(container.firstElementChild).toHaveClass("gmail-email-card--unread");
+  });
+
+  it("does not apply --unread modifier for read emails", () => {
+    const { container } = renderCard(fixtures.read);
+    expect(container.firstElementChild).not.toHaveClass(
+      "gmail-email-card--unread",
+    );
+  });
+
+  it("renders urgency badge when urgency is set", () => {
+    renderCard(fixtures.unread);
+    const badge = document.querySelector(".gmail-email-card__urgency");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass("gmail-email-card__urgency--high");
+    expect(badge?.textContent).toBe("high");
+  });
+
+  it("renders star icon for starred emails", () => {
+    renderCard(fixtures.starred);
+    const star = document.querySelector(".gmail-email-card__star");
+    expect(star).toBeInTheDocument();
+    expect(star?.textContent).toBe("\u2605"); // filled star
+  });
+
+  it("renders 'No Subject' when subject is empty", () => {
+    renderCard(fixtures.minimal);
+    const subject = document.querySelector(".gmail-email-card__subject");
+    expect(subject?.textContent).toBe("No Subject");
+  });
+
+  it("renders three quick-action buttons (archive, reply, snooze)", () => {
+    renderCard(fixtures.unread);
+    expect(screen.getByLabelText("Archive email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Reply to email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Snooze email")).toBeInTheDocument();
+  });
+
+  it("has accessible aria-label on card root", () => {
+    renderCard(fixtures.unread);
+    expect(
+      screen.getByLabelText(/Unread:.*Q3 Revenue Report.*from Alice Johnson/),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/blocks/components/__tests__/GmailInboxList.test.tsx
+++ b/apps/frontend/src/blocks/components/__tests__/GmailInboxList.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GmailInboxList } from "../domain/gmail/GmailInboxList";
+import { makeBlock } from "./test-utils";
+import { gmailInboxList as fixtures } from "./fixtures";
+
+function renderInbox(
+  props: Record<string, unknown>,
+  children?: React.ReactNode,
+) {
+  const block = makeBlock("GmailInboxList", props);
+  return render(
+    <GmailInboxList block={block} onEvent={vi.fn()}>
+      {children}
+    </GmailInboxList>,
+  );
+}
+
+describe("GmailInboxList", () => {
+  // -----------------------------------------------------------------------
+  // Snapshot tests
+  // -----------------------------------------------------------------------
+
+  it("matches snapshot: normal scanned inbox", () => {
+    const { container } = renderInbox(fixtures.normal, [
+      <div key="1">Email 1</div>,
+      <div key="2">Email 2</div>,
+    ]);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  it("matches snapshot: unscanned inbox", () => {
+    const { container } = renderInbox(fixtures.unscanned);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  it("matches snapshot: error state", () => {
+    const { container } = renderInbox(fixtures.error);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  it("matches snapshot: truncated inbox", () => {
+    const { container } = renderInbox(fixtures.truncated, [
+      <div key="1">Email 1</div>,
+    ]);
+    expect(container.firstElementChild).toMatchSnapshot();
+  });
+
+  // -----------------------------------------------------------------------
+  // Structural assertions
+  // -----------------------------------------------------------------------
+
+  it("renders inbox title", () => {
+    renderInbox(fixtures.normal);
+    expect(screen.getByText("Inbox")).toBeInTheDocument();
+  });
+
+  it("shows unread badge with count", () => {
+    renderInbox(fixtures.normal);
+    const badge = document.querySelector(".gmail-inbox-list__badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge?.textContent).toBe("3");
+  });
+
+  it("does not show unread badge when count is zero", () => {
+    renderInbox(fixtures.unscanned);
+    const badge = document.querySelector(".gmail-inbox-list__badge");
+    expect(badge).not.toBeInTheDocument();
+  });
+
+  it("renders WaibScan button when not scanned", () => {
+    renderInbox(fixtures.unscanned);
+    expect(screen.getByText("WaibScan")).toBeInTheDocument();
+  });
+
+  it("does not render scan button when already scanned", () => {
+    renderInbox(fixtures.normal);
+    expect(screen.queryByText("WaibScan")).not.toBeInTheDocument();
+  });
+
+  it("renders error message in error state", () => {
+    renderInbox(fixtures.error);
+    expect(
+      screen.getByText(/Failed to connect to Gmail/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders truncation notice when isTruncated", () => {
+    renderInbox(fixtures.truncated, [<div key="1">Email 1</div>]);
+    expect(screen.getByText(/Showing 25 of 142 emails/)).toBeInTheDocument();
+  });
+
+  it("wraps children in drag-reorder items", () => {
+    renderInbox(fixtures.normal, [
+      <div key="a">A</div>,
+      <div key="b">B</div>,
+    ]);
+    const dragItems = document.querySelectorAll(
+      ".gmail-inbox-list__drag-item",
+    );
+    expect(dragItems.length).toBe(2);
+  });
+
+  it("has accessible region landmark", () => {
+    renderInbox(fixtures.normal);
+    expect(screen.getByRole("region")).toHaveAttribute(
+      "aria-label",
+      "Gmail Inbox",
+    );
+  });
+});

--- a/apps/frontend/src/blocks/components/__tests__/__snapshots__/CalendarDayTimeline.test.tsx.snap
+++ b/apps/frontend/src/blocks/components/__tests__/__snapshots__/CalendarDayTimeline.test.tsx.snap
@@ -1,0 +1,343 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CalendarDayTimeline > matches snapshot: empty day 1`] = `
+<div
+  class="gcal-day-timeline"
+>
+  <div
+    class="gcal-day-timeline__markers"
+  >
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 0%;"
+    >
+      8 AM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 10%;"
+    >
+      9 AM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 20%;"
+    >
+      10 AM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 30%;"
+    >
+      11 AM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 40%;"
+    >
+      12 PM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 50%;"
+    >
+      1 PM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 60%;"
+    >
+      2 PM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 70%;"
+    >
+      3 PM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 80%;"
+    >
+      4 PM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 90%;"
+    >
+      5 PM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 100%;"
+    >
+      6 PM
+    </div>
+  </div>
+  <div
+    class="gcal-day-timeline__track"
+  >
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 0%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 10%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 20%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 30%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 40%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 50%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 60%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 70%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 80%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 90%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 100%;"
+    />
+    <div
+      class="gcal-day-timeline__free-slot"
+      style="top: 0%; height: 100%;"
+    />
+    <div
+      class="gcal-day-timeline__now-line"
+      style="top: 20%;"
+    />
+  </div>
+</div>
+`;
+
+exports[`CalendarDayTimeline > matches snapshot: workday with events and free slots 1`] = `
+<div
+  class="gcal-day-timeline"
+>
+  <div
+    class="gcal-day-timeline__markers"
+  >
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 0%;"
+    >
+      8 AM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 10%;"
+    >
+      9 AM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 20%;"
+    >
+      10 AM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 30%;"
+    >
+      11 AM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 40%;"
+    >
+      12 PM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 50%;"
+    >
+      1 PM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 60%;"
+    >
+      2 PM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 70%;"
+    >
+      3 PM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 80%;"
+    >
+      4 PM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 90%;"
+    >
+      5 PM
+    </div>
+    <div
+      class="gcal-day-timeline__hour-label"
+      style="top: 100%;"
+    >
+      6 PM
+    </div>
+  </div>
+  <div
+    class="gcal-day-timeline__track"
+  >
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 0%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 10%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 20%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 30%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 40%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 50%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 60%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 70%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 80%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 90%;"
+    />
+    <div
+      class="gcal-day-timeline__grid-line"
+      style="top: 100%;"
+    />
+    <div
+      class="gcal-day-timeline__free-slot"
+      style="top: 30%; height: 10%;"
+    />
+    <div
+      class="gcal-day-timeline__free-slot"
+      style="top: 50%; height: 20%;"
+    />
+    <div
+      class="gcal-day-timeline__free-slot"
+      style="top: 80%; height: 20%;"
+    />
+    <div
+      class="gcal-day-timeline__event"
+      style="top: 10%; height: 2.5%; border-left-color: hsl(194, 65%, 55%);"
+    >
+      <span
+        class="gcal-day-timeline__event-title"
+      >
+        Stand-up
+      </span>
+      <span
+        class="gcal-day-timeline__event-time"
+      >
+        9 AM
+         – 
+        9:15 AM
+      </span>
+    </div>
+    <div
+      class="gcal-day-timeline__event"
+      style="top: 20%; height: 10%; border-left-color: hsl(291, 65%, 55%);"
+    >
+      <span
+        class="gcal-day-timeline__event-title"
+      >
+        Sprint Planning
+      </span>
+      <span
+        class="gcal-day-timeline__event-time"
+      >
+        10 AM
+         – 
+        11 AM
+      </span>
+    </div>
+    <div
+      class="gcal-day-timeline__event"
+      style="top: 40%; height: 10%; border-left-color: #4caf50;"
+    >
+      <span
+        class="gcal-day-timeline__event-title"
+      >
+        Lunch
+      </span>
+      <span
+        class="gcal-day-timeline__event-time"
+      >
+        12 PM
+         – 
+        1 PM
+      </span>
+    </div>
+    <div
+      class="gcal-day-timeline__event"
+      style="top: 70%; height: 10%; border-left-color: hsl(211, 65%, 55%);"
+    >
+      <span
+        class="gcal-day-timeline__event-title"
+      >
+        Code Review
+      </span>
+      <span
+        class="gcal-day-timeline__event-time"
+      >
+        3 PM
+         – 
+        4 PM
+      </span>
+    </div>
+    <div
+      class="gcal-day-timeline__now-line"
+      style="top: 65%;"
+    />
+  </div>
+</div>
+`;

--- a/apps/frontend/src/blocks/components/__tests__/__snapshots__/CalendarEventCard.test.tsx.snap
+++ b/apps/frontend/src/blocks/components/__tests__/__snapshots__/CalendarEventCard.test.tsx.snap
@@ -1,0 +1,147 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CalendarEventCard > matches snapshot: all-day event 1`] = `
+<div
+  class="gcal-event-card"
+  style="border-left-color: hsl(187, 65%, 55%);"
+>
+  <div
+    class="gcal-event-card__time"
+  >
+    All Day
+  </div>
+  <div
+    class="gcal-event-card__title"
+  >
+    Company Offsite
+  </div>
+  <div
+    class="gcal-event-card__footer"
+  />
+</div>
+`;
+
+exports[`CalendarEventCard > matches snapshot: cancelled event 1`] = `
+<div
+  class="gcal-event-card gcal-event-card--cancelled"
+  style="border-left-color: hsl(263, 65%, 55%);"
+>
+  <div
+    class="gcal-event-card__time"
+  >
+    12 – 1 PM
+  </div>
+  <div
+    class="gcal-event-card__title"
+  >
+    Team Lunch
+  </div>
+  <div
+    class="gcal-event-card__location"
+  >
+    Cafeteria
+  </div>
+  <div
+    class="gcal-event-card__footer"
+  />
+</div>
+`;
+
+exports[`CalendarEventCard > matches snapshot: conflicting event 1`] = `
+<div
+  class="gcal-event-card gcal-event-card--conflict"
+  style="border-left-color: hsl(162, 65%, 55%);"
+>
+  <div
+    class="gcal-event-card__time"
+  >
+    10:30 – 11:30 AM
+  </div>
+  <div
+    class="gcal-event-card__title"
+  >
+    Design Review
+  </div>
+  <div
+    class="gcal-event-card__footer"
+  >
+    <span
+      class="gcal-event-card__attendees"
+    >
+      +
+      2
+       attendee
+      s
+    </span>
+    <span
+      class="gcal-event-card__conflict-badge"
+    >
+      Conflict
+    </span>
+  </div>
+</div>
+`;
+
+exports[`CalendarEventCard > matches snapshot: standard meeting 1`] = `
+<div
+  class="gcal-event-card"
+  style="border-left-color: hsl(291, 65%, 55%);"
+>
+  <div
+    class="gcal-event-card__time"
+  >
+    10 – 11 AM
+  </div>
+  <div
+    class="gcal-event-card__title"
+  >
+    Sprint Planning
+  </div>
+  <div
+    class="gcal-event-card__location"
+  >
+    Conference Room B
+  </div>
+  <div
+    class="gcal-event-card__footer"
+  >
+    <span
+      class="gcal-event-card__attendees"
+    >
+      +
+      3
+       attendee
+      s
+    </span>
+  </div>
+</div>
+`;
+
+exports[`CalendarEventCard > matches snapshot: tentative event 1`] = `
+<div
+  class="gcal-event-card gcal-event-card--tentative"
+  style="border-left-color: hsl(195, 65%, 55%);"
+>
+  <div
+    class="gcal-event-card__time"
+  >
+    2 – 2:30 PM
+  </div>
+  <div
+    class="gcal-event-card__title"
+  >
+    1:1 with Manager
+  </div>
+  <div
+    class="gcal-event-card__footer"
+  >
+    <span
+      class="gcal-event-card__attendees"
+    >
+      +
+      1
+       attendee
+    </span>
+  </div>
+</div>
+`;

--- a/apps/frontend/src/blocks/components/__tests__/__snapshots__/GmailEmailCard.test.tsx.snap
+++ b/apps/frontend/src/blocks/components/__tests__/__snapshots__/GmailEmailCard.test.tsx.snap
@@ -1,0 +1,575 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GmailEmailCard > matches snapshot: minimal email (no subject, no labels) 1`] = `
+<div
+  aria-label="No Subject from notifications@github.com"
+  class="gmail-email-card"
+  role="listitem"
+  tabindex="0"
+>
+  <div
+    aria-hidden="true"
+    class="gmail-email-card__avatar"
+    style="background-color: hsl(138, 55%, 45%);"
+  >
+    NO
+  </div>
+  <div
+    class="gmail-email-card__content"
+  >
+    <div
+      class="gmail-email-card__subject"
+    >
+      No Subject
+    </div>
+    <div
+      class="gmail-email-card__meta"
+    >
+      <span
+        class="gmail-email-card__from"
+      >
+        notifications@github.com
+      </span>
+      <span
+        class="gmail-email-card__date"
+      >
+        Mar 4
+      </span>
+    </div>
+    <div
+      class="gmail-email-card__snippet"
+    >
+      You were mentioned in a comment on issue #42.
+    </div>
+  </div>
+  <div
+    class="gmail-email-card__actions"
+  />
+  <div
+    aria-label="Quick actions"
+    class="gmail-email-card__quick-actions"
+  >
+    <button
+      aria-label="Archive email"
+      class="gmail-email-card__quick-btn"
+      title="Archive"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M1.5 4.5h13M2.5 4.5v8a1 1 0 001 1h9a1 1 0 001-1v-8M5.5 7.5h5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+        <path
+          d="M0.5 2.5h15v2h-15z"
+          stroke="currentColor"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="Reply to email"
+      class="gmail-email-card__quick-btn"
+      title="Reply"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M6.5 4L2.5 8l4 4M2.5 8h7a4 4 0 014 4"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="Snooze email"
+      class="gmail-email-card__quick-btn"
+      title="Snooze"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <circle
+          cx="8"
+          cy="8.5"
+          r="5.5"
+          stroke="currentColor"
+          stroke-width="1.3"
+        />
+        <path
+          d="M8 5.5v3l2 1.5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+        <path
+          d="M5.5 1.5h5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-width="1.3"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`GmailEmailCard > matches snapshot: read email 1`] = `
+<div
+  aria-label="Lunch next week? from Bob Martinez"
+  class="gmail-email-card"
+  role="listitem"
+  tabindex="0"
+>
+  <div
+    aria-hidden="true"
+    class="gmail-email-card__avatar"
+    style="background-color: hsl(195, 55%, 45%);"
+  >
+    BM
+  </div>
+  <div
+    class="gmail-email-card__content"
+  >
+    <div
+      class="gmail-email-card__subject"
+    >
+      Lunch next week?
+    </div>
+    <div
+      class="gmail-email-card__meta"
+    >
+      <span
+        class="gmail-email-card__from"
+      >
+        Bob Martinez
+      </span>
+      <span
+        class="gmail-email-card__date"
+      >
+        Mar 5
+      </span>
+    </div>
+    <div
+      class="gmail-email-card__snippet"
+    >
+      Are you free Tuesday or Wednesday? There's a new ramen spot downtown I've been wanting to try.
+    </div>
+  </div>
+  <div
+    class="gmail-email-card__actions"
+  />
+  <div
+    aria-label="Quick actions"
+    class="gmail-email-card__quick-actions"
+  >
+    <button
+      aria-label="Archive email"
+      class="gmail-email-card__quick-btn"
+      title="Archive"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M1.5 4.5h13M2.5 4.5v8a1 1 0 001 1h9a1 1 0 001-1v-8M5.5 7.5h5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+        <path
+          d="M0.5 2.5h15v2h-15z"
+          stroke="currentColor"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="Reply to email"
+      class="gmail-email-card__quick-btn"
+      title="Reply"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M6.5 4L2.5 8l4 4M2.5 8h7a4 4 0 014 4"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="Snooze email"
+      class="gmail-email-card__quick-btn"
+      title="Snooze"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <circle
+          cx="8"
+          cy="8.5"
+          r="5.5"
+          stroke="currentColor"
+          stroke-width="1.3"
+        />
+        <path
+          d="M8 5.5v3l2 1.5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+        <path
+          d="M5.5 1.5h5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-width="1.3"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`GmailEmailCard > matches snapshot: starred email 1`] = `
+<div
+  aria-label="Unread: Design review feedback from Carol Wei"
+  class="gmail-email-card gmail-email-card--unread"
+  role="listitem"
+  tabindex="0"
+>
+  <div
+    aria-hidden="true"
+    class="gmail-email-card__avatar"
+    style="background-color: hsl(4, 55%, 45%);"
+  >
+    CW
+  </div>
+  <div
+    class="gmail-email-card__content"
+  >
+    <div
+      class="gmail-email-card__subject"
+    >
+      Design review feedback
+    </div>
+    <div
+      class="gmail-email-card__meta"
+    >
+      <span
+        class="gmail-email-card__from"
+      >
+        Carol Wei
+      </span>
+      <span
+        class="gmail-email-card__date"
+      >
+        Mar 6
+      </span>
+    </div>
+    <div
+      class="gmail-email-card__snippet"
+    >
+      Overall looks great! A few minor tweaks on the navigation component — see inline comments.
+    </div>
+  </div>
+  <div
+    class="gmail-email-card__actions"
+  >
+    <span
+      class="gmail-email-card__urgency gmail-email-card__urgency--medium"
+    >
+      medium
+    </span>
+    <span
+      class="gmail-email-card__star"
+    >
+      ★
+    </span>
+  </div>
+  <div
+    aria-label="Quick actions"
+    class="gmail-email-card__quick-actions"
+  >
+    <button
+      aria-label="Archive email"
+      class="gmail-email-card__quick-btn"
+      title="Archive"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M1.5 4.5h13M2.5 4.5v8a1 1 0 001 1h9a1 1 0 001-1v-8M5.5 7.5h5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+        <path
+          d="M0.5 2.5h15v2h-15z"
+          stroke="currentColor"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="Reply to email"
+      class="gmail-email-card__quick-btn"
+      title="Reply"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M6.5 4L2.5 8l4 4M2.5 8h7a4 4 0 014 4"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="Snooze email"
+      class="gmail-email-card__quick-btn"
+      title="Snooze"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <circle
+          cx="8"
+          cy="8.5"
+          r="5.5"
+          stroke="currentColor"
+          stroke-width="1.3"
+        />
+        <path
+          d="M8 5.5v3l2 1.5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+        <path
+          d="M5.5 1.5h5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-width="1.3"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`GmailEmailCard > matches snapshot: unread email with urgency 1`] = `
+<div
+  aria-label="Unread: Q3 Revenue Report — Action Required from Alice Johnson"
+  class="gmail-email-card gmail-email-card--unread"
+  role="listitem"
+  tabindex="0"
+>
+  <div
+    aria-hidden="true"
+    class="gmail-email-card__avatar"
+    style="background-color: hsl(273, 55%, 45%);"
+  >
+    AJ
+  </div>
+  <div
+    class="gmail-email-card__content"
+  >
+    <div
+      class="gmail-email-card__subject"
+    >
+      Q3 Revenue Report — Action Required
+    </div>
+    <div
+      class="gmail-email-card__meta"
+    >
+      <span
+        class="gmail-email-card__from"
+      >
+        Alice Johnson
+      </span>
+      <span
+        class="gmail-email-card__date"
+      >
+        Mar 7
+      </span>
+    </div>
+    <div
+      class="gmail-email-card__snippet"
+    >
+      Hey team, please review the attached Q3 numbers before Friday's board meeting. Key highlights…
+    </div>
+  </div>
+  <div
+    class="gmail-email-card__actions"
+  >
+    <span
+      class="gmail-email-card__urgency gmail-email-card__urgency--high"
+    >
+      high
+    </span>
+    <span
+      class="gmail-email-card__star"
+    >
+      ☆
+    </span>
+  </div>
+  <div
+    aria-label="Quick actions"
+    class="gmail-email-card__quick-actions"
+  >
+    <button
+      aria-label="Archive email"
+      class="gmail-email-card__quick-btn"
+      title="Archive"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M1.5 4.5h13M2.5 4.5v8a1 1 0 001 1h9a1 1 0 001-1v-8M5.5 7.5h5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+        <path
+          d="M0.5 2.5h15v2h-15z"
+          stroke="currentColor"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="Reply to email"
+      class="gmail-email-card__quick-btn"
+      title="Reply"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M6.5 4L2.5 8l4 4M2.5 8h7a4 4 0 014 4"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="Snooze email"
+      class="gmail-email-card__quick-btn"
+      title="Snooze"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <circle
+          cx="8"
+          cy="8.5"
+          r="5.5"
+          stroke="currentColor"
+          stroke-width="1.3"
+        />
+        <path
+          d="M8 5.5v3l2 1.5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.3"
+        />
+        <path
+          d="M5.5 1.5h5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-width="1.3"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;

--- a/apps/frontend/src/blocks/components/__tests__/__snapshots__/GmailInboxList.test.tsx.snap
+++ b/apps/frontend/src/blocks/components/__tests__/__snapshots__/GmailInboxList.test.tsx.snap
@@ -1,0 +1,470 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GmailInboxList > matches snapshot: error state 1`] = `
+<div
+  aria-label="Gmail Inbox"
+  class="gmail-inbox-list"
+  role="region"
+>
+  <div
+    class="gmail-inbox-list__header"
+  >
+    <div
+      class="gmail-inbox-list__title-row"
+    >
+      <h3
+        class="gmail-inbox-list__title"
+      >
+        Inbox
+      </h3>
+    </div>
+  </div>
+  <div
+    class="gmail-inbox-list__error"
+    role="alert"
+  >
+    <p
+      class="gmail-inbox-list__error-text"
+    >
+      Failed to connect to Gmail. Please re-authenticate.
+    </p>
+  </div>
+</div>
+`;
+
+exports[`GmailInboxList > matches snapshot: normal scanned inbox 1`] = `
+<div
+  aria-label="Gmail Inbox"
+  class="gmail-inbox-list"
+  role="region"
+>
+  <div
+    class="gmail-inbox-list__header"
+  >
+    <div
+      class="gmail-inbox-list__title-row"
+    >
+      <h3
+        class="gmail-inbox-list__title"
+      >
+        Inbox
+      </h3>
+      <span
+        aria-label="3 unread"
+        class="gmail-inbox-list__badge"
+      >
+        3
+      </span>
+    </div>
+  </div>
+  <div
+    aria-label="Email messages — drag to reorder priority"
+    class="gmail-inbox-list__cards"
+    role="list"
+  >
+    <div
+      class="gmail-inbox-list__drag-item"
+      draggable="true"
+    >
+      <div
+        aria-hidden="true"
+        class="gmail-inbox-list__drag-handle"
+      >
+        <svg
+          fill="none"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+        >
+          <circle
+            cx="4"
+            cy="2.5"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="8"
+            cy="2.5"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="4"
+            cy="6"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="8"
+            cy="6"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="4"
+            cy="9.5"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="8"
+            cy="9.5"
+            fill="currentColor"
+            r="1"
+          />
+        </svg>
+      </div>
+      <div
+        class="gmail-inbox-list__drag-content"
+      >
+        <div>
+          Email 1
+        </div>
+      </div>
+      <div
+        aria-label="Reorder email"
+        class="gmail-inbox-list__reorder-btns"
+        role="group"
+      >
+        <button
+          aria-label="Move up"
+          class="gmail-inbox-list__reorder-btn"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            height="12"
+            viewBox="0 0 12 12"
+            width="12"
+          >
+            <path
+              d="M2 8l4-4 4 4"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+            />
+          </svg>
+        </button>
+        <button
+          aria-label="Move down"
+          class="gmail-inbox-list__reorder-btn"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            height="12"
+            viewBox="0 0 12 12"
+            width="12"
+          >
+            <path
+              d="M2 4l4 4 4-4"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div
+      class="gmail-inbox-list__drag-item"
+      draggable="true"
+    >
+      <div
+        aria-hidden="true"
+        class="gmail-inbox-list__drag-handle"
+      >
+        <svg
+          fill="none"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+        >
+          <circle
+            cx="4"
+            cy="2.5"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="8"
+            cy="2.5"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="4"
+            cy="6"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="8"
+            cy="6"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="4"
+            cy="9.5"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="8"
+            cy="9.5"
+            fill="currentColor"
+            r="1"
+          />
+        </svg>
+      </div>
+      <div
+        class="gmail-inbox-list__drag-content"
+      >
+        <div>
+          Email 2
+        </div>
+      </div>
+      <div
+        aria-label="Reorder email"
+        class="gmail-inbox-list__reorder-btns"
+        role="group"
+      >
+        <button
+          aria-label="Move up"
+          class="gmail-inbox-list__reorder-btn"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            height="12"
+            viewBox="0 0 12 12"
+            width="12"
+          >
+            <path
+              d="M2 8l4-4 4 4"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+            />
+          </svg>
+        </button>
+        <button
+          aria-label="Move down"
+          class="gmail-inbox-list__reorder-btn"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            height="12"
+            viewBox="0 0 12 12"
+            width="12"
+          >
+            <path
+              d="M2 4l4 4 4-4"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GmailInboxList > matches snapshot: truncated inbox 1`] = `
+<div
+  aria-label="Gmail Inbox"
+  class="gmail-inbox-list"
+  role="region"
+>
+  <div
+    class="gmail-inbox-list__header"
+  >
+    <div
+      class="gmail-inbox-list__title-row"
+    >
+      <h3
+        class="gmail-inbox-list__title"
+      >
+        Inbox
+      </h3>
+      <span
+        aria-label="5 unread"
+        class="gmail-inbox-list__badge"
+      >
+        5
+      </span>
+    </div>
+  </div>
+  <div
+    aria-label="Email messages — drag to reorder priority"
+    class="gmail-inbox-list__cards"
+    role="list"
+  >
+    <div
+      class="gmail-inbox-list__drag-item"
+      draggable="true"
+    >
+      <div
+        aria-hidden="true"
+        class="gmail-inbox-list__drag-handle"
+      >
+        <svg
+          fill="none"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+        >
+          <circle
+            cx="4"
+            cy="2.5"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="8"
+            cy="2.5"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="4"
+            cy="6"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="8"
+            cy="6"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="4"
+            cy="9.5"
+            fill="currentColor"
+            r="1"
+          />
+          <circle
+            cx="8"
+            cy="9.5"
+            fill="currentColor"
+            r="1"
+          />
+        </svg>
+      </div>
+      <div
+        class="gmail-inbox-list__drag-content"
+      >
+        <div>
+          Email 1
+        </div>
+      </div>
+      <div
+        aria-label="Reorder email"
+        class="gmail-inbox-list__reorder-btns"
+        role="group"
+      >
+        <button
+          aria-label="Move up"
+          class="gmail-inbox-list__reorder-btn"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            height="12"
+            viewBox="0 0 12 12"
+            width="12"
+          >
+            <path
+              d="M2 8l4-4 4 4"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+            />
+          </svg>
+        </button>
+        <button
+          aria-label="Move down"
+          class="gmail-inbox-list__reorder-btn"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            height="12"
+            viewBox="0 0 12 12"
+            width="12"
+          >
+            <path
+              d="M2 4l4 4 4-4"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+  <p
+    class="gmail-inbox-list__truncated"
+  >
+    Showing 
+    25
+     of 
+    142
+     emails
+  </p>
+</div>
+`;
+
+exports[`GmailInboxList > matches snapshot: unscanned inbox 1`] = `
+<div
+  aria-label="Gmail Inbox"
+  class="gmail-inbox-list"
+  role="region"
+>
+  <div
+    class="gmail-inbox-list__header"
+  >
+    <div
+      class="gmail-inbox-list__title-row"
+    >
+      <h3
+        class="gmail-inbox-list__title"
+      >
+        Inbox
+      </h3>
+    </div>
+    <button
+      class="gmail-inbox-list__scan-btn"
+    >
+      WaibScan
+    </button>
+  </div>
+  <div
+    aria-label="Email messages — drag to reorder priority"
+    class="gmail-inbox-list__cards"
+    role="list"
+  />
+</div>
+`;

--- a/apps/frontend/src/blocks/components/__tests__/fixtures.ts
+++ b/apps/frontend/src/blocks/components/__tests__/fixtures.ts
@@ -1,0 +1,215 @@
+/**
+ * Test fixtures — representative data for block component visual regression tests.
+ *
+ * Each fixture mirrors the prop shapes consumed by its target component.
+ * Keep these stable; changing fixture data will (intentionally) cause
+ * snapshot diffs so layout regressions are caught.
+ */
+
+// ---------------------------------------------------------------------------
+// GmailEmailCard fixtures
+// ---------------------------------------------------------------------------
+
+export const gmailEmailCard = {
+  /** Standard unread email with urgency badge */
+  unread: {
+    emailId: "msg-001",
+    threadId: "thread-001",
+    from: "Alice Johnson",
+    subject: "Q3 Revenue Report — Action Required",
+    snippet:
+      "Hey team, please review the attached Q3 numbers before Friday's board meeting. Key highlights…",
+    date: "Mar 7",
+    isUnread: true,
+    labels: ["IMPORTANT", "INBOX"],
+    urgency: "high" as const,
+  },
+
+  /** Read email, no urgency */
+  read: {
+    emailId: "msg-002",
+    threadId: "thread-002",
+    from: "Bob Martinez",
+    subject: "Lunch next week?",
+    snippet:
+      "Are you free Tuesday or Wednesday? There's a new ramen spot downtown I've been wanting to try.",
+    date: "Mar 5",
+    isUnread: false,
+    labels: ["INBOX"],
+  },
+
+  /** Starred email with suggested reply */
+  starred: {
+    emailId: "msg-003",
+    threadId: "thread-003",
+    from: "Carol Wei",
+    subject: "Design review feedback",
+    snippet:
+      "Overall looks great! A few minor tweaks on the navigation component — see inline comments.",
+    date: "Mar 6",
+    isUnread: true,
+    labels: ["STARRED", "INBOX"],
+    urgency: "medium" as const,
+    suggestedReply: "Thanks Carol, I'll address those comments today.",
+  },
+
+  /** Minimal — no labels, no urgency */
+  minimal: {
+    emailId: "msg-004",
+    from: "notifications@github.com",
+    subject: "",
+    snippet: "You were mentioned in a comment on issue #42.",
+    date: "Mar 4",
+    isUnread: false,
+    labels: [],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// CalendarEventCard fixtures
+// ---------------------------------------------------------------------------
+
+export const calendarEventCard = {
+  /** Standard meeting with attendees */
+  meeting: {
+    eventId: "evt-001",
+    title: "Sprint Planning",
+    start: "2026-03-09T10:00:00",
+    end: "2026-03-09T11:00:00",
+    location: "Conference Room B",
+    attendees: ["alice@co.com", "bob@co.com", "carol@co.com"],
+    status: "confirmed",
+  },
+
+  /** All-day event */
+  allDay: {
+    eventId: "evt-002",
+    title: "Company Offsite",
+    start: "2026-03-10T00:00:00",
+    end: "2026-03-10T23:59:59",
+    status: "confirmed",
+    isAllDay: true,
+  },
+
+  /** Tentative event */
+  tentative: {
+    eventId: "evt-003",
+    title: "1:1 with Manager",
+    start: "2026-03-09T14:00:00",
+    end: "2026-03-09T14:30:00",
+    status: "tentative",
+    attendees: ["manager@co.com"],
+  },
+
+  /** Cancelled event */
+  cancelled: {
+    eventId: "evt-004",
+    title: "Team Lunch",
+    start: "2026-03-09T12:00:00",
+    end: "2026-03-09T13:00:00",
+    location: "Cafeteria",
+    status: "cancelled",
+  },
+
+  /** Conflicting event */
+  conflict: {
+    eventId: "evt-005",
+    title: "Design Review",
+    start: "2026-03-09T10:30:00",
+    end: "2026-03-09T11:30:00",
+    status: "confirmed",
+    conflictWith: "evt-001",
+    attendees: ["designer@co.com", "pm@co.com"],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// CalendarDayTimeline fixtures
+// ---------------------------------------------------------------------------
+
+export const calendarDayTimeline = {
+  /** Typical work day with events and free slots */
+  workday: {
+    date: "2026-03-09",
+    dayStart: "08:00",
+    dayEnd: "18:00",
+    events: [
+      {
+        eventId: "evt-t1",
+        title: "Stand-up",
+        start: "2026-03-09T09:00:00",
+        end: "2026-03-09T09:15:00",
+      },
+      {
+        eventId: "evt-t2",
+        title: "Sprint Planning",
+        start: "2026-03-09T10:00:00",
+        end: "2026-03-09T11:00:00",
+      },
+      {
+        eventId: "evt-t3",
+        title: "Lunch",
+        start: "2026-03-09T12:00:00",
+        end: "2026-03-09T13:00:00",
+        color: "#4caf50",
+      },
+      {
+        eventId: "evt-t4",
+        title: "Code Review",
+        start: "2026-03-09T15:00:00",
+        end: "2026-03-09T16:00:00",
+      },
+    ],
+    freeSlots: [
+      { start: "2026-03-09T11:00:00", end: "2026-03-09T12:00:00" },
+      { start: "2026-03-09T13:00:00", end: "2026-03-09T15:00:00" },
+      { start: "2026-03-09T16:00:00", end: "2026-03-09T18:00:00" },
+    ],
+  },
+
+  /** Empty day — no events */
+  empty: {
+    date: "2026-03-15",
+    dayStart: "08:00",
+    dayEnd: "18:00",
+    events: [],
+    freeSlots: [{ start: "2026-03-15T08:00:00", end: "2026-03-15T18:00:00" }],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// GmailInboxList fixtures
+// ---------------------------------------------------------------------------
+
+export const gmailInboxList = {
+  /** Normal inbox with unread emails */
+  normal: {
+    unreadCount: 3,
+    totalCount: 5,
+    isScanned: true,
+  },
+
+  /** Inbox not yet scanned */
+  unscanned: {
+    unreadCount: 0,
+    totalCount: 10,
+    isScanned: false,
+  },
+
+  /** Inbox with error */
+  error: {
+    unreadCount: 0,
+    totalCount: 0,
+    isScanned: false,
+    error: "Failed to connect to Gmail. Please re-authenticate.",
+  },
+
+  /** Truncated inbox */
+  truncated: {
+    unreadCount: 5,
+    totalCount: 25,
+    isScanned: true,
+    isTruncated: true,
+    fullCount: 142,
+  },
+};

--- a/apps/frontend/src/blocks/components/__tests__/test-utils.ts
+++ b/apps/frontend/src/blocks/components/__tests__/test-utils.ts
@@ -1,0 +1,23 @@
+import type { ComponentBlock } from "@waibspace/types";
+
+/**
+ * Create a ComponentBlock with the given type and props for testing.
+ * Provides sensible defaults for the required `id` and `type` fields.
+ */
+export function makeBlock(
+  type: string,
+  props: Record<string, unknown>,
+  children?: ComponentBlock[],
+): ComponentBlock {
+  return {
+    id: `test-${type}-${Math.random().toString(36).slice(2, 8)}`,
+    type,
+    props,
+    ...(children ? { children } : {}),
+  };
+}
+
+/**
+ * No-op event handler for tests that don't care about events.
+ */
+export const noopEvent = () => {};

--- a/apps/frontend/src/test-setup.ts
+++ b/apps/frontend/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@waibspace/types": path.resolve(
+        __dirname,
+        "../../packages/types/src/index.ts",
+      ),
+      "@waibspace/ui-renderer-contract": path.resolve(
+        __dirname,
+        "../../packages/ui-renderer-contract/src/index.ts",
+      ),
+    },
+  },
+  test: {
+    environment: "happy-dom",
+    setupFiles: ["./src/test-setup.ts"],
+    globals: true,
+    // Exclude bun:test files — they use a different test runner
+    exclude: ["**/node_modules/**", "src/lib/**/*.test.ts"],
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -40,10 +40,14 @@
         "react-router-dom": "^7.13.1",
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.4",
+        "happy-dom": "^20.8.3",
         "vite": "^7.3.1",
+        "vitest": "^4.0.18",
       },
     },
     "packages/agents": {
@@ -145,6 +149,8 @@
     },
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -309,6 +315,16 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -316,6 +332,10 @@
     "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -325,7 +345,25 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.4", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA=="],
+
+    "@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
+
+    "@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
 
     "@waibspace/agents": ["@waibspace/agents@workspace:packages/agents"],
 
@@ -367,6 +405,10 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
@@ -393,6 +435,8 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001777", "", {}, "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ=="],
 
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
@@ -417,6 +461,8 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
@@ -424,6 +470,10 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -439,9 +489,13 @@
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -451,11 +505,15 @@
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
@@ -511,6 +569,8 @@
 
     "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
 
+    "happy-dom": ["happy-dom@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
@@ -524,6 +584,8 @@
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -563,6 +625,10 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
@@ -572,6 +638,8 @@
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
@@ -593,6 +661,8 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -607,6 +677,8 @@
 
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -614,6 +686,8 @@
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -627,11 +701,15 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "react-router": ["react-router@7.13.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA=="],
 
     "react-router-dom": ["react-router-dom@7.13.1", "", { "dependencies": { "react-router": "7.13.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -675,11 +753,17 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -689,9 +773,17 @@
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
@@ -721,19 +813,27 @@
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
+    "vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
+
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -753,6 +853,10 @@
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "googleapis/google-auth-library": ["google-auth-library@10.6.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "7.1.3", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA=="],
@@ -762,6 +866,8 @@
     "googleapis-common/google-auth-library": ["google-auth-library@10.6.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "7.1.3", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 


### PR DESCRIPTION
## Summary
- Set up **vitest** + **happy-dom** + **@testing-library/react** as the frontend test framework
- Added **snapshot tests** and **structural DOM assertions** for four block components: `GmailEmailCard`, `GmailInboxList`, `CalendarEventCard`, `CalendarDayTimeline`
- Created shared test fixtures with representative data and a `makeBlock` utility for constructing `ComponentBlock` props in tests

## What's tested (49 tests)
- **GmailEmailCard** (12 tests): unread/read states, urgency badges, star icons, avatar initials, empty subject fallback, quick-action buttons, aria labels
- **CalendarEventCard** (14 tests): standard/all-day/tentative/cancelled/conflict variants, location rendering, attendee counts, colored borders
- **CalendarDayTimeline** (10 tests): hour markers, event blocks, free slots, now-line visibility, custom event colors, deterministic time via fake timers
- **GmailInboxList** (13 tests): unread badge, scan button, error state, truncation notice, drag-reorder wrappers, accessible landmarks

## How to run
```bash
cd apps/frontend
bun run test          # run all tests once
bun run test:watch    # watch mode
bun run test:update   # update snapshots after intentional changes
```

## Test plan
- [x] All 49 tests pass locally
- [x] Snapshots generated and committed
- [ ] Verify CI runs tests successfully

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)