### PR TITLE
feat: create BriefingCard, ActionCard, InsightCard, StatusCard block components

### DIFF
--- a/apps/frontend/src/blocks/components/domain/ActionCard.tsx
+++ b/apps/frontend/src/blocks/components/domain/ActionCard.tsx
@@ -1,0 +1,74 @@
+import type { BlockProps } from "../../registry";
+
+interface ActionButton {
+  id: string;
+  label: string;
+  variant: "primary" | "secondary" | "danger";
+}
+
+interface ActionCardData {
+  title: string;
+  context: string;
+  draftContent?: string;
+  riskClass: "A" | "B" | "C";
+  actions: ActionButton[];
+  source?: string;
+}
+
+const RISK_LABELS: Record<string, string> = {
+  A: "Low risk",
+  B: "Medium risk",
+  C: "High risk",
+};
+
+/**
+ * Action card where Waib has drafted something and needs user approval.
+ * Accent border colour reflects the risk classification.
+ */
+export function ActionCard({ block, onEvent }: BlockProps) {
+  const { title, context, draftContent, riskClass, actions, source } =
+    block.props as ActionCardData;
+
+  return (
+    <div className={`action-card action-card--risk-${riskClass.toLowerCase()}`}>
+      <div className="action-card__header">
+        <h3 className="action-card__title">{title}</h3>
+        <div className="action-card__badges">
+          <span
+            className={`action-card__risk-badge action-card__risk-badge--${riskClass.toLowerCase()}`}
+          >
+            {RISK_LABELS[riskClass] ?? riskClass}
+          </span>
+          {source && <span className="action-card__source-badge">{source}</span>}
+        </div>
+      </div>
+
+      <div className="action-card__context">{context}</div>
+
+      {draftContent && (
+        <div className="action-card__draft">
+          <div className="action-card__draft-label">Draft</div>
+          <div className="action-card__draft-content">{draftContent}</div>
+        </div>
+      )}
+
+      <div className="action-card__actions">
+        {actions.map((action) => (
+          <button
+            key={action.id}
+            type="button"
+            className={`action-card__btn action-card__btn--${action.variant}`}
+            onClick={() =>
+              onEvent?.("action-card-click", {
+                actionId: action.id,
+                label: action.label,
+              })
+            }
+          >
+            {action.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/blocks/components/domain/BriefingCard.tsx
+++ b/apps/frontend/src/blocks/components/domain/BriefingCard.tsx
@@ -1,0 +1,79 @@
+import type { BlockProps } from "../../registry";
+
+interface BriefingItem {
+  label: string;
+  detail?: string;
+  urgency: "high" | "medium" | "low";
+  actionId?: string;
+}
+
+interface BriefingCardData {
+  title: string;
+  items: BriefingItem[];
+  summary?: string;
+  timestamp?: number;
+}
+
+/**
+ * Briefing card summarising what needs the user's attention.
+ * Renders a list of items with urgency indicators.
+ */
+export function BriefingCard({ block, onEvent }: BlockProps) {
+  const { title, items, summary, timestamp } = block.props as BriefingCardData;
+
+  const formattedTime = timestamp
+    ? new Date(timestamp).toLocaleTimeString(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    : null;
+
+  return (
+    <div className="briefing-card">
+      <div className="briefing-card__header">
+        <h3 className="briefing-card__title">{title}</h3>
+        {formattedTime && (
+          <span className="briefing-card__timestamp">{formattedTime}</span>
+        )}
+      </div>
+
+      <ul className="briefing-card__items">
+        {items.map((item, idx) => (
+          <li
+            key={idx}
+            className={`briefing-card__item${item.actionId ? " briefing-card__item--actionable" : ""}`}
+            role={item.actionId ? "button" : undefined}
+            tabIndex={item.actionId ? 0 : undefined}
+            onClick={
+              item.actionId
+                ? () => onEvent?.("briefing-action", { actionId: item.actionId })
+                : undefined
+            }
+            onKeyDown={
+              item.actionId
+                ? (e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      onEvent?.("briefing-action", { actionId: item.actionId });
+                    }
+                  }
+                : undefined
+            }
+          >
+            <span
+              className={`briefing-card__urgency-dot briefing-card__urgency-dot--${item.urgency}`}
+              aria-label={`${item.urgency} urgency`}
+            />
+            <div className="briefing-card__item-content">
+              <span className="briefing-card__item-label">{item.label}</span>
+              {item.detail && (
+                <span className="briefing-card__item-detail">{item.detail}</span>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {summary && <p className="briefing-card__summary">{summary}</p>}
+    </div>
+  );
+}

--- a/apps/frontend/src/blocks/components/domain/InsightCard.tsx
+++ b/apps/frontend/src/blocks/components/domain/InsightCard.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import type { BlockProps } from "../../registry";
+
+interface InsightAction {
+  description: string;
+  count: number;
+}
+
+interface InsightCardData {
+  title: string;
+  actions: InsightAction[];
+  expandable?: boolean;
+  details?: string[];
+}
+
+/**
+ * Insight card showing what Waib did autonomously.
+ * Optionally expandable to reveal detail items.
+ */
+export function InsightCard({ block }: BlockProps) {
+  const { title, actions, expandable, details } =
+    block.props as InsightCardData;
+
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="insight-card">
+      <div className="insight-card__header">
+        <span className="insight-card__check" aria-hidden="true">
+          &#x2713;
+        </span>
+        <h3 className="insight-card__title">{title}</h3>
+      </div>
+
+      <ul className="insight-card__actions">
+        {actions.map((action, idx) => (
+          <li key={idx} className="insight-card__action">
+            <span className="insight-card__action-desc">
+              {action.description}
+            </span>
+            <span className="insight-card__action-count">{action.count}</span>
+          </li>
+        ))}
+      </ul>
+
+      {expandable && details && details.length > 0 && (
+        <div className="insight-card__expandable">
+          <button
+            type="button"
+            className="insight-card__toggle"
+            aria-expanded={expanded}
+            onClick={() => setExpanded((prev) => !prev)}
+          >
+            {expanded ? "Hide details" : "Show details"}
+          </button>
+          {expanded && (
+            <ul className="insight-card__details">
+              {details.map((detail, idx) => (
+                <li key={idx} className="insight-card__detail">
+                  {detail}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/blocks/components/domain/StatusCard.tsx
+++ b/apps/frontend/src/blocks/components/domain/StatusCard.tsx
@@ -1,0 +1,97 @@
+import type { BlockProps } from "../../registry";
+
+interface ConnectorStatus {
+  name: string;
+  status: "active" | "error" | "idle";
+  lastPoll?: string;
+}
+
+interface MemoryStats {
+  shortTerm: number;
+  midTerm: number;
+  longTerm: number;
+}
+
+interface StatusCardData {
+  title: string;
+  connectors: ConnectorStatus[];
+  memoryStats?: MemoryStats;
+  uptime?: string;
+}
+
+/**
+ * System status card showing connector health and memory statistics.
+ * Compact, information-dense layout.
+ */
+export function StatusCard({ block }: BlockProps) {
+  const { title, connectors, memoryStats, uptime } =
+    block.props as StatusCardData;
+
+  return (
+    <div className="status-card">
+      <div className="status-card__header">
+        <h3 className="status-card__title">{title}</h3>
+        {uptime && <span className="status-card__uptime">Up {uptime}</span>}
+      </div>
+
+      <div className="status-card__connectors">
+        {connectors.map((conn) => (
+          <div key={conn.name} className="status-card__connector">
+            <span
+              className={`status-card__status-dot status-card__status-dot--${conn.status}`}
+              aria-label={conn.status}
+            />
+            <span className="status-card__connector-name">{conn.name}</span>
+            {conn.lastPoll && (
+              <span className="status-card__last-poll">{conn.lastPoll}</span>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {memoryStats && (
+        <div className="status-card__memory">
+          <div className="status-card__memory-label">Memory</div>
+          <div className="status-card__memory-bars">
+            <div className="status-card__memory-item">
+              <span className="status-card__memory-name">Short</span>
+              <div className="status-card__memory-bar">
+                <div
+                  className="status-card__memory-fill status-card__memory-fill--short"
+                  style={{ width: `${Math.min(memoryStats.shortTerm, 100)}%` }}
+                />
+              </div>
+              <span className="status-card__memory-value">
+                {memoryStats.shortTerm}%
+              </span>
+            </div>
+            <div className="status-card__memory-item">
+              <span className="status-card__memory-name">Mid</span>
+              <div className="status-card__memory-bar">
+                <div
+                  className="status-card__memory-fill status-card__memory-fill--mid"
+                  style={{ width: `${Math.min(memoryStats.midTerm, 100)}%` }}
+                />
+              </div>
+              <span className="status-card__memory-value">
+                {memoryStats.midTerm}%
+              </span>
+            </div>
+            <div className="status-card__memory-item">
+              <span className="status-card__memory-name">Long</span>
+              <div className="status-card__memory-bar">
+                <div
+                  className="status-card__memory-fill status-card__memory-fill--long"
+                  style={{ width: `${Math.min(memoryStats.longTerm, 100)}%` }}
+                />
+              </div>
+              <span className="status-card__memory-value">
+                {memoryStats.longTerm}%
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/blocks/components/domain/index.ts
+++ b/apps/frontend/src/blocks/components/domain/index.ts
@@ -1,7 +1,11 @@
-import { registerBlock } from "../../registry";
+import { registerBlock, registerBlocks } from "../../registry";
 import { registerGmailComponents } from "./gmail";
 import { registerCalendarComponents } from "./gcal";
 import { ErrorSurface } from "./ErrorSurface";
+import { BriefingCard } from "./BriefingCard";
+import { ActionCard } from "./ActionCard";
+import { InsightCard } from "./InsightCard";
+import { StatusCard } from "./StatusCard";
 
 /**
  * Register all domain-specific block components.
@@ -18,4 +22,51 @@ export function registerDomainComponents(): void {
     description:
       "Error surface displayed when a connector or API call fails, with optional retry",
   });
+
+  registerBlocks([
+    {
+      type: "briefing-card",
+      component: BriefingCard,
+      registration: {
+        type: "briefing-card",
+        category: "domain",
+        source: "builtin",
+        description:
+          "Briefing card summarising what needs the user's attention",
+      },
+    },
+    {
+      type: "action-card",
+      component: ActionCard,
+      registration: {
+        type: "action-card",
+        category: "domain",
+        source: "builtin",
+        description:
+          "Action card with drafted content requiring user approval",
+      },
+    },
+    {
+      type: "insight-card",
+      component: InsightCard,
+      registration: {
+        type: "insight-card",
+        category: "domain",
+        source: "builtin",
+        description:
+          "Insight card showing autonomous actions Waib performed",
+      },
+    },
+    {
+      type: "status-card",
+      component: StatusCard,
+      registration: {
+        type: "status-card",
+        category: "domain",
+        source: "builtin",
+        description:
+          "System status card with connector health and memory statistics",
+      },
+    },
+  ]);
 }

--- a/apps/frontend/src/styles/briefing-components.css
+++ b/apps/frontend/src/styles/briefing-components.css
@@ -1,0 +1,554 @@
+/* ================================================================
+   Briefing Components — BriefingCard, ActionCard, InsightCard, StatusCard
+   BEM naming · CSS custom properties from global design tokens
+   ================================================================ */
+
+/* --------------------------------
+   BriefingCard
+   -------------------------------- */
+.briefing-card {
+  background: var(--color-surface);
+  border: var(--block-card-border);
+  border-radius: var(--block-card-radius);
+  box-shadow: var(--block-card-shadow);
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.briefing-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.briefing-card__title {
+  margin: 0;
+  font-size: var(--text-md);
+  font-weight: var(--weight-bold);
+  color: var(--color-text);
+  line-height: var(--leading-tight);
+}
+
+.briefing-card__timestamp {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  white-space: nowrap;
+}
+
+.briefing-card__items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.briefing-card__item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast);
+}
+
+.briefing-card__item--actionable {
+  cursor: pointer;
+}
+
+.briefing-card__item--actionable:hover {
+  background: var(--color-surface-hover);
+}
+
+.briefing-card__urgency-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  margin-top: 5px;
+}
+
+.briefing-card__urgency-dot--high {
+  background: var(--color-danger);
+  box-shadow: 0 0 6px var(--color-danger-subtle);
+}
+
+.briefing-card__urgency-dot--medium {
+  background: var(--color-warning);
+}
+
+.briefing-card__urgency-dot--low {
+  background: var(--color-neutral);
+}
+
+.briefing-card__item-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.briefing-card__item-label {
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+}
+
+.briefing-card__item-detail {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.briefing-card__summary {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+  line-height: var(--leading-normal);
+  padding-top: var(--space-1);
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+/* --------------------------------
+   ActionCard
+   -------------------------------- */
+.action-card {
+  background: var(--color-surface);
+  border: var(--block-card-border);
+  border-radius: var(--block-card-radius);
+  box-shadow: var(--block-card-shadow);
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  border-left: 3px solid var(--color-border);
+}
+
+.action-card--risk-a {
+  border-left-color: var(--color-success);
+}
+
+.action-card--risk-b {
+  border-left-color: var(--color-warning);
+}
+
+.action-card--risk-c {
+  border-left-color: var(--color-danger);
+}
+
+.action-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.action-card__title {
+  margin: 0;
+  font-size: var(--text-md);
+  font-weight: var(--weight-bold);
+  color: var(--color-text);
+  line-height: var(--leading-tight);
+}
+
+.action-card__badges {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.action-card__risk-badge {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.action-card__risk-badge--a {
+  background: var(--color-success-subtle);
+  color: var(--color-success-text);
+}
+
+.action-card__risk-badge--b {
+  background: var(--color-warning-subtle);
+  color: var(--color-warning-text);
+}
+
+.action-card__risk-badge--c {
+  background: var(--color-danger-subtle);
+  color: var(--color-danger-text);
+}
+
+.action-card__source-badge {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  background: var(--color-neutral-subtle);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+}
+
+.action-card__context {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  line-height: var(--leading-normal);
+}
+
+.action-card__draft {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.action-card__draft-label {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-elevated);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.action-card__draft-content {
+  font-size: var(--text-base);
+  color: var(--color-text);
+  padding: var(--space-3);
+  line-height: var(--leading-relaxed);
+  white-space: pre-wrap;
+}
+
+.action-card__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding-top: var(--space-1);
+}
+
+.action-card__btn {
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.action-card__btn--primary {
+  background: var(--color-accent);
+  color: #fff;
+  border-color: var(--color-accent);
+}
+
+.action-card__btn--primary:hover {
+  background: var(--color-accent-hover);
+}
+
+.action-card__btn--secondary {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border-color: var(--color-border-strong);
+}
+
+.action-card__btn--secondary:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.action-card__btn--danger {
+  background: transparent;
+  color: var(--color-danger-text);
+  border-color: var(--color-danger-subtle);
+}
+
+.action-card__btn--danger:hover {
+  background: var(--color-danger-subtle);
+}
+
+/* --------------------------------
+   InsightCard
+   -------------------------------- */
+.insight-card {
+  background: var(--color-surface);
+  border: var(--block-card-border);
+  border-radius: var(--block-card-radius);
+  box-shadow: var(--block-card-shadow);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.insight-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.insight-card__check {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+  background: var(--color-success-subtle);
+  color: var(--color-success-text);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+}
+
+.insight-card__title {
+  margin: 0;
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  line-height: var(--leading-tight);
+}
+
+.insight-card__actions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.insight-card__action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-sm);
+}
+
+.insight-card__action-desc {
+  color: var(--color-text-secondary);
+}
+
+.insight-card__action-count {
+  flex-shrink: 0;
+  min-width: 22px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  background: var(--color-accent-subtle);
+  border-radius: var(--radius-full);
+  padding: 0 var(--space-2);
+}
+
+.insight-card__expandable {
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--space-2);
+}
+
+.insight-card__toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--color-accent);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.insight-card__toggle:hover {
+  color: var(--color-accent-hover);
+}
+
+.insight-card__details {
+  list-style: none;
+  margin: var(--space-2) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.insight-card__detail {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  padding-left: var(--space-3);
+  position: relative;
+}
+
+.insight-card__detail::before {
+  content: "\2022";
+  position: absolute;
+  left: 0;
+  color: var(--color-muted);
+}
+
+/* --------------------------------
+   StatusCard
+   -------------------------------- */
+.status-card {
+  background: var(--color-surface);
+  border: var(--block-card-border);
+  border-radius: var(--block-card-radius);
+  box-shadow: var(--block-card-shadow);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.status-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.status-card__title {
+  margin: 0;
+  font-size: var(--text-md);
+  font-weight: var(--weight-bold);
+  color: var(--color-text);
+}
+
+.status-card__uptime {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+}
+
+.status-card__connectors {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: var(--space-2);
+}
+
+.status-card__connector {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  font-size: var(--text-sm);
+}
+
+.status-card__status-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+}
+
+.status-card__status-dot--active {
+  background: var(--color-success);
+  box-shadow: 0 0 6px var(--color-success-subtle);
+}
+
+.status-card__status-dot--error {
+  background: var(--color-danger);
+  box-shadow: 0 0 6px var(--color-danger-subtle);
+}
+
+.status-card__status-dot--idle {
+  background: var(--color-neutral);
+}
+
+.status-card__connector-name {
+  color: var(--color-text);
+  font-weight: var(--weight-medium);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-card__last-poll {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  white-space: nowrap;
+}
+
+.status-card__memory {
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.status-card__memory-label {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-card__memory-bars {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.status-card__memory-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.status-card__memory-name {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  width: 36px;
+  flex-shrink: 0;
+}
+
+.status-card__memory-bar {
+  flex: 1;
+  height: 4px;
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+.status-card__memory-fill {
+  height: 100%;
+  border-radius: var(--radius-full);
+  transition: width var(--transition-base);
+}
+
+.status-card__memory-fill--short {
+  background: var(--color-accent);
+}
+
+.status-card__memory-fill--mid {
+  background: var(--color-info);
+}
+
+.status-card__memory-fill--long {
+  background: var(--color-success);
+}
+
+.status-card__memory-value {
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  width: 32px;
+  text-align: right;
+  flex-shrink: 0;
+}

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -1,4 +1,5 @@
 @import "./block-error.css";
+@import "./briefing-components.css";
 @import "./calendar-components.css";
 @import "./error-surface.css";
 @import "./health-dashboard.css";


### PR DESCRIPTION
## Summary
- Add four new domain block components: **BriefingCard**, **ActionCard**, **InsightCard**, and **StatusCard**
- Register all four as domain blocks (`briefing-card`, `action-card`, `insight-card`, `status-card`) in the block registry
- Add BEM CSS styles in a dedicated `briefing-components.css` file using existing dark theme design tokens

## Components

| Block type | Purpose |
|---|---|
| `briefing-card` | Summarises what needs the user's attention, with urgency-colored indicators |
| `action-card` | Presents Waib's drafted actions with risk classification (A/B/C) and approval buttons |
| `insight-card` | Shows what Waib did autonomously, with expandable detail list |
| `status-card` | Displays connector health (green/red/gray dots) and memory usage bars |

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Verify each component renders correctly when fed matching block data
- [ ] Confirm CSS follows BEM naming and uses only CSS custom properties from the theme
- [ ] No inline styles used

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)