### PR TITLE
feat: rewrite LayoutComposer to produce briefings instead of surface grids

### DIFF
--- a/packages/agents/src/ui/layout-composer.ts
+++ b/packages/agents/src/ui/layout-composer.ts
@@ -4,8 +4,11 @@ import type {
   LayoutDirective,
 } from "@waibspace/ui-renderer-contract";
 import type { EngagementTracker, EngagementScore } from "@waibspace/memory";
+import { SurfaceFactory } from "@waibspace/surfaces";
+import type { BriefingCardSpec, BriefingSurfaceData } from "@waibspace/surfaces";
 import { BaseAgent } from "../base-agent";
 import type { AgentInput, AgentContext } from "../types";
+import type { TriageOutput, TriagedItem } from "../triage/types";
 
 const MAX_VISIBLE_SURFACES = 4;
 
@@ -14,6 +17,16 @@ const MAX_VISIBLE_SURFACES = 4;
  * A fully engaged surface (score=1) gets up to this many extra priority points.
  */
 const ENGAGEMENT_PRIORITY_BOOST = 30;
+
+/**
+ * Return a time-of-day greeting string.
+ */
+function getGreeting(): string {
+  const hour = new Date().getHours();
+  if (hour < 12) return "Good morning";
+  if (hour < 17) return "Good afternoon";
+  return "Good evening";
+}
 
 /**
  * Extract SurfaceSpec objects from a list of agent outputs.
@@ -46,6 +59,41 @@ export function extractSurfaces(outputs: AgentOutput[]): SurfaceSpec[] {
   return surfaces;
 }
 
+/**
+ * Extract TriageOutput from prior agent outputs, if any triage agent ran.
+ */
+function extractTriageOutput(outputs: AgentOutput[]): TriageOutput | null {
+  for (const out of outputs) {
+    const value = out.output as Record<string, unknown> | undefined;
+    if (!value || typeof value !== "object") continue;
+
+    // TriageOutput has items[], stats, classifierId, connectorId
+    if (
+      Array.isArray(value["items"]) &&
+      value["stats"] &&
+      typeof value["classifierId"] === "string" &&
+      typeof value["connectorId"] === "string"
+    ) {
+      return value as unknown as TriageOutput;
+    }
+
+    // Check nested `triageOutput` or `triage` fields
+    for (const key of ["triageOutput", "triage"] as const) {
+      const nested = value[key] as Record<string, unknown> | undefined;
+      if (
+        nested &&
+        typeof nested === "object" &&
+        Array.isArray(nested["items"]) &&
+        nested["stats"] &&
+        typeof nested["classifierId"] === "string"
+      ) {
+        return nested as unknown as TriageOutput;
+      }
+    }
+  }
+  return null;
+}
+
 function isSurfaceSpec(obj: Record<string, unknown>): boolean {
   return typeof obj["surfaceType"] === "string" && typeof obj["surfaceId"] === "string";
 }
@@ -55,6 +103,9 @@ function isSurfaceSpec(obj: Record<string, unknown>): boolean {
  *
  * Collects SurfaceSpec outputs from prior UI agents, resolves position
  * conflicts, generates LayoutDirectives, and returns a ComposedLayout.
+ *
+ * When triage data is available, transforms the layout into a briefing
+ * with intelligent cards instead of a raw surface grid.
  */
 export class LayoutComposerAgent extends BaseAgent {
   constructor() {
@@ -77,7 +128,183 @@ export class LayoutComposerAgent extends BaseAgent {
 
     this.log("Collected surfaces", { count: surfaces.length });
 
-    // 2. Retrieve engagement data if available
+    // 2. Check for triage data in priorOutputs
+    const triageOutput = extractTriageOutput(input.priorOutputs);
+
+    if (triageOutput) {
+      this.log("Triage data found, composing briefing", {
+        totalItems: triageOutput.stats.total,
+        highUrgency: triageOutput.stats.byUrgency.high ?? 0,
+        autoActions: triageOutput.autoActions?.length ?? 0,
+      });
+      return this.composeBriefingLayout(triageOutput, surfaces, context, startMs);
+    }
+
+    // 3. Fallback: grid-based layout (existing behavior)
+    this.log("No triage data, using grid layout");
+    return this.composeGridLayout(surfaces, context, startMs);
+  }
+
+  /**
+   * Compose a briefing-oriented layout from triage data.
+   *
+   * Transforms triaged items into briefing cards:
+   * - Main briefing card with greeting and summary stats
+   * - Action cards for high-urgency items needing attention
+   * - Insight card summarizing auto-handled items
+   * - Status card for connector health
+   */
+  private composeBriefingLayout(
+    triageOutput: TriageOutput,
+    surfaces: SurfaceSpec[],
+    context: AgentContext,
+    startMs: number,
+  ): AgentOutput {
+    const cards: BriefingCardSpec[] = [];
+
+    // --- Main Briefing Card ---
+    const { stats, items } = triageOutput;
+    const highCount = stats.byUrgency.high ?? 0;
+    const mediumCount = stats.byUrgency.medium ?? 0;
+    const lowCount = stats.byUrgency.low ?? 0;
+    const autoActionCount = triageOutput.autoActions?.length ?? 0;
+
+    cards.push({
+      cardType: "briefing-card",
+      priority: 100,
+      data: {
+        title: getGreeting(),
+        summary: `${stats.total} items triaged from ${triageOutput.connectorId}`,
+        urgentCount: highCount,
+        mediumCount,
+        lowCount,
+        handledCount: autoActionCount,
+      },
+    });
+
+    // --- Action Cards for high-urgency items ---
+    const urgentItems = items.filter(
+      (item: TriagedItem) => item.triage.urgency === "high",
+    );
+
+    for (const item of urgentItems) {
+      const raw = item.raw as Record<string, unknown>;
+      cards.push({
+        cardType: "action-card",
+        priority: 90,
+        data: {
+          itemId: item.triage.itemId,
+          from: raw["from"] ?? raw["sender"] ?? "Unknown",
+          subject: raw["subject"] ?? raw["title"] ?? "No subject",
+          snippet: raw["snippet"] ?? raw["body"] ?? "",
+          category: item.triage.category,
+          reasoning: item.triage.reasoning,
+          suggestedAction: item.triage.suggestedAction,
+          confidence: item.triage.confidence,
+          actions: ["approve", "edit", "dismiss"],
+        },
+      });
+    }
+
+    // --- Insight Card for auto-actions ---
+    if (autoActionCount > 0 || (triageOutput.memoryCandidates?.length ?? 0) > 0) {
+      const autoActions = triageOutput.autoActions ?? [];
+      const memoryCandidates = triageOutput.memoryCandidates ?? [];
+
+      const actionSummary: Record<string, number> = {};
+      for (const action of autoActions) {
+        actionSummary[action.type] = (actionSummary[action.type] ?? 0) + 1;
+      }
+
+      cards.push({
+        cardType: "insight-card",
+        priority: 60,
+        data: {
+          title: "Auto-handled",
+          autoActionCount,
+          actionBreakdown: actionSummary,
+          memoryCandidateCount: memoryCandidates.length,
+          memorySummaries: memoryCandidates.map((mc) => ({
+            domain: mc.domain,
+            summary: mc.summary,
+          })),
+        },
+      });
+    }
+
+    // --- Status Card ---
+    cards.push({
+      cardType: "status-card",
+      priority: 40,
+      data: {
+        connectorId: triageOutput.connectorId,
+        classifierId: triageOutput.classifierId,
+        itemsProcessed: stats.total,
+        categoryBreakdown: stats.byCategory,
+        timestamp: Date.now(),
+      },
+    });
+
+    // Sort cards by priority descending
+    cards.sort((a, b) => b.priority - a.priority);
+
+    // Build the briefing surface
+    const briefingData: BriefingSurfaceData = {
+      cards,
+      generatedAt: Date.now(),
+      mode: "initial",
+    };
+
+    const briefingSurface = SurfaceFactory.briefing(briefingData, {
+      sourceType: "system",
+      sourceId: "layout-composer",
+      trustLevel: "trusted",
+      timestamp: Date.now(),
+      freshness: "realtime",
+      dataState: "transformed",
+      transformations: ["triage-to-briefing"],
+    });
+
+    // Keep overlay surfaces (e.g., approvals) alongside the briefing
+    const overlays = surfaces.filter(
+      (s) => s.layoutHints.position === "overlay",
+    );
+
+    const allSurfaces = [briefingSurface, ...overlays];
+    const layout = this.buildDirectives(allSurfaces);
+
+    const endMs = Date.now();
+
+    const composed: ComposedLayout = {
+      surfaces: allSurfaces,
+      layout,
+      timestamp: Date.now(),
+      traceId: context.traceId,
+    };
+
+    return {
+      ...this.createOutput(composed, 1.0, {
+        dataState: "transformed",
+        transformations: ["triage-to-briefing", "layout-composition"],
+        timestamp: startMs,
+      }),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
+  }
+
+  /**
+   * Compose the original grid-based layout (fallback when no triage data).
+   */
+  private composeGridLayout(
+    surfaces: SurfaceSpec[],
+    context: AgentContext,
+    startMs: number,
+  ): AgentOutput {
+    // Retrieve engagement data if available
     const engagementTracker = context.config?.engagementTracker as
       | EngagementTracker
       | undefined;
@@ -95,28 +322,28 @@ export class LayoutComposerAgent extends BaseAgent {
       });
     }
 
-    // 3. Sort by priority, boosted by engagement score
+    // Sort by priority, boosted by engagement score
     surfaces.sort((a, b) => {
       const boostA = (scoreMap.get(a.surfaceType)?.score ?? 0) * ENGAGEMENT_PRIORITY_BOOST;
       const boostB = (scoreMap.get(b.surfaceType)?.score ?? 0) * ENGAGEMENT_PRIORITY_BOOST;
       return (b.priority + boostB) - (a.priority + boostA);
     });
 
-    // 4. Resolve position conflicts
+    // Resolve position conflicts
     const resolved = this.resolvePositions(surfaces);
 
-    // 5. Apply engagement-based prominence adjustments
+    // Apply engagement-based prominence adjustments
     const prominenceMap = engagementTracker?.getProminenceMap();
     const adjusted = prominenceMap
       ? this.applyEngagementProminence(resolved, prominenceMap)
       : resolved;
 
-    // 6. Generate LayoutDirectives (max 4 visible)
+    // Generate LayoutDirectives (max 4 visible)
     const layout = this.buildDirectives(adjusted);
 
     const endMs = Date.now();
 
-    // 7. Build ComposedLayout
+    // Build ComposedLayout
     const composed: ComposedLayout = {
       surfaces: adjusted,
       layout,

--- a/packages/surfaces/src/factories.ts
+++ b/packages/surfaces/src/factories.ts
@@ -8,6 +8,7 @@ import type {
   ConnectionGuideSurfaceData,
   MorningDigestSurfaceData,
   SearchSurfaceData,
+  BriefingSurfaceData,
 } from "./surface-data";
 
 export class SurfaceFactory {
@@ -192,6 +193,30 @@ export class SurfaceFactory {
       .setLayout({
         position: "primary",
         prominence: "hero",
+      })
+      .setProvenance(provenance)
+      .build();
+  }
+
+  static briefing(
+    data: BriefingSurfaceData,
+    provenance: ProvenanceMetadata
+  ): SurfaceSpec {
+    const cardCount = data.cards.length;
+    return new SurfaceSpecBuilder("briefing")
+      .setTitle("Your Briefing")
+      .setSummary(`${cardCount} card${cardCount !== 1 ? "s" : ""} ready`)
+      .setPriority(98)
+      .setData(data)
+      .setLayout({
+        position: "primary",
+        prominence: "hero",
+      })
+      .addAction({
+        id: "dismiss-briefing",
+        label: "Dismiss",
+        actionType: "briefing.dismiss",
+        riskClass: "A",
       })
       .setProvenance(provenance)
       .build();

--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -10,4 +10,6 @@ export type {
   ConnectionGuideSurfaceData,
   MorningDigestSurfaceData,
   SearchSurfaceData,
+  BriefingCardSpec,
+  BriefingSurfaceData,
 } from "./surface-data";

--- a/packages/surfaces/src/surface-data.ts
+++ b/packages/surfaces/src/surface-data.ts
@@ -150,3 +150,15 @@ export interface SearchSurfaceData {
   totalResults: number;
   sources: string[];
 }
+
+export interface BriefingCardSpec {
+  cardType: "briefing-card" | "action-card" | "insight-card" | "status-card";
+  data: Record<string, unknown>;
+  priority: number;
+}
+
+export interface BriefingSurfaceData {
+  cards: BriefingCardSpec[];
+  generatedAt: number;
+  mode: "initial" | "away-summary" | "update";
+}


### PR DESCRIPTION
## Summary

- **Adds briefing surface types** (`BriefingSurfaceData`, `BriefingCardSpec`) to `packages/surfaces/src/surface-data.ts` with four card types: `briefing-card`, `action-card`, `insight-card`, `status-card`
- **Adds `SurfaceFactory.briefing()`** factory method in `packages/surfaces/src/factories.ts` producing a high-priority hero surface
- **Rewrites LayoutComposer** to detect triage data in `priorOutputs` and transform it into an intelligent briefing layout with time-of-day greeting, urgent action cards, auto-action insight summaries, and connector status
- **Preserves backward compatibility** — falls back to the existing grid-based layout when no triage data is present

## How it works

When the triage system (Phase 3) classifies incoming data, `TriageOutput` flows through the pipeline in `priorOutputs`. The LayoutComposer now detects this and generates:

1. **Briefing Card** — greeting + summary stats (urgent/medium/low/auto-handled counts)
2. **Action Cards** — one per high-urgency item with context, reasoning, and approve/edit/dismiss actions
3. **Insight Card** — auto-handled action breakdown and memory candidates
4. **Status Card** — connector health and category breakdown

Overlay surfaces (e.g., approvals) are preserved alongside the briefing.

## Test plan

- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Pipeline with triage output produces briefing cards instead of grid
- [ ] Pipeline without triage output still produces grid layout (backward compat)
- [ ] Overlay surfaces (approvals) appear alongside briefings
- [ ] Greeting changes based on time of day

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)