### PR TITLE
feat: create generic DataTriageAgent with pluggable classifiers

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -33,6 +33,9 @@ import {
   ProvenanceAnnotatorAgent,
   // Execution agents
   ActionExecutorAgent,
+  // Triage agents
+  DataTriageAgent,
+  EmailTriageClassifier,
 } from "@waibspace/agents";
 import {
   ConnectorRegistry,
@@ -148,6 +151,11 @@ agentRegistry.register(new ConnectorSelectionAgent());
 agentRegistry.register(new DataRetrievalAgent());
 agentRegistry.register(new PolicyGateAgent());
 agentRegistry.register(new BehavioralPreferenceAgent());
+
+// Triage agents
+const dataTriageAgent = new DataTriageAgent();
+dataTriageAgent.registerClassifier(new EmailTriageClassifier());
+agentRegistry.register(dataTriageAgent);
 
 // UI agents
 agentRegistry.register(new InboxSurfaceAgent());

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -49,4 +49,15 @@ export {
   LayoutComposerAgent,
   extractSurfaces,
 } from "./ui";
+export {
+  DataTriageAgent,
+  EmailTriageClassifier,
+  type TriageOutput,
+  type TriageResult,
+  type TriagedItem,
+  type TriageClassifier,
+  type TriageContext,
+  type UrgencyLevel,
+  type TriageCategory,
+} from "./triage";
 export { ActionExecutorAgent } from "./execution";

--- a/packages/agents/src/triage/data-triage-agent.ts
+++ b/packages/agents/src/triage/data-triage-agent.ts
@@ -1,0 +1,163 @@
+/**
+ * DataTriageAgent — generic triage agent with pluggable classifiers.
+ *
+ * Sits between the context phase (data-retrieval) and the UI phase.
+ * For each retrieval result, it finds a matching classifier and produces
+ * a TriageOutput with urgency/category annotations on every item.
+ */
+
+import type { AgentOutput } from "@waibspace/types";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+import type { DataRetrievalOutput } from "../context/data-retrieval";
+import type {
+  TriageClassifier,
+  TriageOutput,
+  TriagedItem,
+  UrgencyLevel,
+  TriageCategory,
+} from "./types";
+
+export class DataTriageAgent extends BaseAgent {
+  private classifiers = new Map<string, TriageClassifier>();
+
+  constructor() {
+    super({
+      id: "triage.data-classifier",
+      name: "DataTriageAgent",
+      type: "classifier",
+      category: "triage",
+    });
+  }
+
+  /** Register a classifier for a set of connector types. */
+  registerClassifier(classifier: TriageClassifier): void {
+    this.classifiers.set(classifier.id, classifier);
+    this.log("Classifier registered", {
+      classifierId: classifier.id,
+      connectors: classifier.supportedConnectors,
+    });
+  }
+
+  /**
+   * Find a classifier whose supportedConnectors matches the given connectorId.
+   * Uses case-insensitive partial matching so "gmail" matches "gmail-personal".
+   */
+  private findClassifier(connectorId: string): TriageClassifier | undefined {
+    const lower = connectorId.toLowerCase();
+    for (const classifier of this.classifiers.values()) {
+      const matches = classifier.supportedConnectors.some((supported) =>
+        lower.includes(supported.toLowerCase()),
+      );
+      if (matches) return classifier;
+    }
+    return undefined;
+  }
+
+  async execute(
+    input: AgentInput,
+    _context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+
+    // Find DataRetrievalOutput from prior outputs
+    const retrievalOutput = input.priorOutputs.find(
+      (o) => o.category === "context" && this.isDataRetrievalOutput(o.output),
+    );
+
+    if (!retrievalOutput) {
+      this.log("No data retrieval output found, skipping triage");
+      return this.createOutput([], 0.5);
+    }
+
+    const retrieval = retrievalOutput.output as DataRetrievalOutput;
+    const triageOutputs: TriageOutput[] = [];
+
+    for (const result of retrieval.results) {
+      if (result.status !== "fulfilled" || !result.data) continue;
+
+      const classifier = this.findClassifier(result.connectorId);
+      if (!classifier) {
+        this.log("No classifier for connector, skipping", {
+          connectorId: result.connectorId,
+        });
+        continue;
+      }
+
+      // Normalize data to an array
+      const rawItems = Array.isArray(result.data)
+        ? (result.data as unknown[])
+        : [result.data];
+
+      if (rawItems.length === 0) continue;
+
+      try {
+        const triageResults = await classifier.classify(rawItems);
+
+        // Pair raw items with their triage results
+        const items: TriagedItem[] = rawItems.map((raw, i) => ({
+          raw,
+          triage: triageResults[i]!,
+        }));
+
+        // Compute stats
+        const byUrgency: Record<UrgencyLevel, number> = {
+          high: 0,
+          medium: 0,
+          low: 0,
+        };
+        const byCategory: Record<TriageCategory, number> = {
+          actionable: 0,
+          informational: 0,
+          promotional: 0,
+          personal: 0,
+          professional: 0,
+        };
+
+        for (const item of items) {
+          byUrgency[item.triage.urgency]++;
+          byCategory[item.triage.category]++;
+        }
+
+        triageOutputs.push({
+          items,
+          stats: {
+            total: items.length,
+            byUrgency,
+            byCategory,
+          },
+          classifierId: classifier.id,
+          connectorId: result.connectorId,
+        });
+
+        this.log("Triage complete for connector", {
+          connectorId: result.connectorId,
+          classifierId: classifier.id,
+          total: items.length,
+          highUrgency: byUrgency.high,
+        });
+      } catch (err) {
+        this.log("Classifier error", {
+          connectorId: result.connectorId,
+          classifierId: classifier.id,
+          error: String(err),
+        });
+      }
+    }
+
+    const endMs = Date.now();
+    const output = this.createOutput(triageOutputs, 0.8);
+    output.timing = {
+      startMs,
+      endMs,
+      durationMs: endMs - startMs,
+    };
+    return output;
+  }
+
+  private isDataRetrievalOutput(output: unknown): output is DataRetrievalOutput {
+    if (!output || typeof output !== "object") return false;
+    const obj = output as Record<string, unknown>;
+    return Array.isArray(obj.results);
+  }
+}

--- a/packages/agents/src/triage/email-classifier.ts
+++ b/packages/agents/src/triage/email-classifier.ts
@@ -1,0 +1,194 @@
+/**
+ * Email triage classifier that wraps the existing heuristic-based
+ * email urgency scoring from email-urgency.ts and maps results
+ * into the generic TriageResult format.
+ */
+
+import { classifyEmailUrgency } from "../ui/email-urgency";
+import type {
+  TriageClassifier,
+  TriageContext,
+  TriageResult,
+  TriageCategory,
+  UrgencyLevel,
+} from "./types";
+
+// Keywords that signal promotional content
+const PROMOTIONAL_KEYWORDS = [
+  "unsubscribe",
+  "newsletter",
+  "promo",
+  "promotional",
+  "sale",
+  "% off",
+  "special offer",
+  "limited time",
+  "deal of",
+  "discount",
+  "coupon",
+  "free shipping",
+];
+
+// Keywords that signal newsletter content
+const NEWSLETTER_KEYWORDS = [
+  "newsletter",
+  "digest",
+  "weekly update",
+  "daily update",
+  "weekly roundup",
+  "weekly recap",
+];
+
+// Personal email domains
+const PERSONAL_DOMAINS = [
+  "gmail.com",
+  "yahoo.com",
+  "hotmail.com",
+  "outlook.com",
+  "icloud.com",
+  "aol.com",
+  "protonmail.com",
+  "fastmail.com",
+  "hey.com",
+  "mail.com",
+];
+
+function extractSearchableText(email: Record<string, unknown>): string {
+  const subject = (email.subject as string) ?? "";
+  const body =
+    (email.snippet as string) ??
+    (email.text as string) ??
+    (email.body as string) ??
+    "";
+  return `${subject} ${body}`.toLowerCase();
+}
+
+function extractSender(email: Record<string, unknown>): string {
+  return ((email.from as string) ?? (email.sender as string) ?? "").toLowerCase();
+}
+
+function hasKeyword(text: string, keywords: string[]): boolean {
+  const lower = text.toLowerCase();
+  return keywords.some((kw) => lower.includes(kw));
+}
+
+function classifyCategory(
+  email: Record<string, unknown>,
+  urgency: UrgencyLevel,
+): TriageCategory {
+  const searchable = extractSearchableText(email);
+  const sender = extractSender(email);
+  const labels = (email.labels as string[]) ?? [];
+  const upperLabels = labels.map((l) => l.toUpperCase());
+
+  // Promotional signals
+  if (
+    upperLabels.includes("CATEGORY_PROMOTIONS") ||
+    hasKeyword(searchable, PROMOTIONAL_KEYWORDS)
+  ) {
+    return "promotional";
+  }
+
+  // Informational / newsletter
+  if (
+    upperLabels.includes("CATEGORY_UPDATES") ||
+    hasKeyword(searchable, NEWSLETTER_KEYWORDS)
+  ) {
+    return "informational";
+  }
+
+  // Personal — from a personal domain and not automated
+  const senderDomain = sender.split("@")[1] ?? "";
+  const isFromNoreply = /no-?reply|noreply|do-?not-?reply|notifications?@/i.test(
+    sender,
+  );
+  if (PERSONAL_DOMAINS.includes(senderDomain) && !isFromNoreply) {
+    return "personal";
+  }
+
+  // High urgency typically means actionable
+  if (urgency === "high") {
+    return "actionable";
+  }
+
+  // Default to professional for work-related email
+  return "professional";
+}
+
+function suggestAction(
+  category: TriageCategory,
+  urgency: UrgencyLevel,
+  email: Record<string, unknown>,
+): string | undefined {
+  const searchable = extractSearchableText(email);
+
+  // Promotional + low urgency → mark as read
+  if (category === "promotional" && urgency === "low") {
+    return "mark_read";
+  }
+
+  // Newsletter pattern → recommend unsubscribe
+  if (hasKeyword(searchable, NEWSLETTER_KEYWORDS) && urgency === "low") {
+    return "unsubscribe_recommend";
+  }
+
+  // High urgency + actionable → reply
+  if (urgency === "high" && category === "actionable") {
+    return "reply";
+  }
+
+  // Informational → archive
+  if (category === "informational") {
+    return "archive";
+  }
+
+  return undefined;
+}
+
+function generateReasoning(
+  category: TriageCategory,
+  urgency: UrgencyLevel,
+  score: number,
+): string {
+  const parts: string[] = [];
+  parts.push(`Urgency score: ${score} → ${urgency}`);
+  parts.push(`Category: ${category}`);
+  return parts.join(". ");
+}
+
+export class EmailTriageClassifier implements TriageClassifier {
+  readonly id = "email";
+  readonly supportedConnectors = ["gmail", "mail", "email"];
+
+  async classify(
+    items: unknown[],
+    _context?: TriageContext,
+  ): Promise<TriageResult[]> {
+    return items.map((item, index) => {
+      const email = item as Record<string, unknown>;
+      const { urgency, score } = classifyEmailUrgency(email);
+
+      const category = classifyCategory(email, urgency);
+      const action = suggestAction(category, urgency, email);
+
+      // Derive an item ID from the email or fall back to index
+      const itemId =
+        (email.id as string) ??
+        (email.messageId as string) ??
+        `email-${index}`;
+
+      // Confidence based on score magnitude — higher absolute score = more confident
+      const confidence = Math.min(1, 0.5 + Math.abs(score) * 0.05);
+
+      return {
+        itemId,
+        urgency,
+        category,
+        suggestedAction: action,
+        confidence,
+        reasoning: generateReasoning(category, urgency, score),
+        domain: "email",
+      };
+    });
+  }
+}

--- a/packages/agents/src/triage/index.ts
+++ b/packages/agents/src/triage/index.ts
@@ -1,0 +1,11 @@
+export {
+  type UrgencyLevel,
+  type TriageCategory,
+  type TriageResult,
+  type TriagedItem,
+  type TriageClassifier,
+  type TriageContext,
+  type TriageOutput,
+} from "./types";
+export { EmailTriageClassifier } from "./email-classifier";
+export { DataTriageAgent } from "./data-triage-agent";

--- a/packages/agents/src/triage/types.ts
+++ b/packages/agents/src/triage/types.ts
@@ -1,0 +1,49 @@
+export type UrgencyLevel = "high" | "medium" | "low";
+export type TriageCategory =
+  | "actionable"
+  | "informational"
+  | "promotional"
+  | "personal"
+  | "professional";
+
+export interface TriageResult {
+  itemId: string;
+  urgency: UrgencyLevel;
+  category: TriageCategory;
+  suggestedAction?: string; // e.g., "mark_read", "reply", "archive", "unsubscribe"
+  confidence: number; // 0-1
+  reasoning?: string; // why this classification
+  domain?: string; // memory domain hint
+}
+
+export interface TriagedItem<T = unknown> {
+  raw: T;
+  triage: TriageResult;
+}
+
+export interface TriageClassifier {
+  /** Unique identifier for this classifier */
+  id: string;
+  /** Which connector types this classifier handles */
+  supportedConnectors: string[];
+  /** Classify a batch of raw items */
+  classify(items: unknown[], context?: TriageContext): Promise<TriageResult[]>;
+}
+
+export interface TriageContext {
+  /** Memory context for informed classification */
+  memoryContext?: string;
+  /** Known domains for this data source */
+  domains?: string[];
+}
+
+export interface TriageOutput {
+  items: TriagedItem[];
+  stats: {
+    total: number;
+    byUrgency: Record<UrgencyLevel, number>;
+    byCategory: Record<TriageCategory, number>;
+  };
+  classifierId: string;
+  connectorId: string;
+}

--- a/packages/orchestrator/src/execution-planner.ts
+++ b/packages/orchestrator/src/execution-planner.ts
@@ -55,6 +55,12 @@ const AGENT_ORDERINGS: Record<string, AgentOrdering[]> = {
       ],
     },
     {
+      category: "triage",
+      groups: [
+        ["triage.data-classifier"],
+      ],
+    },
+    {
       category: "ui",
       groups: [
         ["ui.inbox-surface", "ui.calendar-surface", "ui.generic-data-surface"],
@@ -69,6 +75,12 @@ const AGENT_ORDERINGS: Record<string, AgentOrdering[]> = {
         ["context.planner"],
         ["context.connector-selection"],
         ["context.data-retrieval"],
+      ],
+    },
+    {
+      category: "triage",
+      groups: [
+        ["triage.data-classifier"],
       ],
     },
     {
@@ -90,11 +102,11 @@ function getPipelineForEvent(eventType: string): AgentCategory[] {
     eventType === "user.message.received" ||
     eventType === "user.intent.url_received"
   ) {
-    return ["perception", "reasoning", "context", "ui", "safety"];
+    return ["perception", "reasoning", "context", "triage", "ui", "safety"];
   }
 
   if (eventType.startsWith("user.interaction.")) {
-    return ["perception", "reasoning", "context", "ui", "safety"];
+    return ["perception", "reasoning", "context", "triage", "ui", "safety"];
   }
 
   if (eventType === "policy.approval.response") {
@@ -104,11 +116,11 @@ function getPipelineForEvent(eventType: string): AgentCategory[] {
   // system.poll events already know the intent (check for updates) — skip
   // perception and reasoning, go straight to context + ui + safety.
   if (eventType === "system.poll") {
-    return ["context", "ui", "safety"];
+    return ["context", "triage", "ui", "safety"];
   }
 
   // Default pipeline
-  return ["perception", "reasoning", "context", "ui", "safety"];
+  return ["perception", "reasoning", "context", "triage", "ui", "safety"];
 }
 
 /**

--- a/packages/types/src/agents.ts
+++ b/packages/types/src/agents.ts
@@ -4,6 +4,7 @@ export type AgentCategory =
   | "perception"
   | "reasoning"
   | "context"
+  | "triage"
   | "ui"
   | "safety"
   | "execution";


### PR DESCRIPTION
## Summary

- Adds a new **triage phase** to the agent pipeline between context (data-retrieval) and UI, introducing `DataTriageAgent` with a pluggable classifier architecture
- Implements `EmailTriageClassifier` that wraps existing `email-urgency.ts` heuristics and maps results to a generic `TriageResult` format with urgency, category, suggested actions, and confidence scores
- Updates the execution planner to run triage after data retrieval for `system.poll`, `user.message.received`, and default event pipelines

Closes #310

## Changes

| File | Change |
|------|--------|
| `packages/agents/src/triage/types.ts` | Triage type definitions (TriageResult, TriagedItem, TriageClassifier, TriageOutput) |
| `packages/agents/src/triage/email-classifier.ts` | EmailTriageClassifier implementing TriageClassifier interface |
| `packages/agents/src/triage/data-triage-agent.ts` | DataTriageAgent with classifier registry and connector matching |
| `packages/agents/src/triage/index.ts` | Module barrel exports |
| `packages/agents/src/index.ts` | Export triage module |
| `packages/types/src/agents.ts` | Add "triage" to AgentCategory union |
| `packages/orchestrator/src/execution-planner.ts` | Add triage phase to pipeline orderings |
| `apps/backend/src/index.ts` | Register DataTriageAgent with EmailTriageClassifier |

## Test plan

- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Verify existing email urgency scoring still works via InboxSurfaceAgent
- [ ] Verify triage phase runs between context and UI in system.poll pipeline
- [ ] Test EmailTriageClassifier produces correct urgency/category for promotional, personal, and actionable emails
- [ ] Test DataTriageAgent gracefully skips connectors without a matching classifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)