### PR TITLE
feat: add background task scheduler for periodic connector polling

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -49,6 +49,7 @@ import {
 import { MemoryStore, MemoryUpdatePipeline, ObservationProcessor, ConversationContextStore, EngagementTracker, BehavioralTracker, BehavioralModel } from "@waibspace/memory";
 import { WaibDatabase } from "@waibspace/db";
 import { BackgroundTaskScheduler, MVP_BACKGROUND_TASKS } from "./background";
+import { TaskScheduler } from "./scheduler";
 import { startServer } from "./server";
 import { broadcast } from "./ws";
 
@@ -249,6 +250,28 @@ log.info("Background tasks registered", {
   tasks: MVP_BACKGROUND_TASKS.map((t) => t.id),
 });
 
+// ---------- 9b. Connector Polling Scheduler ----------
+const pollingScheduler = new TaskScheduler((event) => {
+  const traceId = event.traceId;
+  log.child({ traceId }).info("Polling event emitted", { eventType: event.type, payload: event.payload });
+  orchestrator.processEvent(event).catch((err: unknown) => {
+    const payload = event.payload as { connectorId?: string; operation?: string } | undefined;
+    const taskId = payload ? `${payload.connectorId}:${payload.operation}` : "unknown";
+    pollingScheduler.recordFailure(taskId);
+    log.child({ traceId }).error("Poll event processing failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+});
+
+// Register default polling tasks for connected services
+pollingScheduler.register("mcp-gmail", "get_unseen_messages", 5 * 60 * 1000);      // Email: every 5 minutes
+pollingScheduler.register("mcp-google-calendar", "get_events", 15 * 60 * 1000);    // Calendar: every 15 minutes
+pollingScheduler.start();
+log.info("Connector polling scheduler started", {
+  tasks: pollingScheduler.status().map((t) => `${t.connectorId}:${t.operation}`),
+});
+
 // ---------- 10. Route user events to orchestrator ----------
 const USER_EVENT_PATTERNS = [
   "user.*",
@@ -350,6 +373,7 @@ function handleShutdown(signal: string) {
   log.info("Shutting down", { signal });
   mcpRegistry.stopHealthChecks();
   scheduler.stop();
+  pollingScheduler.stop();
   conversationContextStore.stopCleanup();
   server.stop();
   log.info("Shutdown complete");

--- a/apps/backend/src/scheduler.ts
+++ b/apps/backend/src/scheduler.ts
@@ -1,0 +1,141 @@
+import { createEvent } from "@waibspace/event-bus";
+import type { WaibEvent } from "@waibspace/types";
+
+/**
+ * A polling task that periodically checks a connected data source.
+ */
+export interface PollingTask {
+  connectorId: string;
+  operation: string;
+  intervalMs: number;
+  lastRunMs: number;
+  consecutiveFailures: number;
+  enabled: boolean;
+}
+
+const TICK_INTERVAL_MS = 10_000; // check every 10 seconds
+const MAX_BACKOFF_MS = 60 * 60 * 1000; // 1 hour cap
+
+/**
+ * TaskScheduler periodically polls connected data sources (email, calendar,
+ * etc.) so Waib can monitor and act proactively.
+ *
+ * It runs a single setInterval loop every 10 seconds, checks which tasks are
+ * due, and emits `system.poll` WaibEvents for each.
+ *
+ * Backoff strategy: after 3 consecutive failures the interval doubles; after 5
+ * it quadruples. The effective interval is capped at 1 hour.
+ */
+export class TaskScheduler {
+  private tasks = new Map<string, PollingTask>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private emitEvent: (event: WaibEvent) => void;
+
+  constructor(emitEvent: (event: WaibEvent) => void) {
+    this.emitEvent = emitEvent;
+  }
+
+  /** Register a polling task. The task key is `connectorId:operation`. */
+  register(connectorId: string, operation: string, intervalMs: number): void {
+    const taskId = `${connectorId}:${operation}`;
+    this.tasks.set(taskId, {
+      connectorId,
+      operation,
+      intervalMs,
+      lastRunMs: 0,
+      consecutiveFailures: 0,
+      enabled: true,
+    });
+  }
+
+  /** Start the scheduler tick loop. */
+  start(): void {
+    if (this.timer) return; // already running
+    this.timer = setInterval(() => this.tick(), TICK_INTERVAL_MS);
+  }
+
+  /** Stop the scheduler. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Get status of all registered tasks. */
+  status(): PollingTask[] {
+    return Array.from(this.tasks.values());
+  }
+
+  /** Enable or disable a specific task by its id (`connectorId:operation`). */
+  setEnabled(taskId: string, enabled: boolean): void {
+    const task = this.tasks.get(taskId);
+    if (task) {
+      task.enabled = enabled;
+    }
+  }
+
+  /** Record a successful poll so the failure count resets. */
+  recordSuccess(taskId: string): void {
+    const task = this.tasks.get(taskId);
+    if (task) {
+      task.consecutiveFailures = 0;
+    }
+  }
+
+  /** Record a poll failure so the backoff kicks in. */
+  recordFailure(taskId: string): void {
+    const task = this.tasks.get(taskId);
+    if (task) {
+      task.consecutiveFailures += 1;
+    }
+  }
+
+  // ---- private ----
+
+  private tick(): void {
+    const now = Date.now();
+    for (const [taskId, task] of this.tasks) {
+      if (!task.enabled) continue;
+
+      const effectiveInterval = this.getEffectiveInterval(task);
+      if (now - task.lastRunMs >= effectiveInterval) {
+        task.lastRunMs = now;
+        this.emitPollEvent(task);
+      }
+    }
+  }
+
+  /**
+   * Compute the effective polling interval taking exponential backoff into
+   * account.
+   *
+   * - 0-2 failures: base interval
+   * - 3-4 failures: 2x base interval
+   * - 5+ failures: 4x base interval
+   * - Capped at MAX_BACKOFF_MS (1 hour)
+   */
+  private getEffectiveInterval(task: PollingTask): number {
+    let multiplier = 1;
+    if (task.consecutiveFailures >= 5) {
+      multiplier = 4;
+    } else if (task.consecutiveFailures >= 3) {
+      multiplier = 2;
+    }
+    return Math.min(task.intervalMs * multiplier, MAX_BACKOFF_MS);
+  }
+
+  private emitPollEvent(task: PollingTask): void {
+    const event = createEvent(
+      "system.poll",
+      {
+        connectorId: task.connectorId,
+        operation: task.operation,
+        source: "scheduler",
+      },
+      "scheduler",
+    );
+    event.metadata = { userId: "default" };
+    this.emitEvent(event);
+  }
+}

--- a/packages/orchestrator/src/execution-planner.ts
+++ b/packages/orchestrator/src/execution-planner.ts
@@ -46,6 +46,22 @@ const AGENT_ORDERINGS: Record<string, AgentOrdering[]> = {
       ],
     },
   ],
+  "system.poll": [
+    {
+      category: "context",
+      groups: [
+        ["context.connector-selection"],
+        ["context.data-retrieval"],
+      ],
+    },
+    {
+      category: "ui",
+      groups: [
+        ["ui.inbox-surface", "ui.calendar-surface", "ui.generic-data-surface"],
+        ["layout-composer"],
+      ],
+    },
+  ],
   "user.message.received": [
     {
       category: "context",
@@ -83,6 +99,12 @@ function getPipelineForEvent(eventType: string): AgentCategory[] {
 
   if (eventType === "policy.approval.response") {
     return ["execution"];
+  }
+
+  // system.poll events already know the intent (check for updates) — skip
+  // perception and reasoning, go straight to context + ui + safety.
+  if (eventType === "system.poll") {
+    return ["context", "ui", "safety"];
   }
 
   // Default pipeline

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -17,6 +17,8 @@ export type WaibEventType =
   | "execution.requested"
   | "execution.completed"
   | "background.task.triggered"
+  | "background.task.complete"
+  | "system.poll"
   | "memory.updated";
 
 export interface WaibEvent {


### PR DESCRIPTION
## Summary
- Adds a `TaskScheduler` class (`apps/backend/src/scheduler.ts`) that periodically polls connected data sources by emitting `system.poll` WaibEvents on a 10-second tick loop
- Implements exponential backoff on consecutive failures (2x after 3 failures, 4x after 5, capped at 1 hour)
- Adds `system.poll` event type to the type system and a dedicated execution pipeline that skips perception/reasoning phases, going straight to context → ui → safety

## Changes
- **`apps/backend/src/scheduler.ts`** — New `TaskScheduler` class with register/start/stop/setEnabled/recordSuccess/recordFailure methods
- **`packages/orchestrator/src/execution-planner.ts`** — Added `system.poll` pipeline (context + ui + safety) and agent ordering (connector-selection → data-retrieval, then surface agents → layout-composer)
- **`packages/types/src/events.ts`** — Added `system.poll` and `background.task.complete` to `WaibEventType` union
- **`apps/backend/src/index.ts`** — Wired `TaskScheduler` with default polling tasks (email 5min, calendar 15min), graceful shutdown

## Test plan
- [ ] Verify backend starts without errors with the polling scheduler
- [ ] Confirm `system.poll` events are emitted at the correct intervals
- [ ] Test backoff behavior by simulating connector failures
- [ ] Verify graceful shutdown stops the polling scheduler
- [ ] Confirm `system.poll` events skip perception/reasoning phases in the orchestrator

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)