### PR TITLE
feat: proactive overlay alerts via WebSocket push for high-urgency items

### DIFF
--- a/apps/backend/src/alert-emitter.ts
+++ b/apps/backend/src/alert-emitter.ts
@@ -1,0 +1,84 @@
+import { EventBus, createEvent } from "@waibspace/event-bus";
+
+export interface AlertPayload {
+  itemId: string;
+  cardType: "action-card";
+  title: string;
+  context: string;
+  urgency: "high";
+  source: string;
+  suggestedAction?: string;
+  timestamp: number;
+}
+
+export class AlertEmitter {
+  private sentAlerts = new Map<string, number>(); // itemId -> timestamp
+  private readonly dedupeWindowMs = 5 * 60 * 1000; // 5 minutes
+
+  constructor(private bus: EventBus) {}
+
+  /**
+   * Check triage results and emit alerts for high-urgency items.
+   * Deduplicates: won't send the same alert twice within the window.
+   */
+  emitAlerts(
+    triageItems: Array<{
+      raw: unknown;
+      triage: {
+        itemId: string;
+        urgency: string;
+        category: string;
+        reasoning?: string;
+        suggestedAction?: string;
+      };
+    }>,
+    connectorId: string,
+    traceId: string,
+  ): void {
+    const now = Date.now();
+    this.cleanStaleEntries(now);
+
+    for (const item of triageItems) {
+      if (item.triage.urgency !== "high") continue;
+      if (this.sentAlerts.has(item.triage.itemId)) continue;
+
+      const raw = item.raw as Record<string, unknown>;
+      const payload: AlertPayload = {
+        itemId: item.triage.itemId,
+        cardType: "action-card",
+        title:
+          (raw.subject as string) ??
+          (raw.title as string) ??
+          "Urgent item",
+        context: `From ${(raw.from as string) ?? (raw.sender as string) ?? "unknown"} via ${connectorId}`,
+        urgency: "high",
+        source: connectorId,
+        suggestedAction: item.triage.suggestedAction,
+        timestamp: now,
+      };
+
+      const event = createEvent(
+        "briefing.alert",
+        payload,
+        "alert-emitter",
+        traceId,
+      );
+      this.bus.emit(event);
+
+      this.sentAlerts.set(item.triage.itemId, now);
+    }
+  }
+
+  private cleanStaleEntries(now: number): void {
+    for (const [id, timestamp] of this.sentAlerts) {
+      if (now - timestamp > this.dedupeWindowMs) {
+        this.sentAlerts.delete(id);
+      }
+    }
+  }
+
+  /** Reset tracking (e.g., when user acknowledges all alerts). */
+  clearTracking(): void {
+    this.sentAlerts.clear();
+  }
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -57,6 +57,7 @@ import { BackgroundTaskScheduler, MVP_BACKGROUND_TASKS } from "./background";
 import { TaskScheduler } from "./scheduler";
 import { startServer } from "./server";
 import { broadcast } from "./ws";
+import { AlertEmitter } from "./alert-emitter";
 
 // ---------- 1. Event Bus ----------
 const bus = new EventBus();
@@ -225,6 +226,28 @@ const orchestrator = new Orchestrator(bus, agentRegistry, {
   triageFeedbackTracker,
 });
 
+// ---------- 7b. Alert Emitter ----------
+const alertEmitter = new AlertEmitter(bus);
+
+// Subscribe to triage results with high-urgency items and emit proactive alerts
+bus.on("triage.high_urgency", (event: WaibEvent) => {
+  const payload = event.payload as {
+    triageItems: Array<{
+      raw: unknown;
+      triage: {
+        itemId: string;
+        urgency: string;
+        category: string;
+        reasoning?: string;
+        suggestedAction?: string;
+      };
+    }>;
+    connectorId: string;
+  };
+  alertEmitter.emitAlerts(payload.triageItems, payload.connectorId, event.traceId);
+});
+log.info("Alert emitter initialized");
+
 // ---------- 8. Memory Update Pipeline ----------
 const memoryPipeline = new MemoryUpdatePipeline(memoryStore, bus);
 memoryPipeline.start();
@@ -385,6 +408,29 @@ bus.on("background.task.complete", (event: WaibEvent) => {
   log.child({ traceId: event.traceId }).info("Broadcasting task.complete", {
     taskId: payload.taskId,
     success: payload.success,
+  });
+  broadcast(message);
+});
+
+// ---------- 11c. Broadcast proactive alerts to WebSocket clients ----------
+bus.on("briefing.alert", (event: WaibEvent) => {
+  const payload = event.payload as {
+    itemId: string;
+    cardType: string;
+    title: string;
+    context: string;
+    urgency: string;
+    source: string;
+    suggestedAction?: string;
+    timestamp: number;
+  };
+  const message: ServerMessage = {
+    type: "briefing.alert",
+    payload,
+  };
+  log.child({ traceId: event.traceId }).info("Broadcasting briefing.alert", {
+    itemId: payload.itemId,
+    title: payload.title,
   });
   broadcast(message);
 });

--- a/apps/frontend/src/components/OverlayAlerts.tsx
+++ b/apps/frontend/src/components/OverlayAlerts.tsx
@@ -1,0 +1,79 @@
+import { useState, useEffect, useCallback } from "react";
+import type { WebSocketMessage } from "../hooks/useWebSocket";
+
+interface AlertData {
+  itemId: string;
+  cardType: string;
+  title: string;
+  context: string;
+  urgency: string;
+  source: string;
+  suggestedAction?: string;
+  timestamp: number;
+}
+
+const MAX_VISIBLE = 3;
+const AUTO_DISMISS_MS = 30_000;
+
+interface OverlayAlertsProps {
+  lastMessage: WebSocketMessage | null;
+}
+
+export function OverlayAlerts({ lastMessage }: OverlayAlertsProps) {
+  const [alerts, setAlerts] = useState<AlertData[]>([]);
+
+  // Listen for briefing.alert events from WebSocket
+  useEffect(() => {
+    if (!lastMessage || lastMessage.type !== "briefing.alert") return;
+
+    const payload = lastMessage.payload as AlertData;
+    setAlerts((prev) => {
+      // Deduplicate by itemId
+      const exists = prev.some((a) => a.itemId === payload.itemId);
+      if (exists) return prev;
+      // Keep only the most recent MAX_VISIBLE alerts
+      return [...prev.slice(-(MAX_VISIBLE - 1)), payload];
+    });
+  }, [lastMessage]);
+
+  // Auto-dismiss after timeout
+  useEffect(() => {
+    if (alerts.length === 0) return;
+    const timer = setTimeout(() => {
+      setAlerts((prev) => prev.slice(1)); // Remove oldest
+    }, AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [alerts]);
+
+  const dismiss = useCallback((itemId: string) => {
+    setAlerts((prev) => prev.filter((a) => a.itemId !== itemId));
+  }, []);
+
+  if (alerts.length === 0) return null;
+
+  return (
+    <div className="overlay-alerts">
+      {alerts.slice(0, MAX_VISIBLE).map((alert) => (
+        <div key={alert.itemId} className="overlay-alerts__card">
+          <div className="overlay-alerts__header">
+            <span className="overlay-alerts__urgency-dot" />
+            <span className="overlay-alerts__title">{alert.title}</span>
+            <button
+              className="overlay-alerts__dismiss"
+              onClick={() => dismiss(alert.itemId)}
+              aria-label="Dismiss alert"
+            >
+              &times;
+            </button>
+          </div>
+          <div className="overlay-alerts__context">{alert.context}</div>
+          {alert.suggestedAction && (
+            <div className="overlay-alerts__action">
+              Suggested: {alert.suggestedAction}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -21,6 +21,7 @@ import { NotificationStack } from "../components/NotificationToast";
 import { useActionHistory } from "../hooks/useActionHistory";
 import type { ReversibleAction } from "../hooks/useActionHistory";
 import { UndoToast } from "../components/UndoToast";
+import { OverlayAlerts } from "../components/OverlayAlerts";
 
 const WS_URL = `ws://${window.location.hostname}:${import.meta.env.VITE_WS_PORT || 3001}/ws`;
 const API_BASE = `http://${window.location.hostname}:${import.meta.env.VITE_WS_PORT || 3001}`;
@@ -324,6 +325,7 @@ export default function HomePage() {
 
   return (
     <div className="page home-page">
+      <OverlayAlerts lastMessage={lastMessage} />
       <NotificationStack notifications={notifications} onDismiss={dismissNotification} />
       {status !== "connected" && (
         <div className={`connection-banner ${status === "reconnecting" ? "connecting" : status}`}>

--- a/apps/frontend/src/styles/briefing-components.css
+++ b/apps/frontend/src/styles/briefing-components.css
@@ -552,3 +552,93 @@
   text-align: right;
   flex-shrink: 0;
 }
+
+/* --------------------------------
+   Overlay Alerts
+   -------------------------------- */
+.overlay-alerts {
+  position: fixed;
+  top: var(--space-4);
+  right: var(--space-4);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 380px;
+}
+
+.overlay-alerts__card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-danger);
+  border-radius: var(--block-card-radius);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  padding: var(--space-4);
+  animation: slideInRight 0.3s ease-out;
+}
+
+@keyframes slideInRight {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.overlay-alerts__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.overlay-alerts__urgency-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--color-danger);
+  box-shadow: 0 0 6px var(--color-danger-subtle);
+}
+
+.overlay-alerts__title {
+  flex: 1;
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.overlay-alerts__dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  font-size: var(--text-md);
+  color: var(--color-muted);
+  cursor: pointer;
+  padding: 0 var(--space-1);
+  line-height: 1;
+  transition: color var(--transition-fast);
+}
+
+.overlay-alerts__dismiss:hover {
+  color: var(--color-text);
+}
+
+.overlay-alerts__context {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+}
+
+.overlay-alerts__action {
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-accent);
+  font-weight: var(--weight-medium);
+}

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -225,9 +225,12 @@ export class Orchestrator {
       // Accumulate outputs for the next phase
       priorOutputs = [...priorOutputs, ...phaseOutputs];
 
-      // After triage phase: store memory candidates in mid-term memory
-      if (phase.category === "triage" && this.options?.midTermMemory) {
-        this.storeTriageMemoryCandidates(phaseOutputs, traceId);
+      // After triage phase: store memory candidates and emit triage results
+      if (phase.category === "triage") {
+        if (this.options?.midTermMemory) {
+          this.storeTriageMemoryCandidates(phaseOutputs, traceId);
+        }
+        this.emitTriageResults(phaseOutputs, event, traceId);
       }
 
       // Emit phase progress so the frontend can show incremental loading state
@@ -359,6 +362,45 @@ export class Orchestrator {
 
     // Clean up per-trace short-term memory
     this.options?.shortTermMemoryManager?.destroy(traceId);
+  }
+
+  /**
+   * Emit triage results onto the event bus so downstream consumers
+   * (e.g. AlertEmitter) can react to high-urgency items.
+   */
+  private emitTriageResults(
+    phaseOutputs: AgentOutput[],
+    event: WaibEvent,
+    traceId: string,
+  ): void {
+    for (const output of phaseOutputs) {
+      const triageOutputs = output.output as unknown;
+      if (!Array.isArray(triageOutputs)) continue;
+
+      for (const triageOutput of triageOutputs as TriageOutput[]) {
+        if (!triageOutput.items || triageOutput.items.length === 0) continue;
+
+        const hasHighUrgency = triageOutput.items.some(
+          (item) => item.triage.urgency === "high",
+        );
+        if (!hasHighUrgency) continue;
+
+        // Use createEvent with the type cast — "triage.high_urgency" is an
+        // internal bus event consumed by AlertEmitter; it is not a
+        // WaibEventType sent to clients.
+        const triageEvent = createEvent(
+          "triage.high_urgency" as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          {
+            triageItems: triageOutput.items,
+            connectorId: triageOutput.connectorId,
+            eventType: event.type,
+          },
+          "orchestrator",
+          traceId,
+        );
+        this.eventBus.emit(triageEvent);
+      }
+    }
   }
 
   /**

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -19,6 +19,7 @@ export type WaibEventType =
   | "background.task.triggered"
   | "background.task.complete"
   | "system.poll"
+  | "briefing.alert"
   | "memory.updated";
 
 export interface WaibEvent {

--- a/packages/ui-renderer-contract/src/messages.ts
+++ b/packages/ui-renderer-contract/src/messages.ts
@@ -23,6 +23,19 @@ export type ServerMessage =
         durationMs: number;
         error?: string;
       };
+    }
+  | {
+      type: "briefing.alert";
+      payload: {
+        itemId: string;
+        cardType: string;
+        title: string;
+        context: string;
+        urgency: string;
+        source: string;
+        suggestedAction?: string;
+        timestamp: number;
+      };
     };
 
 // Frontend → Backend messages


### PR DESCRIPTION
## Summary
- Adds end-to-end proactive alert system: when background polling triage detects high-urgency items, overlay alert cards are pushed to the UI via WebSocket in real time
- New `AlertEmitter` backend module with 5-minute deduplication window prevents alert spam
- New `OverlayAlerts` React component renders up to 3 stacked cards with slide-in animation, auto-dismiss after 30s, and manual dismiss

## Changes
- **`packages/types/src/events.ts`** — Added `"briefing.alert"` to `WaibEventType` union
- **`packages/ui-renderer-contract/src/messages.ts`** — Added `"briefing.alert"` variant to `ServerMessage` type
- **`apps/backend/src/alert-emitter.ts`** — New `AlertEmitter` class that filters high-urgency triage items, deduplicates, and emits `briefing.alert` events
- **`packages/orchestrator/src/orchestrator.ts`** — Emits `triage.high_urgency` internal event after triage phase when high-urgency items are found
- **`apps/backend/src/index.ts`** — Wires AlertEmitter to bus, subscribes to `triage.high_urgency` and broadcasts `briefing.alert` to WebSocket clients
- **`apps/frontend/src/components/OverlayAlerts.tsx`** — New component that listens for `briefing.alert` WebSocket messages and renders overlay cards
- **`apps/frontend/src/pages/HomePage.tsx`** — Mounts `OverlayAlerts` at the top level
- **`apps/frontend/src/styles/briefing-components.css`** — Overlay alert styles with slide-in animation

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] With mock connectors, trigger a poll that returns high-urgency items and verify overlay cards appear
- [ ] Verify duplicate alerts within 5 minutes are suppressed
- [ ] Verify auto-dismiss after 30 seconds
- [ ] Verify manual dismiss via X button
- [ ] Verify max 3 alerts visible at once

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)