### PR TITLE
fix: register block components before first render

### DIFF
--- a/apps/frontend/src/blocks/WaibRenderer.tsx
+++ b/apps/frontend/src/blocks/WaibRenderer.tsx
@@ -15,13 +15,13 @@
  *                         └─ children BlockNodes (recursive)
  */
 
-import { memo, useCallback, useContext, useEffect, type ReactNode } from "react";
+import { memo, useCallback, useContext, type ReactNode } from "react";
 import type { ComponentBlock, ComponentEventAction } from "@waibspace/types";
 import { ObservationCollectorProvider } from "./ObservationCollector";
 import { BlockStateProvider, BlockStateContext } from "./BlockStateStore";
 import { ObservationWrapper } from "./ObservationWrapper";
 import { getBlockComponent } from "./registry";
-import { registerPrimitiveBlocks, registerDomainComponents, FallbackBlock } from "./components";
+import { FallbackBlock } from "./components";
 import { BlockErrorBoundary } from "../components/BlockErrorBoundary";
 
 // ---------------------------------------------------------------------------
@@ -34,11 +34,6 @@ export interface WaibRendererProps {
 }
 
 export const WaibRenderer = memo(function WaibRenderer({ blocks, send }: WaibRendererProps) {
-  useEffect(() => {
-    registerPrimitiveBlocks();
-    registerDomainComponents();
-  }, []);
-
   return (
     <ObservationCollectorProvider send={send}>
       <BlockStateProvider>

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -6,9 +6,14 @@ import "./styles/theme.css";
 import "./styles/gmail-components.css";
 import "./styles/undo-toast.css";
 import { initTheme } from "./hooks/useTheme";
+import { registerPrimitiveBlocks, registerDomainComponents } from "./blocks/components";
 
 // Apply saved theme before first paint to avoid flash
 initTheme();
+
+// Register all block components before first render
+registerPrimitiveBlocks();
+registerDomainComponents();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- Block components (GmailInboxList, CalendarEventCard, etc.) were registered inside `useEffect` in WaibRenderer, which runs **after** the first paint
- This caused "Unknown block: GmailInboxList" on initial load because the registry was empty during the first render
- Moved `registerPrimitiveBlocks()` and `registerDomainComponents()` to `main.tsx` so they run before `ReactDOM.createRoot`

## Test plan
- [ ] Load homepage with Gmail MCP connected — inbox should render immediately without "Unknown block" fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)