### PR TITLE
feat: adaptive layout based on user engagement patterns

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -46,7 +46,7 @@ import {
   ModelProviderRegistry,
   AnthropicProvider,
 } from "@waibspace/model-provider";
-import { MemoryStore, MemoryUpdatePipeline, ObservationProcessor, ConversationContextStore } from "@waibspace/memory";
+import { MemoryStore, MemoryUpdatePipeline, ObservationProcessor, ConversationContextStore, EngagementTracker } from "@waibspace/memory";
 import { WaibDatabase } from "@waibspace/db";
 import { BackgroundTaskScheduler, MVP_BACKGROUND_TASKS } from "./background";
 import { startServer } from "./server";
@@ -177,7 +177,11 @@ log.info("Agent registry initialized", {
 // ---------- 6. Memory Store ----------
 const memoryStore = new MemoryStore(db, bus);
 
-// ---------- 6a. Conversation Context Store ----------
+// ---------- 6a. Engagement Tracker ----------
+const engagementTracker = new EngagementTracker(memoryStore);
+log.info("Engagement tracker initialized");
+
+// ---------- 6b. Conversation Context Store ----------
 const conversationContextStore = new ConversationContextStore();
 conversationContextStore.startCleanup();
 log.info("Conversation context store initialized");
@@ -194,6 +198,7 @@ const orchestrator = new Orchestrator(bus, agentRegistry, {
   connectorRegistry,
   policyEngine,
   pendingActionStore,
+  engagementTracker,
   db,
 });
 
@@ -204,6 +209,26 @@ memoryPipeline.start();
 // ---------- 8b. Observation Processor ----------
 const observationProcessor = new ObservationProcessor(memoryStore, bus);
 observationProcessor.start();
+
+// ---------- 8c. Engagement Tracking (interaction events -> engagement tracker) ----------
+bus.on("user.interaction.*", (event: WaibEvent) => {
+  const payload = event.payload as Record<string, unknown> | undefined;
+  if (!payload) return;
+
+  const surfaceType = (payload.surfaceType as string) || "";
+  const surfaceId = (payload.surfaceId as string) || "";
+  const interaction = (payload.interaction as string) || "";
+
+  // Only track interactions with identified surfaces
+  if (surfaceType && surfaceId) {
+    engagementTracker.recordInteraction({
+      surfaceType,
+      surfaceId,
+      interaction,
+      timestamp: Date.now(),
+    });
+  }
+});
 
 // ---------- 9. Background Task Scheduler ----------
 const scheduler = new BackgroundTaskScheduler(bus, orchestrator, memoryStore);

--- a/packages/agents/src/ui/layout-composer.ts
+++ b/packages/agents/src/ui/layout-composer.ts
@@ -3,10 +3,17 @@ import type {
   ComposedLayout,
   LayoutDirective,
 } from "@waibspace/ui-renderer-contract";
+import type { EngagementTracker, EngagementScore } from "@waibspace/memory";
 import { BaseAgent } from "../base-agent";
 import type { AgentInput, AgentContext } from "../types";
 
 const MAX_VISIBLE_SURFACES = 4;
+
+/**
+ * Priority boost applied per engagement score point (0-1 range).
+ * A fully engaged surface (score=1) gets up to this many extra priority points.
+ */
+const ENGAGEMENT_PRIORITY_BOOST = 30;
 
 /**
  * Extract SurfaceSpec objects from a list of agent outputs.
@@ -70,20 +77,48 @@ export class LayoutComposerAgent extends BaseAgent {
 
     this.log("Collected surfaces", { count: surfaces.length });
 
-    // 2. Sort by priority (highest first)
-    surfaces.sort((a, b) => b.priority - a.priority);
+    // 2. Retrieve engagement data if available
+    const engagementTracker = context.config?.engagementTracker as
+      | EngagementTracker
+      | undefined;
+    const engagementScores = engagementTracker?.getScores() ?? [];
+    const scoreMap = new Map<string, EngagementScore>();
+    for (const score of engagementScores) {
+      scoreMap.set(score.surfaceType, score);
+    }
 
-    // 3. Resolve position conflicts
+    if (engagementScores.length > 0) {
+      this.log("Engagement data available", {
+        trackedTypes: engagementScores.length,
+        topType: engagementScores[0]?.surfaceType,
+        topScore: engagementScores[0]?.score.toFixed(3),
+      });
+    }
+
+    // 3. Sort by priority, boosted by engagement score
+    surfaces.sort((a, b) => {
+      const boostA = (scoreMap.get(a.surfaceType)?.score ?? 0) * ENGAGEMENT_PRIORITY_BOOST;
+      const boostB = (scoreMap.get(b.surfaceType)?.score ?? 0) * ENGAGEMENT_PRIORITY_BOOST;
+      return (b.priority + boostB) - (a.priority + boostA);
+    });
+
+    // 4. Resolve position conflicts
     const resolved = this.resolvePositions(surfaces);
 
-    // 4. Generate LayoutDirectives (max 4 visible)
-    const layout = this.buildDirectives(resolved);
+    // 5. Apply engagement-based prominence adjustments
+    const prominenceMap = engagementTracker?.getProminenceMap();
+    const adjusted = prominenceMap
+      ? this.applyEngagementProminence(resolved, prominenceMap)
+      : resolved;
+
+    // 6. Generate LayoutDirectives (max 4 visible)
+    const layout = this.buildDirectives(adjusted);
 
     const endMs = Date.now();
 
-    // 5. Build ComposedLayout
+    // 7. Build ComposedLayout
     const composed: ComposedLayout = {
-      surfaces: resolved,
+      surfaces: adjusted,
       layout,
       timestamp: Date.now(),
       traceId: context.traceId,
@@ -92,7 +127,7 @@ export class LayoutComposerAgent extends BaseAgent {
     return {
       ...this.createOutput(composed, 1.0, {
         dataState: "transformed",
-        transformations: ["layout-composition"],
+        transformations: ["layout-composition", ...(prominenceMap ? ["engagement-adaptive"] : [])],
         timestamp: startMs,
       }),
       timing: {
@@ -135,6 +170,35 @@ export class LayoutComposerAgent extends BaseAgent {
       }
 
       return surface;
+    });
+  }
+
+  /**
+   * Apply engagement-driven prominence to surfaces.
+   *
+   * If a surface's layoutHints don't already specify a prominence, the
+   * engagement tracker's prominence map overrides the default. This means
+   * highly-used surfaces get "hero" prominence and rarely-used ones get
+   * "compact", without overriding explicit agent hints.
+   */
+  private applyEngagementProminence(
+    surfaces: SurfaceSpec[],
+    prominenceMap: Map<string, "hero" | "standard" | "compact">,
+  ): SurfaceSpec[] {
+    return surfaces.map((surface) => {
+      // Only override if the agent didn't explicitly set prominence
+      if (surface.layoutHints.prominence) return surface;
+
+      const engagementProminence = prominenceMap.get(surface.surfaceType);
+      if (!engagementProminence) return surface;
+
+      return {
+        ...surface,
+        layoutHints: {
+          ...surface.layoutHints,
+          prominence: engagementProminence,
+        },
+      };
     });
   }
 

--- a/packages/memory/src/__tests__/engagement-tracker.test.ts
+++ b/packages/memory/src/__tests__/engagement-tracker.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { EngagementTracker } from "../engagement-tracker";
+import { MemoryStore } from "../memory-store";
+
+describe("EngagementTracker", () => {
+  let memoryStore: MemoryStore;
+  let tracker: EngagementTracker;
+
+  beforeEach(() => {
+    memoryStore = new MemoryStore();
+    tracker = new EngagementTracker(memoryStore);
+  });
+
+  describe("recordInteraction", () => {
+    it("should store a new interaction in memory", () => {
+      tracker.recordInteraction({
+        surfaceType: "inbox",
+        surfaceId: "inbox-1",
+        interaction: "click",
+        timestamp: Date.now(),
+      });
+
+      const entry = memoryStore.get("engagement", "surface:inbox");
+      expect(entry).toBeDefined();
+      expect((entry!.value as { totalInteractions: number }).totalInteractions).toBe(1);
+    });
+
+    it("should increment counts for repeated interactions", () => {
+      const now = Date.now();
+      tracker.recordInteraction({
+        surfaceType: "calendar",
+        surfaceId: "cal-1",
+        interaction: "click",
+        timestamp: now,
+      });
+      tracker.recordInteraction({
+        surfaceType: "calendar",
+        surfaceId: "cal-1",
+        interaction: "expand",
+        timestamp: now + 1000,
+      });
+      tracker.recordInteraction({
+        surfaceType: "calendar",
+        surfaceId: "cal-1",
+        interaction: "click",
+        timestamp: now + 2000,
+      });
+
+      const entry = memoryStore.get("engagement", "surface:calendar");
+      const metrics = entry!.value as {
+        totalInteractions: number;
+        interactionsByType: Record<string, number>;
+      };
+      expect(metrics.totalInteractions).toBe(3);
+      expect(metrics.interactionsByType["click"]).toBe(2);
+      expect(metrics.interactionsByType["expand"]).toBe(1);
+    });
+  });
+
+  describe("getScores", () => {
+    it("should return empty array with no data", () => {
+      expect(tracker.getScores()).toEqual([]);
+    });
+
+    it("should rank more-interacted surfaces higher", () => {
+      const now = Date.now();
+
+      // Inbox: 5 interactions
+      for (let i = 0; i < 5; i++) {
+        tracker.recordInteraction({
+          surfaceType: "inbox",
+          surfaceId: "inbox-1",
+          interaction: "click",
+          timestamp: now + i,
+        });
+      }
+
+      // Calendar: 1 interaction
+      tracker.recordInteraction({
+        surfaceType: "calendar",
+        surfaceId: "cal-1",
+        interaction: "click",
+        timestamp: now,
+      });
+
+      const scores = tracker.getScores();
+      expect(scores.length).toBe(2);
+      expect(scores[0].surfaceType).toBe("inbox");
+      expect(scores[0].score).toBeGreaterThan(scores[1].score);
+    });
+
+    it("should produce scores between 0 and 1", () => {
+      const now = Date.now();
+      tracker.recordInteraction({
+        surfaceType: "inbox",
+        surfaceId: "inbox-1",
+        interaction: "click",
+        timestamp: now,
+      });
+
+      const scores = tracker.getScores();
+      for (const s of scores) {
+        expect(s.score).toBeGreaterThanOrEqual(0);
+        expect(s.score).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+
+  describe("getProminenceMap", () => {
+    it("should return empty map with no data", () => {
+      expect(tracker.getProminenceMap().size).toBe(0);
+    });
+
+    it("should assign hero to top surface and compact to lowest", () => {
+      const now = Date.now();
+
+      // High engagement
+      for (let i = 0; i < 10; i++) {
+        tracker.recordInteraction({
+          surfaceType: "inbox",
+          surfaceId: "inbox-1",
+          interaction: "click",
+          timestamp: now + i,
+        });
+      }
+
+      // Medium engagement
+      for (let i = 0; i < 5; i++) {
+        tracker.recordInteraction({
+          surfaceType: "calendar",
+          surfaceId: "cal-1",
+          interaction: "click",
+          timestamp: now + i,
+        });
+      }
+
+      // Low engagement
+      tracker.recordInteraction({
+        surfaceType: "discovery",
+        surfaceId: "disc-1",
+        interaction: "click",
+        timestamp: now,
+      });
+
+      const map = tracker.getProminenceMap();
+      expect(map.get("inbox")).toBe("hero");
+      expect(map.get("discovery")).toBe("compact");
+    });
+  });
+
+  describe("getScoreFor", () => {
+    it("should return undefined for unknown surface types", () => {
+      expect(tracker.getScoreFor("nonexistent")).toBeUndefined();
+    });
+
+    it("should return score for tracked surface type", () => {
+      tracker.recordInteraction({
+        surfaceType: "inbox",
+        surfaceId: "inbox-1",
+        interaction: "click",
+        timestamp: Date.now(),
+      });
+
+      const score = tracker.getScoreFor("inbox");
+      expect(score).toBeDefined();
+      expect(score!.surfaceType).toBe("inbox");
+      expect(score!.score).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/memory/src/engagement-tracker.ts
+++ b/packages/memory/src/engagement-tracker.ts
@@ -1,0 +1,218 @@
+import type { MemoryStore } from "./memory-store";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw record of a single user interaction with a surface.
+ */
+export interface SurfaceInteraction {
+  surfaceType: string;
+  surfaceId: string;
+  interaction: string;
+  timestamp: number;
+}
+
+/**
+ * Aggregated engagement metrics for a surface type.
+ *
+ * Stored in memory under category "engagement", keyed by surfaceType.
+ */
+export interface EngagementMetrics {
+  surfaceType: string;
+  /** Total number of interactions across all time. */
+  totalInteractions: number;
+  /** Number of interactions in the recent window (last 7 days). */
+  recentInteractions: number;
+  /** Timestamp of the most recent interaction. */
+  lastInteractedAt: number;
+  /** Interaction count broken down by interaction type (click, expand, etc.). */
+  interactionsByType: Record<string, number>;
+}
+
+/**
+ * Scored surface type, combining recency and frequency into a single rank.
+ */
+export interface EngagementScore {
+  surfaceType: string;
+  /** Normalized score between 0 and 1. Higher = more engaged. */
+  score: number;
+  metrics: EngagementMetrics;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Interactions within this window are weighted more heavily. */
+const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/**
+ * Weights for the engagement scoring formula.
+ * - recentFrequency: how often the user interacted recently (0-1)
+ * - recency: how recently the last interaction occurred (0-1)
+ * - totalFrequency: lifetime interaction share (0-1)
+ */
+const WEIGHTS = {
+  recentFrequency: 0.5,
+  recency: 0.3,
+  totalFrequency: 0.2,
+} as const;
+
+/** Half-life for recency decay (3 days). */
+const RECENCY_HALF_LIFE_MS = 3 * 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// EngagementTracker
+// ---------------------------------------------------------------------------
+
+/**
+ * Heuristic-based engagement tracker.
+ *
+ * Records surface interactions in the MemoryStore under the "engagement"
+ * category and produces ranked scores that the LayoutComposerAgent can use
+ * to influence surface ordering and prominence.
+ */
+export class EngagementTracker {
+  constructor(private readonly memoryStore: MemoryStore) {}
+
+  // -----------------------------------------------------------------------
+  // Recording
+  // -----------------------------------------------------------------------
+
+  /**
+   * Record a user interaction with a surface.
+   *
+   * Updates the aggregated EngagementMetrics stored in memory.
+   */
+  recordInteraction(interaction: SurfaceInteraction): void {
+    const { surfaceType, interaction: interactionType, timestamp } = interaction;
+    const key = `surface:${surfaceType}`;
+
+    const existing = this.memoryStore.get("engagement", key);
+    const now = timestamp || Date.now();
+
+    let metrics: EngagementMetrics;
+
+    if (existing) {
+      metrics = existing.value as EngagementMetrics;
+      metrics.totalInteractions += 1;
+      metrics.lastInteractedAt = Math.max(metrics.lastInteractedAt, now);
+      metrics.interactionsByType[interactionType] =
+        (metrics.interactionsByType[interactionType] ?? 0) + 1;
+
+      // Recompute recent interactions from a simple increment.
+      // The full recomputation happens at scoring time; here we optimistically
+      // increment so the stored value stays roughly correct.
+      metrics.recentInteractions += 1;
+    } else {
+      metrics = {
+        surfaceType,
+        totalInteractions: 1,
+        recentInteractions: 1,
+        lastInteractedAt: now,
+        interactionsByType: { [interactionType]: 1 },
+      };
+    }
+
+    this.memoryStore.set("engagement", key, metrics, "engagement-tracker");
+  }
+
+  // -----------------------------------------------------------------------
+  // Scoring
+  // -----------------------------------------------------------------------
+
+  /**
+   * Compute engagement scores for all tracked surface types.
+   *
+   * Returns an array sorted by score descending (most engaged first).
+   */
+  getScores(): EngagementScore[] {
+    const entries = this.memoryStore.getAll("engagement");
+    if (entries.length === 0) return [];
+
+    const now = Date.now();
+    const recentCutoff = now - RECENT_WINDOW_MS;
+
+    // Refresh recentInteractions based on the stored lastInteractedAt.
+    // Since we don't store individual event timestamps, we approximate:
+    // if lastInteractedAt is within the window, recentInteractions stands;
+    // otherwise decay it toward zero.
+    const metricsList: EngagementMetrics[] = entries
+      .filter((e) => e.key.startsWith("surface:"))
+      .map((e) => {
+        const m = e.value as EngagementMetrics;
+        if (m.lastInteractedAt < recentCutoff) {
+          // All recent activity is stale — zero out recent count
+          m.recentInteractions = 0;
+        }
+        return m;
+      });
+
+    if (metricsList.length === 0) return [];
+
+    // Compute normalizers
+    const maxRecent = Math.max(...metricsList.map((m) => m.recentInteractions), 1);
+    const maxTotal = Math.max(...metricsList.map((m) => m.totalInteractions), 1);
+
+    const scores: EngagementScore[] = metricsList.map((metrics) => {
+      // Recent frequency: normalized 0-1
+      const recentFrequency = metrics.recentInteractions / maxRecent;
+
+      // Recency: exponential decay from lastInteractedAt
+      const ageSinceLastMs = now - metrics.lastInteractedAt;
+      const recency = Math.pow(0.5, ageSinceLastMs / RECENCY_HALF_LIFE_MS);
+
+      // Total frequency: normalized 0-1
+      const totalFrequency = metrics.totalInteractions / maxTotal;
+
+      const score =
+        WEIGHTS.recentFrequency * recentFrequency +
+        WEIGHTS.recency * recency +
+        WEIGHTS.totalFrequency * totalFrequency;
+
+      return { surfaceType: metrics.surfaceType, score, metrics };
+    });
+
+    scores.sort((a, b) => b.score - a.score);
+    return scores;
+  }
+
+  /**
+   * Get the engagement score for a specific surface type, or undefined
+   * if no interactions have been recorded for it.
+   */
+  getScoreFor(surfaceType: string): EngagementScore | undefined {
+    return this.getScores().find((s) => s.surfaceType === surfaceType);
+  }
+
+  /**
+   * Map engagement scores to prominence hints.
+   *
+   * - Top-scored surface -> "hero"
+   * - Above median -> "standard"
+   * - Below median -> "compact"
+   * - No data -> undefined (use defaults)
+   */
+  getProminenceMap(): Map<string, "hero" | "standard" | "compact"> {
+    const scores = this.getScores();
+    if (scores.length === 0) return new Map();
+
+    const map = new Map<string, "hero" | "standard" | "compact">();
+    const median = scores[Math.floor(scores.length / 2)].score;
+
+    for (let i = 0; i < scores.length; i++) {
+      const { surfaceType, score } = scores[i];
+      if (i === 0 && score > 0) {
+        map.set(surfaceType, "hero");
+      } else if (score >= median) {
+        map.set(surfaceType, "standard");
+      } else {
+        map.set(surfaceType, "compact");
+      }
+    }
+
+    return map;
+  }
+}

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -13,3 +13,9 @@ export { ConversationContextStore } from "./conversation-context-store";
 export type { ConversationContextStoreOptions } from "./conversation-context-store";
 export { ContactProfileStore, parseFromHeader } from "./contact-profile-store";
 export type { ContactProfile, SenderSummary } from "./contact-profile-store";
+export { EngagementTracker } from "./engagement-tracker";
+export type {
+  SurfaceInteraction,
+  EngagementMetrics,
+  EngagementScore,
+} from "./engagement-tracker";

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -21,6 +21,8 @@ export interface OrchestratorOptions {
   policyEngine?: PolicyEngine;
   pendingActionStore?: IPendingActionStore;
   db?: WaibDatabase;
+  /** Engagement tracker for adaptive layout based on user interaction patterns */
+  engagementTracker?: unknown;
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -105,6 +107,9 @@ export class Orchestrator {
             : {}),
           ...(this.options?.conversationContextStore
             ? { conversationContextStore: this.options.conversationContextStore }
+            : {}),
+          ...(this.options?.engagementTracker
+            ? { engagementTracker: this.options.engagementTracker }
             : {}),
         },
       };

--- a/packages/types/src/memory.ts
+++ b/packages/types/src/memory.ts
@@ -4,7 +4,8 @@ export type MemoryCategory =
   | "task"
   | "relationship"
   | "system"
-  | "conversation";
+  | "conversation"
+  | "engagement";
 
 /**
  * A single turn in a conversation history.


### PR DESCRIPTION
## Summary
- Adds an `EngagementTracker` that records surface interactions in the memory store and computes heuristic engagement scores (weighted by recency, recent frequency, and total frequency)
- Integrates engagement scores into `LayoutComposerAgent` to boost priority of frequently-used surfaces and apply adaptive prominence (hero/standard/compact) to surfaces without explicit hints
- Wires interaction events from the WebSocket event bus to the tracker in the backend

## Changed files
- `packages/memory/src/engagement-tracker.ts` — new EngagementTracker class
- `packages/memory/src/__tests__/engagement-tracker.test.ts` — 9 unit tests
- `packages/memory/src/index.ts` — export EngagementTracker
- `packages/types/src/memory.ts` — add "engagement" MemoryCategory
- `packages/agents/src/ui/layout-composer.ts` — consume engagement scores for sorting + prominence
- `packages/orchestrator/src/orchestrator.ts` — pass engagementTracker through agent context
- `apps/backend/src/index.ts` — initialize tracker, wire event bus, pass to orchestrator

## Test plan
- [x] 9 new unit tests for EngagementTracker (recording, scoring, prominence mapping)
- [ ] Verify existing tests still pass (morning-digest, email-urgency confirmed passing)
- [ ] Manual: interact with surfaces and confirm ordering adapts over time

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)