### PR TITLE
fix: parse email headers from MIME when MCP fields are empty

### DIFF
--- a/packages/agents/src/context/data-retrieval.ts
+++ b/packages/agents/src/context/data-retrieval.ts
@@ -184,7 +184,7 @@ export class DataRetrievalAgent extends BaseAgent {
    */
   private truncateData(data: unknown): unknown {
     const MAX_DATA_SIZE = 50_000;
-    const MAX_ITEMS = 20;
+    const MAX_ITEMS = 10;
     const MAX_FIELD_LENGTH = 500;
 
     // MCP tools return [{type: "text", text: "..."}] — truncate the text content
@@ -205,7 +205,7 @@ export class DataRetrievalAgent extends BaseAgent {
                 // Take first N items, then strip large fields from each
                 const truncated = parsed.slice(0, MAX_ITEMS).map((entry: unknown) => {
                   if (typeof entry === "object" && entry !== null) {
-                    return this.trimObjectFields(
+                    return this.trimBodyFields(
                       entry as Record<string, unknown>,
                       MAX_FIELD_LENGTH,
                     );
@@ -213,10 +213,13 @@ export class DataRetrievalAgent extends BaseAgent {
                   return entry;
                 });
 
+                // Log sample fields for debugging MCP data quality
+                const sample = truncated[0] as Record<string, unknown> | undefined;
                 this.log("Truncated MCP array data", {
                   originalCount: parsed.length,
                   keptCount: truncated.length,
                   serializedSize: JSON.stringify(truncated).length,
+                  sampleFields: sample ? Object.keys(sample) : [],
                 });
 
                 return { type: "text", text: JSON.stringify(truncated) };
@@ -239,25 +242,31 @@ export class DataRetrievalAgent extends BaseAgent {
   }
 
   /**
-   * Trim long string fields in an object to keep data compact.
-   * Preserves short fields (headers, IDs, dates) while truncating
-   * large fields (body, html, content).
+   * Trim only body/content fields in an object to keep data compact.
+   * Preserves ALL other fields exactly as-is (from, subject, to, date, etc.)
+   * so downstream agents receive unmangled header data.
+   *
+   * Only these known body field names are truncated:
+   * text, html, body, content, snippet, textBody, htmlBody
    */
-  private trimObjectFields(
+  private static readonly BODY_FIELDS = new Set([
+    "text", "html", "body", "content", "snippet", "textBody", "htmlBody",
+  ]);
+
+  private trimBodyFields(
     obj: Record<string, unknown>,
     maxLen: number,
   ): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
-      if (typeof value === "string" && value.length > maxLen) {
+      if (
+        DataRetrievalAgent.BODY_FIELDS.has(key) &&
+        typeof value === "string" &&
+        value.length > maxLen
+      ) {
         result[key] = value.slice(0, maxLen) + "...";
-      } else if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-        // Recurse one level for nested objects (e.g., headers)
-        result[key] = this.trimObjectFields(
-          value as Record<string, unknown>,
-          maxLen,
-        );
       } else {
+        // Preserve everything else exactly as-is — no recursive trimming
         result[key] = value;
       }
     }

--- a/packages/agents/src/ui/inbox-surface.ts
+++ b/packages/agents/src/ui/inbox-surface.ts
@@ -161,7 +161,7 @@ export class InboxSurfaceAgent extends BaseAgent {
       };
     }
 
-    // Truncate to 20 emails max
+    // Truncate to 10 emails max
     const originalCount = Array.isArray(gmailData) ? gmailData.length : 1;
     const truncatedData = this.truncateEmailData(gmailData);
 
@@ -190,14 +190,10 @@ export class InboxSurfaceAgent extends BaseAgent {
     // Default path: map raw email fields directly — no LLM involved
     // Apply lightweight heuristic urgency scoring (no LLM cost)
     const emails: InboxSurfaceData["emails"] = rawEmails.map((email, i) => {
+      const normalized = this.normalizeEmailFields(email, i);
       const { urgency } = classifyEmailUrgency(email);
       return {
-        id: String(email.id ?? email.messageId ?? `email-${i}`),
-        from: String(email.from || email.sender || "Unknown"),
-        subject: String(email.subject || "No Subject"),
-        snippet: String(email.snippet ?? email.text ?? email.body ?? "").slice(0, 200),
-        date: String(email.date ?? email.receivedAt ?? ""),
-        isUnread: Boolean(email.isUnread ?? email.unread ?? true),
+        ...normalized,
         urgency,
       };
     });
@@ -369,20 +365,160 @@ export class InboxSurfaceAgent extends BaseAgent {
       const rawEmails = (Array.isArray(truncatedData) ? truncatedData : [truncatedData]) as Record<string, unknown>[];
       return {
         emails: rawEmails.map((email, i) => {
+          const normalized = this.normalizeEmailFields(email, i);
           const { urgency } = classifyEmailUrgency(email);
           return {
-            id: String(email.id ?? email.messageId ?? `email-${i}`),
-            from: String(email.from || email.sender || "Unknown"),
-            subject: String(email.subject || "No Subject"),
-            snippet: String(email.snippet ?? email.text ?? email.body ?? "").slice(0, 200),
-            date: String(email.date ?? email.receivedAt ?? ""),
-            isUnread: Boolean(email.isUnread ?? email.unread ?? true),
+            ...normalized,
             urgency,
           };
         }),
         overallSummary: `${rawEmails.length} emails (LLM analysis unavailable, heuristic urgency applied)`,
       };
     }
+  }
+
+  /**
+   * Normalize email fields from raw MCP data.
+   *
+   * MCP mail servers (e.g. mcp-mail-server) sometimes return empty from/subject
+   * fields while the actual headers are embedded in the raw MIME `text` field.
+   * This method:
+   * 1. Tries standard field names, then alternative names (From, sender, uid, etc.)
+   * 2. If `from` is still empty, attempts to parse From: header from MIME text
+   * 3. If `subject` is empty/"No Subject", attempts to parse Subject: header from MIME text
+   * 4. Handles `from` being an object ({name, address})
+   * 5. Normalizes unread status from IMAP flags
+   */
+  private normalizeEmailFields(
+    email: Record<string, unknown>,
+    index: number,
+  ): Omit<EmailSummary, "urgency" | "suggestedReply"> {
+    // --- ID ---
+    const id = String(
+      email.id ?? email.uid ?? email.messageId ?? email.message_id ?? `email-${index}`,
+    );
+
+    // --- FROM ---
+    let from = "";
+    // Try standard fields
+    const rawFrom = email.from ?? email.From ?? email.sender ?? email.Sender;
+    if (rawFrom) {
+      if (typeof rawFrom === "string") {
+        from = rawFrom;
+      } else if (typeof rawFrom === "object" && rawFrom !== null) {
+        // Handle {name, address} or {value: [{name, address}]}
+        const obj = rawFrom as Record<string, unknown>;
+        if (obj.address) {
+          from = obj.name ? `${obj.name} <${obj.address}>` : String(obj.address);
+        } else if (obj.name) {
+          from = String(obj.name);
+        } else if (Array.isArray(obj.value)) {
+          const first = obj.value[0] as Record<string, unknown> | undefined;
+          if (first?.address) {
+            from = first.name ? `${first.name} <${first.address}>` : String(first.address);
+          }
+        }
+      }
+    }
+    // If still empty, try to extract From: header from MIME text
+    if (!from) {
+      from = this.extractMimeHeader(email, "From") || "Unknown";
+    }
+
+    // --- SUBJECT ---
+    let subject = String(email.subject ?? email.Subject ?? "");
+    if (!subject || subject === "No Subject") {
+      const parsed = this.extractMimeHeader(email, "Subject");
+      if (parsed) subject = parsed;
+    }
+    if (!subject) subject = "No Subject";
+
+    // --- DATE ---
+    const date = String(
+      email.date ?? email.Date ?? email.receivedAt ?? email.received_at ?? "",
+    );
+
+    // --- SNIPPET ---
+    let snippet = String(
+      email.snippet ?? email.text ?? email.body ?? email.textBody ?? "",
+    );
+    // Strip MIME headers from snippet if they leaked into it
+    snippet = snippet.replace(/^(From:|To:|Subject:|Date:|MIME-Version:|Content-Type:)[^\n]*\n/gm, "").trim();
+    snippet = snippet.slice(0, 200);
+
+    // --- UNREAD ---
+    let isUnread: boolean;
+    if (typeof email.isUnread === "boolean") {
+      isUnread = email.isUnread;
+    } else if (typeof email.unread === "boolean") {
+      isUnread = email.unread;
+    } else if (Array.isArray(email.flags)) {
+      // IMAP flags: if \\Seen is present, it's read
+      isUnread = !(email.flags as string[]).some(
+        (f) => f === "\\Seen" || f === "\\seen" || f.toLowerCase() === "\\seen",
+      );
+    } else {
+      isUnread = true;
+    }
+
+    return { id, from, subject, snippet, date, isUnread };
+  }
+
+  /**
+   * Extract a specific header value from raw MIME text embedded in email fields.
+   * Handles formats like:
+   *   From: "John Doe" <john@example.com>
+   *   From: john@example.com
+   *   From: "Google Workspace Team" [workspace-noreply@google.com]
+   */
+  private extractMimeHeader(
+    email: Record<string, unknown>,
+    headerName: string,
+  ): string | undefined {
+    // Look in text, body, textBody, content fields
+    const textContent = String(email.text ?? email.body ?? email.textBody ?? email.content ?? "");
+    if (!textContent) return undefined;
+
+    // Try exact header line match
+    const lineRegex = new RegExp(`^${headerName}:\\s*(.+)$`, "m");
+    const lineMatch = textContent.match(lineRegex);
+    if (lineMatch) {
+      const raw = lineMatch[1].trim();
+      if (headerName === "From") {
+        return this.parseFromValue(raw);
+      }
+      return raw;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Parse a From header value into a clean display string.
+   * Handles:
+   *   "John Doe" <john@example.com>  -> John Doe <john@example.com>
+   *   john@example.com               -> john@example.com
+   *   "Team Name" [addr@example.com] -> Team Name <addr@example.com>
+   */
+  private parseFromValue(raw: string): string {
+    // Pattern: "Display Name" <email@addr> or Display Name <email@addr>
+    const angleBracket = raw.match(/"?([^"<]+)"?\s*<([^>]+)>/);
+    if (angleBracket) {
+      const name = angleBracket[1].trim();
+      const addr = angleBracket[2].trim();
+      return name ? `${name} <${addr}>` : addr;
+    }
+
+    // Pattern: "Display Name" [email@addr] (seen in some MCP servers)
+    const squareBracket = raw.match(/"?([^"[\]]+)"?\s*\[([^\]]+)\]/);
+    if (squareBracket) {
+      const name = squareBracket[1].trim();
+      const addr = squareBracket[2].trim();
+      return name ? `${name} <${addr}>` : addr;
+    }
+
+    // Plain email or text
+    return raw.trim();
   }
 
   private findDataRetrieval(
@@ -522,10 +658,10 @@ export class InboxSurfaceAgent extends BaseAgent {
 
   /**
    * Truncate email data to keep within limits.
-   * Keeps at most 20 emails, truncates body text to 500 chars each.
+   * Keeps at most 10 emails, truncates body text to 500 chars each.
    */
   private truncateEmailData(data: unknown): unknown {
-    const MAX_EMAILS = 20;
+    const MAX_EMAILS = 10;
     const MAX_BODY_LENGTH = 500;
     const MAX_TOTAL_LENGTH = 50_000; // ~12k tokens
 


### PR DESCRIPTION
## Summary
- **Fixes #291**: MCP mail server returns empty `from`/`subject`/`to` fields while actual headers are embedded in the raw MIME `text` body
- **data-retrieval.ts**: Replaced `trimObjectFields()` (which recursively truncated ALL string fields including headers) with `trimBodyFields()` that only truncates known body content fields (`text`, `html`, `body`, `content`, `snippet`, `textBody`, `htmlBody`), preserving headers intact. Reduced MAX_ITEMS from 20 to 10.
- **inbox-surface.ts**: Added `normalizeEmailFields()` method that tries standard then alternative field names, extracts `From:`/`Subject:` from MIME text when fields are empty, handles `from` as object `{name, address}`, normalizes IMAP `\Seen` flags for unread status, and strips leaked MIME headers from snippets. Applied in both default and LLM fallback paths. Reduced MAX_EMAILS from 20 to 10.

## Test plan
- [ ] Verify emails from mcp-mail-server now show correct From/Subject instead of empty/"No Subject"
- [ ] Verify MIME header extraction handles: `"Name" <email>`, `email@addr`, `"Name" [email]`
- [ ] Verify body fields are still truncated at 500 chars
- [ ] Verify non-body fields (from, subject, to, date) are preserved without truncation
- [ ] Verify inbox renders correctly with 10-email limit
- [ ] Verify WaibScan LLM fallback path also uses normalized fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)