### PR TITLE
feat: agent spawning for parallel tasks

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -3,7 +3,7 @@ import type { WaibEvent } from "@waibspace/types";
 import { createLogger } from "@waibspace/logger";
 
 import type { ServerMessage, ComposedLayout } from "@waibspace/ui-renderer-contract";
-import { Orchestrator, AgentRegistry, InMemoryPendingActionStore } from "@waibspace/orchestrator";
+import { Orchestrator, AgentRegistry, InMemoryPendingActionStore, AgentSpawner } from "@waibspace/orchestrator";
 import {
   // Perception agents
   InputNormalizerAgent,
@@ -227,6 +227,10 @@ log.info("Conversation context store initialized");
 const pendingActionStore = new InMemoryPendingActionStore();
 log.info("Pending action store initialized");
 
+// ---------- 6c. Agent Spawner ----------
+const agentSpawner = new AgentSpawner(bus, { maxConcurrent: 5 });
+log.info("Agent spawner initialized", { maxConcurrent: 5 });
+
 // ---------- 7. Orchestrator ----------
 const orchestrator = new Orchestrator(bus, agentRegistry, {
   modelProvider: modelRegistry,
@@ -245,6 +249,7 @@ const orchestrator = new Orchestrator(bus, agentRegistry, {
   approvalTracker,
   userRulesManager,
   escalationEngine,
+  agentSpawner,
 });
 
 // ---------- 7b. Alert Emitter ----------
@@ -465,6 +470,7 @@ log.info("WaibSpace backend started", { port: PORT });
 // ---------- 13. Graceful Shutdown ----------
 function handleShutdown(signal: string) {
   log.info("Shutting down", { signal });
+  agentSpawner.shutdown();
   mcpRegistry.stopHealthChecks();
   scheduler.stop();
   pollingScheduler.stop();

--- a/packages/orchestrator/src/agent-spawner.ts
+++ b/packages/orchestrator/src/agent-spawner.ts
@@ -1,0 +1,129 @@
+import type { WaibEvent, AgentOutput } from "@waibspace/types";
+import { EventBus, createEvent } from "@waibspace/event-bus";
+
+export interface SpawnRequest {
+  parentTraceId: string;
+  agentType: "coding" | "research" | "analysis" | "custom";
+  task: string;                    // Human-readable task description
+  payload: Record<string, unknown>; // Task-specific data
+  priority?: number;               // 0-100, default 50
+  timeoutMs?: number;              // Default 60000
+}
+
+export interface SpawnResult {
+  requestId: string;
+  parentTraceId: string;
+  agentType: string;
+  status: "completed" | "failed" | "timeout";
+  output?: AgentOutput;
+  error?: string;
+  durationMs: number;
+}
+
+export class AgentSpawner {
+  private activeSpawns = new Map<string, { request: SpawnRequest; startMs: number }>();
+  private readonly maxConcurrent: number;
+
+  constructor(
+    private bus: EventBus,
+    options?: { maxConcurrent?: number },
+  ) {
+    this.maxConcurrent = options?.maxConcurrent ?? 5;
+    this.setupListeners();
+  }
+
+  private setupListeners(): void {
+    // Listen for spawn requests
+    this.bus.on("agent.spawn.request", (event: WaibEvent) => {
+      const request = event.payload as SpawnRequest;
+      this.handleSpawnRequest(request, event.traceId);
+    });
+  }
+
+  /**
+   * Request spawning a new agent task.
+   * Returns a requestId that can be used to track the result.
+   */
+  spawn(request: SpawnRequest): string {
+    const requestId = `spawn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    if (this.activeSpawns.size >= this.maxConcurrent) {
+      // Emit failure — at capacity
+      const result: SpawnResult = {
+        requestId,
+        parentTraceId: request.parentTraceId,
+        agentType: request.agentType,
+        status: "failed",
+        error: `Max concurrent spawns reached (${this.maxConcurrent})`,
+        durationMs: 0,
+      };
+      this.emitComplete(result, request.parentTraceId);
+      return requestId;
+    }
+
+    this.activeSpawns.set(requestId, { request, startMs: Date.now() });
+
+    // Set timeout
+    const timeout = request.timeoutMs ?? 60_000;
+    setTimeout(() => {
+      if (this.activeSpawns.has(requestId)) {
+        this.activeSpawns.delete(requestId);
+        const result: SpawnResult = {
+          requestId,
+          parentTraceId: request.parentTraceId,
+          agentType: request.agentType,
+          status: "timeout",
+          error: `Timed out after ${timeout}ms`,
+          durationMs: timeout,
+        };
+        this.emitComplete(result, request.parentTraceId);
+      }
+    }, timeout);
+
+    return requestId;
+  }
+
+  /**
+   * Complete a spawned task (called by the task executor).
+   */
+  complete(requestId: string, output?: AgentOutput, error?: string): void {
+    const entry = this.activeSpawns.get(requestId);
+    if (!entry) return;
+
+    this.activeSpawns.delete(requestId);
+    const result: SpawnResult = {
+      requestId,
+      parentTraceId: entry.request.parentTraceId,
+      agentType: entry.request.agentType,
+      status: error ? "failed" : "completed",
+      output,
+      error,
+      durationMs: Date.now() - entry.startMs,
+    };
+    this.emitComplete(result, entry.request.parentTraceId);
+  }
+
+  private handleSpawnRequest(request: SpawnRequest, traceId: string): void {
+    this.spawn({ ...request, parentTraceId: traceId });
+  }
+
+  private emitComplete(result: SpawnResult, traceId: string): void {
+    const event = createEvent(
+      "agent.spawn.complete",
+      result,
+      "agent-spawner",
+      traceId,
+    );
+    this.bus.emit(event);
+  }
+
+  /** Get count of active spawns. */
+  get activeCount(): number {
+    return this.activeSpawns.size;
+  }
+
+  /** Stop all active spawns. */
+  shutdown(): void {
+    this.activeSpawns.clear();
+  }
+}

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -13,3 +13,8 @@ export {
   type BenchmarkSummary,
   type PercentileStats,
 } from "./benchmark";
+export {
+  AgentSpawner,
+  type SpawnRequest,
+  type SpawnResult,
+} from "./agent-spawner";

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -11,6 +11,7 @@ import { AgentRegistry } from "./agent-registry";
 import { buildExecutionPlan } from "./execution-planner";
 import { createPipelineTrace, logTrace } from "./trace";
 import { BenchmarkCollector } from "./benchmark";
+import type { AgentSpawner } from "./agent-spawner";
 import type { TriageOutput, MemoryCandidate } from "@waibspace/agents";
 
 export interface OrchestratorOptions {
@@ -40,6 +41,8 @@ export interface OrchestratorOptions {
   userRulesManager?: unknown;
   /** Trust escalation engine — auto-approves actions based on approval patterns */
   escalationEngine?: unknown;
+  /** Agent spawner — enables agents to spawn sub-agents for parallel tasks */
+  agentSpawner?: AgentSpawner;
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -148,6 +151,9 @@ export class Orchestrator {
             : {}),
           ...(this.options?.escalationEngine
             ? { escalationEngine: this.options.escalationEngine }
+            : {}),
+          ...(this.options?.agentSpawner
+            ? { agentSpawner: this.options.agentSpawner }
             : {}),
         },
       };

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -20,7 +20,9 @@ export type WaibEventType =
   | "background.task.complete"
   | "system.poll"
   | "briefing.alert"
-  | "memory.updated";
+  | "memory.updated"
+  | "agent.spawn.request"
+  | "agent.spawn.complete";
 
 export interface WaibEvent {
   id: string;


### PR DESCRIPTION
## Summary
- Add `AgentSpawner` class in `packages/orchestrator/src/agent-spawner.ts` with concurrency limits, per-request timeouts, and event-driven completion tracking
- Add `agent.spawn.request` and `agent.spawn.complete` event types to `WaibEventType` union
- Wire `AgentSpawner` into the orchestrator pipeline context and backend initialization with graceful shutdown

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Verify spawner respects `maxConcurrent` limit and emits failure when at capacity
- [ ] Verify timeout fires and emits `agent.spawn.complete` with `status: "timeout"`
- [ ] Verify `complete()` emits proper result event and clears the active spawn
- [ ] Verify `shutdown()` clears all active spawns
- [ ] Verify agents can access `agentSpawner` via `context.config.agentSpawner`

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)