### PR TITLE
feat: trust escalation engine with auto-approve rules

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -40,6 +40,7 @@ import {
   TriageFeedbackTracker,
   // Trust tracking
   ApprovalTracker,
+  EscalationEngine,
 } from "@waibspace/agents";
 import {
   ConnectorRegistry,
@@ -202,6 +203,12 @@ log.info("Triage memory integrator and feedback tracker initialized");
 const approvalTracker = new ApprovalTracker(midTermMemory);
 log.info("Approval tracker initialized");
 
+// ---------- 6. Escalation Engine ----------
+const escalationEngine = new EscalationEngine(approvalTracker, midTermMemory);
+log.info("Escalation engine initialized", {
+  activeRules: escalationEngine.getActiveRules().length,
+});
+
 // ---------- 6a. Engagement Tracker ----------
 const engagementTracker = new EngagementTracker(memoryStore);
 log.info("Engagement tracker initialized");
@@ -231,6 +238,7 @@ const orchestrator = new Orchestrator(bus, agentRegistry, {
   triageMemoryIntegrator,
   triageFeedbackTracker,
   approvalTracker,
+  escalationEngine,
 });
 
 // ---------- 7b. Alert Emitter ----------

--- a/packages/agents/src/context/policy-gate.ts
+++ b/packages/agents/src/context/policy-gate.ts
@@ -3,6 +3,7 @@ import type { PolicyEngine, ProposedAction } from "@waibspace/policy";
 import { BaseAgent } from "../base-agent";
 import type { AgentInput, AgentContext } from "../types";
 import type { TriageOutput } from "../triage/types";
+import type { EscalationEngine } from "../trust/escalation-engine";
 
 /**
  * Evaluates proposed actions against the PolicyEngine during the context phase.
@@ -83,6 +84,40 @@ export class PolicyGateAgent extends BaseAgent {
     });
 
     const decision = policyEngine.evaluate(proposedAction);
+
+    // Check trust rules — auto-approve if a matching rule exists
+    const escalationEngine = context.config?.["escalationEngine"] as
+      | EscalationEngine
+      | undefined;
+
+    if (
+      escalationEngine &&
+      decision.verdict === "approval_required" &&
+      escalationEngine.shouldAutoApprove(detected.actionType, (detected.payload as Record<string, unknown>)?.domain as string ?? detected.actionType)
+    ) {
+      this.log("Trust rule auto-approved action", {
+        actionType: detected.actionType,
+      });
+
+      const autoDecision: PolicyDecision = {
+        action: decision.action,
+        verdict: "allowed",
+        riskClass: decision.riskClass,
+        reason: "auto-approved by trust rule",
+      };
+
+      const endMs = Date.now();
+      return {
+        ...this.createOutput(autoDecision, 1.0, {
+          sourceType: "system",
+          sourceId: this.id,
+          dataState: "raw",
+          freshness: "realtime",
+          timestamp: startMs,
+        }),
+        timing: { startMs, endMs, durationMs: endMs - startMs },
+      };
+    }
 
     // Enrich the approval prompt with action context
     if (decision.verdict === "approval_required" && decision.requiredApproval) {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -71,6 +71,8 @@ export {
 export { ActionExecutorAgent } from "./execution";
 export {
   ApprovalTracker,
+  EscalationEngine,
+  type TrustRule,
   type ApprovalRecord,
   type ApprovalStats,
   type TrustEscalation,

--- a/packages/agents/src/trust/escalation-engine.ts
+++ b/packages/agents/src/trust/escalation-engine.ts
@@ -1,0 +1,128 @@
+import type { MidTermMemory } from "@waibspace/memory";
+import type { ApprovalTracker } from "./approval-tracker";
+import type { TrustEscalation } from "./types";
+
+export interface TrustRule {
+  id: string;
+  actionType: string;
+  domain: string;
+  autoApprove: boolean;
+  createdAt: number;
+  lastUsedAt: number;
+  usageCount: number;
+}
+
+/**
+ * Analyzes approval patterns from the ApprovalTracker and suggests
+ * auto-approving similar actions after N consecutive approvals.
+ *
+ * Trust rules are persisted to mid-term memory so they survive restarts
+ * and are available to the PolicyGateAgent for auto-approval decisions.
+ */
+export class EscalationEngine {
+  private rules = new Map<string, TrustRule>();
+
+  constructor(
+    private tracker: ApprovalTracker,
+    private midTerm: MidTermMemory,
+  ) {
+    this.loadRules();
+  }
+
+  /**
+   * Check for escalation opportunities and return suggestions.
+   * Filters out action+domain pairs that already have an active rule.
+   */
+  checkForEscalations(): TrustEscalation[] {
+    return this.tracker.checkEscalations().filter((e) => {
+      const ruleKey = `${e.actionType}:${e.domain}`;
+      return !this.rules.has(ruleKey);
+    });
+  }
+
+  /**
+   * Accept an escalation — create an auto-approve rule.
+   */
+  acceptEscalation(actionType: string, domain: string): TrustRule {
+    const ruleKey = `${actionType}:${domain}`;
+    const rule: TrustRule = {
+      id: ruleKey,
+      actionType,
+      domain,
+      autoApprove: true,
+      createdAt: Date.now(),
+      lastUsedAt: Date.now(),
+      usageCount: 0,
+    };
+    this.rules.set(ruleKey, rule);
+    this.persistRule(rule);
+    return rule;
+  }
+
+  /**
+   * Revoke an auto-approve rule.
+   */
+  revokeRule(actionType: string, domain: string): boolean {
+    const ruleKey = `${actionType}:${domain}`;
+    const deleted = this.rules.delete(ruleKey);
+    if (deleted) {
+      this.midTerm.store(
+        "trust:rules",
+        ruleKey,
+        JSON.stringify({ revoked: true, revokedAt: Date.now() }),
+      );
+    }
+    return deleted;
+  }
+
+  /**
+   * Check if an action should be auto-approved based on trust rules.
+   * Updates usage stats when a rule is applied.
+   */
+  shouldAutoApprove(actionType: string, domain: string): boolean {
+    const ruleKey = `${actionType}:${domain}`;
+    const rule = this.rules.get(ruleKey);
+    if (!rule || !rule.autoApprove) return false;
+
+    rule.lastUsedAt = Date.now();
+    rule.usageCount++;
+    this.persistRule(rule);
+    return true;
+  }
+
+  /** Get all active (non-revoked) rules. */
+  getActiveRules(): TrustRule[] {
+    return [...this.rules.values()].filter((r) => r.autoApprove);
+  }
+
+  private persistRule(rule: TrustRule): void {
+    this.midTerm.store("trust:rules", rule.id, JSON.stringify(rule));
+  }
+
+  private loadRules(): void {
+    const entries = this.midTerm.getByDomain("trust:rules");
+    for (const entry of entries) {
+      try {
+        const parsed = JSON.parse(entry.summary) as Record<string, unknown>;
+        // Skip revoked rules
+        if (parsed.revoked) continue;
+
+        const rule: TrustRule = {
+          id: (parsed.id as string) ?? entry.key,
+          actionType: parsed.actionType as string,
+          domain: parsed.domain as string,
+          autoApprove: parsed.autoApprove as boolean,
+          createdAt: parsed.createdAt as number,
+          lastUsedAt: parsed.lastUsedAt as number,
+          usageCount: parsed.usageCount as number,
+        };
+
+        if (rule.actionType && rule.domain && rule.autoApprove) {
+          this.rules.set(rule.id, rule);
+        }
+      } catch {
+        // Skip entries that can't be parsed
+      }
+    }
+  }
+}

--- a/packages/agents/src/trust/index.ts
+++ b/packages/agents/src/trust/index.ts
@@ -1,4 +1,5 @@
 export { ApprovalTracker } from "./approval-tracker";
+export { EscalationEngine, type TrustRule } from "./escalation-engine";
 export type {
   ApprovalRecord,
   ApprovalStats,

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -34,6 +34,8 @@ export interface OrchestratorOptions {
   triageMemoryIntegrator?: unknown;
   /** Triage feedback tracker — learns from user interactions with triaged items */
   triageFeedbackTracker?: unknown;
+  /** Trust escalation engine — auto-approves actions based on approval patterns */
+  escalationEngine?: unknown;
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -139,6 +141,9 @@ export class Orchestrator {
             : {}),
           ...(this.options?.triageFeedbackTracker
             ? { triageFeedbackTracker: this.options.triageFeedbackTracker }
+            : {}),
+          ...(this.options?.escalationEngine
+            ? { escalationEngine: this.options.escalationEngine }
             : {}),
         },
       };


### PR DESCRIPTION
## Summary
- Adds `EscalationEngine` class that analyzes `ApprovalTracker` patterns and suggests auto-approving actions after N consecutive approvals
- Trust rules are persisted to mid-term memory and loaded on startup
- `PolicyGateAgent` checks `EscalationEngine.shouldAutoApprove()` before requiring approval for medium-risk actions, returning verdict "allowed" with reason "auto-approved by trust rule"
- Wired into backend: `EscalationEngine` is instantiated with `ApprovalTracker` + `MidTermMemory` and passed through the orchestrator config

Closes #323

## Test plan
- [ ] Verify `EscalationEngine` loads existing rules from mid-term memory on construction
- [ ] Verify `checkForEscalations()` filters out action+domain pairs with active rules
- [ ] Verify `acceptEscalation()` creates a rule and persists it
- [ ] Verify `revokeRule()` removes the rule and stores a revoked marker
- [ ] Verify `shouldAutoApprove()` returns true for active rules and updates usage stats
- [ ] Verify `PolicyGateAgent` auto-approves when a matching trust rule exists
- [ ] Verify `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)