### PR TITLE
feat: track approval/rejection patterns per action type per domain

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -38,6 +38,8 @@ import {
   EmailTriageClassifier,
   TriageMemoryIntegrator,
   TriageFeedbackTracker,
+  // Trust tracking
+  ApprovalTracker,
 } from "@waibspace/agents";
 import {
   ConnectorRegistry,
@@ -196,6 +198,10 @@ const triageMemoryIntegrator = new TriageMemoryIntegrator(midTermMemory, longTer
 const triageFeedbackTracker = new TriageFeedbackTracker(midTermMemory);
 log.info("Triage memory integrator and feedback tracker initialized");
 
+// ---------- 6. Approval Tracker ----------
+const approvalTracker = new ApprovalTracker(midTermMemory);
+log.info("Approval tracker initialized");
+
 // ---------- 6a. Engagement Tracker ----------
 const engagementTracker = new EngagementTracker(memoryStore);
 log.info("Engagement tracker initialized");
@@ -224,6 +230,7 @@ const orchestrator = new Orchestrator(bus, agentRegistry, {
   longTermMemory,
   triageMemoryIntegrator,
   triageFeedbackTracker,
+  approvalTracker,
 });
 
 // ---------- 7b. Alert Emitter ----------

--- a/packages/agents/src/execution/action-executor.ts
+++ b/packages/agents/src/execution/action-executor.ts
@@ -3,6 +3,7 @@ import type { ConnectorRegistry, ConnectorAction } from "@waibspace/connectors";
 import { SurfaceFactory } from "@waibspace/surfaces";
 import { BaseAgent } from "../base-agent";
 import type { AgentInput, AgentContext } from "../types";
+import type { ApprovalTracker } from "../trust";
 
 /**
  * Executes approved actions by invoking the appropriate connector.
@@ -60,6 +61,9 @@ export class ActionExecutorAgent extends BaseAgent {
       } catch {
         // Store update failure is non-critical
       }
+
+      // Track the rejection decision
+      this.trackDecision(context, pendingAction, false);
 
       const confirmSurface = SurfaceFactory.generic(
         "Action Denied",
@@ -237,6 +241,9 @@ export class ActionExecutorAgent extends BaseAgent {
         // non-critical
       }
 
+      // Track the approval decision
+      this.trackDecision(context, pendingAction, true);
+
       const successSurface = SurfaceFactory.generic(
         "Action Executed",
         {
@@ -308,6 +315,43 @@ export class ActionExecutorAgent extends BaseAgent {
         timing: { startMs, endMs, durationMs: endMs - startMs },
       };
     }
+  }
+
+  /**
+   * Track an approval or rejection decision via the ApprovalTracker (if available).
+   */
+  private trackDecision(
+    context: AgentContext,
+    pendingAction: { actionType: string; actionContext?: unknown } | undefined,
+    approved: boolean,
+  ): void {
+    const approvalTracker = context.config?.["approvalTracker"] as
+      | ApprovalTracker
+      | undefined;
+    if (!approvalTracker || !pendingAction) return;
+
+    try {
+      const actionCtx = pendingAction.actionContext as Record<string, unknown> | undefined;
+      const domain = (actionCtx?.domain as string) ?? this.inferDomain(pendingAction.actionType);
+      approvalTracker.recordDecision({
+        actionType: pendingAction.actionType,
+        domain,
+        approved,
+        timestamp: Date.now(),
+        context: actionCtx,
+      });
+    } catch {
+      // Tracking failure is non-critical
+    }
+  }
+
+  /**
+   * Infer a domain from the action type when no explicit domain is available.
+   * e.g., "email.send" -> "email", "slack.reply" -> "slack"
+   */
+  private inferDomain(actionType: string): string {
+    const dotIndex = actionType.indexOf(".");
+    return dotIndex > 0 ? actionType.slice(0, dotIndex) : actionType;
   }
 
   /**

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -69,3 +69,9 @@ export {
   type MemoryCandidate,
 } from "./triage";
 export { ActionExecutorAgent } from "./execution";
+export {
+  ApprovalTracker,
+  type ApprovalRecord,
+  type ApprovalStats,
+  type TrustEscalation,
+} from "./trust";

--- a/packages/agents/src/trust/approval-tracker.ts
+++ b/packages/agents/src/trust/approval-tracker.ts
@@ -1,0 +1,99 @@
+import type { MidTermMemory } from "@waibspace/memory";
+import type { ApprovalRecord, ApprovalStats, TrustEscalation } from "./types";
+
+export class ApprovalTracker {
+  private records: ApprovalRecord[] = [];
+  private readonly maxRecords = 500;
+  private readonly escalationThreshold = 5; // consecutive approvals needed
+
+  constructor(private midTerm: MidTermMemory) {}
+
+  /**
+   * Record an approval or rejection decision.
+   */
+  recordDecision(record: ApprovalRecord): void {
+    this.records.push(record);
+    if (this.records.length > this.maxRecords) {
+      this.records = this.records.slice(-this.maxRecords);
+    }
+
+    // Persist stats to mid-term memory
+    const stats = this.getStats(record.actionType, record.domain);
+    this.midTerm.store(
+      "trust:approvals",
+      `${record.actionType}:${record.domain}`,
+      JSON.stringify(stats),
+    );
+  }
+
+  /**
+   * Get approval stats for a specific action type and domain.
+   */
+  getStats(actionType: string, domain: string): ApprovalStats {
+    const relevant = this.records.filter(
+      (r) => r.actionType === actionType && r.domain === domain,
+    );
+
+    // Count consecutive approvals from the end
+    let consecutive = 0;
+    for (let i = relevant.length - 1; i >= 0; i--) {
+      if (relevant[i].approved) consecutive++;
+      else break;
+    }
+
+    return {
+      actionType,
+      domain,
+      totalCount: relevant.length,
+      approvedCount: relevant.filter((r) => r.approved).length,
+      rejectedCount: relevant.filter((r) => !r.approved).length,
+      consecutiveApprovals: consecutive,
+      lastDecisionAt:
+        relevant.length > 0 ? relevant[relevant.length - 1].timestamp : 0,
+    };
+  }
+
+  /**
+   * Check if any action+domain pair qualifies for trust escalation.
+   */
+  checkEscalations(): TrustEscalation[] {
+    // Group records by actionType + domain, check each for threshold
+    const pairs = new Map<string, { actionType: string; domain: string }>();
+    for (const r of this.records) {
+      pairs.set(`${r.actionType}:${r.domain}`, {
+        actionType: r.actionType,
+        domain: r.domain,
+      });
+    }
+
+    const escalations: TrustEscalation[] = [];
+    for (const { actionType, domain } of pairs.values()) {
+      const stats = this.getStats(actionType, domain);
+      if (stats.consecutiveApprovals >= this.escalationThreshold) {
+        escalations.push({
+          actionType,
+          domain,
+          currentConsecutive: stats.consecutiveApprovals,
+          threshold: this.escalationThreshold,
+          suggestion: `Auto-approve "${actionType}" for ${domain}?`,
+          reasoning: `${stats.consecutiveApprovals} consecutive approvals without changes`,
+        });
+      }
+    }
+    return escalations;
+  }
+
+  /** Get all tracked stats. */
+  getAllStats(): ApprovalStats[] {
+    const pairs = new Map<string, { actionType: string; domain: string }>();
+    for (const r of this.records) {
+      pairs.set(`${r.actionType}:${r.domain}`, {
+        actionType: r.actionType,
+        domain: r.domain,
+      });
+    }
+    return [...pairs.values()].map((p) =>
+      this.getStats(p.actionType, p.domain),
+    );
+  }
+}

--- a/packages/agents/src/trust/index.ts
+++ b/packages/agents/src/trust/index.ts
@@ -1,0 +1,6 @@
+export { ApprovalTracker } from "./approval-tracker";
+export type {
+  ApprovalRecord,
+  ApprovalStats,
+  TrustEscalation,
+} from "./types";

--- a/packages/agents/src/trust/types.ts
+++ b/packages/agents/src/trust/types.ts
@@ -1,0 +1,27 @@
+export interface ApprovalRecord {
+  actionType: string;      // e.g., "email.send", "slack.reply"
+  domain: string;          // e.g., "email:professional", "slack:work"
+  approved: boolean;
+  timestamp: number;
+  /** Optional context about the specific action (e.g., recipient) */
+  context?: Record<string, unknown>;
+}
+
+export interface ApprovalStats {
+  actionType: string;
+  domain: string;
+  totalCount: number;
+  approvedCount: number;
+  rejectedCount: number;
+  consecutiveApprovals: number;
+  lastDecisionAt: number;
+}
+
+export interface TrustEscalation {
+  actionType: string;
+  domain: string;
+  currentConsecutive: number;
+  threshold: number;
+  suggestion: string;       // Human-readable suggestion
+  reasoning: string;
+}


### PR DESCRIPTION
## Summary
- Adds `ApprovalTracker` class that records user approval/rejection decisions per action type per domain, persisting stats to mid-term memory
- Introduces trust escalation detection: when consecutive approvals reach a threshold (default 5), surfaces a suggestion to auto-approve that action type
- Wires tracking into `ActionExecutorAgent` (records on both approve and deny paths) and instantiates in backend config

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Approve an action multiple times and verify `ApprovalTracker.getAllStats()` reflects correct counts
- [ ] Deny an action and verify `consecutiveApprovals` resets to 0
- [ ] Approve 5+ times consecutively and verify `checkEscalations()` returns a `TrustEscalation`
- [ ] Confirm mid-term memory entries appear under `trust:approvals` domain

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)