### PR TITLE
feat: away summary generation and long-term memory recall

### DIFF
--- a/apps/backend/src/away-tracker.ts
+++ b/apps/backend/src/away-tracker.ts
@@ -1,0 +1,84 @@
+/**
+ * Tracks user absence and accumulates background events that occur while
+ * the user is away. When the user returns after the configured threshold,
+ * the tracker provides a summary of what happened.
+ */
+export class AwayTracker {
+  private lastActivity: number = Date.now();
+  private awayThresholdMs: number = 30 * 60 * 1000; // 30 minutes
+  private accumulatedEvents: Array<{
+    type: string;
+    summary: string;
+    timestamp: number;
+    connectorId?: string;
+  }> = [];
+  private readonly maxEvents = 100;
+
+  /**
+   * Record user activity (called on any user interaction or WS message).
+   */
+  recordActivity(): void {
+    this.lastActivity = Date.now();
+  }
+
+  /**
+   * Record a background event that happened while the user might be away.
+   */
+  recordBackgroundEvent(event: {
+    type: string;
+    summary: string;
+    connectorId?: string;
+  }): void {
+    this.accumulatedEvents.push({
+      ...event,
+      timestamp: Date.now(),
+    });
+    if (this.accumulatedEvents.length > this.maxEvents) {
+      this.accumulatedEvents = this.accumulatedEvents.slice(-this.maxEvents);
+    }
+  }
+
+  /**
+   * Check if user was away and return accumulated events if so.
+   * Clears the accumulated events after returning them.
+   */
+  checkAndGetAwaySummary(): {
+    wasAway: boolean;
+    durationMs: number;
+    events: Array<{
+      type: string;
+      summary: string;
+      timestamp: number;
+      connectorId?: string;
+    }>;
+  } | null {
+    const now = Date.now();
+    const durationMs = now - this.lastActivity;
+
+    if (
+      durationMs < this.awayThresholdMs ||
+      this.accumulatedEvents.length === 0
+    ) {
+      return null;
+    }
+
+    const events = [...this.accumulatedEvents];
+    this.accumulatedEvents = [];
+    this.lastActivity = now;
+
+    return { wasAway: true, durationMs, events };
+  }
+
+  /**
+   * Format duration as human-readable string.
+   */
+  static formatDuration(ms: number): string {
+    const minutes = Math.floor(ms / 60_000);
+    if (minutes < 60) return `${minutes} minute${minutes !== 1 ? "s" : ""}`;
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    if (remainingMinutes === 0)
+      return `${hours} hour${hours !== 1 ? "s" : ""}`;
+    return `${hours}h ${remainingMinutes}m`;
+  }
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -42,6 +42,8 @@ import {
   ApprovalTracker,
   UserRulesManager,
   EscalationEngine,
+  // Context agents
+  MemoryRecallAgent,
 } from "@waibspace/agents";
 import {
   ConnectorRegistry,
@@ -62,6 +64,7 @@ import { TaskScheduler } from "./scheduler";
 import { startServer } from "./server";
 import { broadcast } from "./ws";
 import { AlertEmitter } from "./alert-emitter";
+import { AwayTracker } from "./away-tracker";
 
 // ---------- 1. Event Bus ----------
 const bus = new EventBus();
@@ -158,6 +161,7 @@ agentRegistry.register(new ConnectorSelectionAgent());
 agentRegistry.register(new DataRetrievalAgent());
 agentRegistry.register(new PolicyGateAgent());
 agentRegistry.register(new BehavioralPreferenceAgent());
+agentRegistry.register(new MemoryRecallAgent());
 
 // Triage agents
 const dataTriageAgent = new DataTriageAgent();
@@ -266,8 +270,19 @@ bus.on("triage.high_urgency", (event: WaibEvent) => {
     connectorId: string;
   };
   alertEmitter.emitAlerts(payload.triageItems, payload.connectorId, event.traceId);
+
+  // Record for away tracker
+  awayTracker.recordBackgroundEvent({
+    type: "triage.high_urgency",
+    summary: `${payload.triageItems.length} high-urgency item(s) from ${payload.connectorId}`,
+    connectorId: payload.connectorId,
+  });
 });
 log.info("Alert emitter initialized");
+
+// ---------- 7c. Away Tracker ----------
+const awayTracker = new AwayTracker();
+log.info("Away tracker initialized");
 
 // ---------- 8. Memory Update Pipeline ----------
 const memoryPipeline = new MemoryUpdatePipeline(memoryStore, bus);
@@ -364,6 +379,28 @@ for (const pattern of USER_EVENT_PATTERNS) {
     // ObservationProcessor and should not re-trigger the full pipeline.
     if (PASSIVE_OBSERVATION_TYPES.has(event.type)) return;
 
+    // Record user activity for away tracking
+    awayTracker.recordActivity();
+
+    // On user.message.received, check if user was away and inject summary
+    if (event.type === "user.message.received") {
+      const awaySummary = awayTracker.checkAndGetAwaySummary();
+      if (awaySummary) {
+        const duration = AwayTracker.formatDuration(awaySummary.durationMs);
+        log.info("User returned after absence", {
+          duration,
+          eventCount: awaySummary.events.length,
+        });
+        // Inject away summary into the event payload for LayoutComposer
+        const payload = event.payload as Record<string, unknown>;
+        payload.awaySummary = {
+          durationMs: awaySummary.durationMs,
+          durationFormatted: duration,
+          events: awaySummary.events,
+        };
+      }
+    }
+
     const traceId = event.traceId;
     log.child({ traceId }).info("Routing event to orchestrator", { eventType: event.type });
     try {
@@ -422,6 +459,15 @@ bus.on("background.task.complete", (event: WaibEvent) => {
     durationMs: number;
     error?: string;
   };
+
+  // Record for away tracker
+  if (payload.success) {
+    awayTracker.recordBackgroundEvent({
+      type: "task.complete",
+      summary: `Background task "${payload.taskName}" completed`,
+    });
+  }
+
   const message: ServerMessage = {
     type: "task.complete",
     payload,

--- a/packages/agents/src/context/index.ts
+++ b/packages/agents/src/context/index.ts
@@ -23,3 +23,7 @@ export {
   BehavioralPreferenceAgent,
   type BehavioralPreferenceOutput,
 } from "./behavioral-preference";
+export {
+  MemoryRecallAgent,
+  type MemoryRecallOutput,
+} from "./memory-recall";

--- a/packages/agents/src/context/memory-recall.ts
+++ b/packages/agents/src/context/memory-recall.ts
@@ -1,0 +1,114 @@
+import type { AgentOutput } from "@waibspace/types";
+import type { LongTermMemory } from "@waibspace/memory";
+import { BaseAgent } from "../base-agent";
+import type { AgentInput, AgentContext } from "../types";
+
+export interface MemoryRecallOutput {
+  recalled: Array<{
+    keywords: string[];
+    blurb: string;
+    domain: string;
+    relevance: number;
+  }>;
+  query: string;
+}
+
+export class MemoryRecallAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: "context.memory-recall",
+      name: "MemoryRecallAgent",
+      type: "memory-recall",
+      category: "context",
+    });
+  }
+
+  async execute(
+    input: AgentInput,
+    context: AgentContext,
+  ): Promise<AgentOutput> {
+    const startMs = Date.now();
+    const longTermMemory = context.config?.[
+      "longTermMemory"
+    ] as LongTermMemory | undefined;
+
+    if (!longTermMemory) {
+      return this.createOutput({ recalled: [], query: "" }, 0.5);
+    }
+
+    // Extract searchable terms from the user message
+    const payload = input.event.payload as
+      | Record<string, unknown>
+      | undefined;
+    const userMessage =
+      (payload?.text as string) ?? (payload?.message as string) ?? "";
+
+    if (!userMessage || userMessage.length < 3) {
+      return this.createOutput({ recalled: [], query: "" }, 0.5);
+    }
+
+    // Extract potential names, topics from the message
+    const query = this.extractSearchTerms(userMessage);
+    if (!query) {
+      return this.createOutput({ recalled: [], query: "" }, 0.5);
+    }
+
+    // Search long-term memory
+    const results = longTermMemory.recall(query, 5);
+
+    const output: MemoryRecallOutput = {
+      recalled: results.map((r) => ({
+        keywords: r.keywords,
+        blurb: r.blurb,
+        domain: r.domain,
+        relevance: 1.0,
+      })),
+      query,
+    };
+
+    this.log("Memory recall", { query, resultCount: results.length });
+
+    return {
+      ...this.createOutput(output, results.length > 0 ? 0.9 : 0.3, {
+        sourceType: "memory",
+        dataState: "raw",
+        freshness: "recent",
+        timestamp: startMs,
+      }),
+      timing: {
+        startMs,
+        endMs: Date.now(),
+        durationMs: Date.now() - startMs,
+      },
+    };
+  }
+
+  /**
+   * Extract meaningful search terms from user message.
+   * Focus on proper nouns, specific terms, and quoted phrases.
+   */
+  private extractSearchTerms(message: string): string {
+    // Look for quoted phrases first
+    const quoted = message.match(/"([^"]+)"/);
+    if (quoted) return quoted[1];
+
+    // Look for "remember X" pattern
+    const rememberMatch = message.match(/remember\s+(.+?)(?:\?|$)/i);
+    if (rememberMatch) return rememberMatch[1].trim();
+
+    // Look for "about X" pattern
+    const aboutMatch = message.match(/about\s+(.+?)(?:\?|$)/i);
+    if (aboutMatch) return aboutMatch[1].trim();
+
+    // Extract capitalized words (likely proper nouns) -- at least 2 chars
+    const properNouns = message.match(/\b[A-Z][a-z]{1,}\b/g);
+    if (properNouns && properNouns.length > 0) {
+      return properNouns.join(" ");
+    }
+
+    // Fallback: use the whole message if short enough
+    if (message.length < 50) return message;
+
+    return "";
+  }
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -36,6 +36,8 @@ export {
   PolicyGateAgent,
   BehavioralPreferenceAgent,
   type BehavioralPreferenceOutput,
+  MemoryRecallAgent,
+  type MemoryRecallOutput,
 } from "./context";
 export {
   InboxSurfaceAgent,

--- a/packages/agents/src/ui/layout-composer.ts
+++ b/packages/agents/src/ui/layout-composer.ts
@@ -128,7 +128,23 @@ export class LayoutComposerAgent extends BaseAgent {
 
     this.log("Collected surfaces", { count: surfaces.length });
 
-    // 2. Check for triage data in priorOutputs
+    // 2. Check for away summary data in event payload
+    const eventPayload = input.event.payload as Record<string, unknown> | undefined;
+    const awaySummary = eventPayload?.awaySummary as {
+      durationMs: number;
+      durationFormatted: string;
+      events: Array<{ type: string; summary: string; timestamp: number; connectorId?: string }>;
+    } | undefined;
+
+    if (awaySummary) {
+      this.log("Away summary detected, composing away briefing", {
+        duration: awaySummary.durationFormatted,
+        eventCount: awaySummary.events.length,
+      });
+      return this.composeAwaySummaryLayout(awaySummary, surfaces, context, startMs);
+    }
+
+    // 3. Check for triage data in priorOutputs
     const triageOutput = extractTriageOutput(input.priorOutputs);
 
     if (triageOutput) {
@@ -140,9 +156,101 @@ export class LayoutComposerAgent extends BaseAgent {
       return this.composeBriefingLayout(triageOutput, surfaces, context, startMs);
     }
 
-    // 3. Fallback: grid-based layout (existing behavior)
+    // 4. Fallback: grid-based layout (existing behavior)
     this.log("No triage data, using grid layout");
     return this.composeGridLayout(surfaces, context, startMs);
+  }
+
+  /**
+   * Compose an away-summary layout when the user returns after an absence.
+   *
+   * Generates a "While you were away" briefing card summarizing background
+   * events that occurred during the user's absence.
+   */
+  private composeAwaySummaryLayout(
+    awaySummary: {
+      durationMs: number;
+      durationFormatted: string;
+      events: Array<{ type: string; summary: string; timestamp: number; connectorId?: string }>;
+    },
+    surfaces: SurfaceSpec[],
+    context: AgentContext,
+    startMs: number,
+  ): AgentOutput {
+    const cards: BriefingCardSpec[] = [];
+
+    // Group events by type for a cleaner summary
+    const eventsByType: Record<string, number> = {};
+    for (const event of awaySummary.events) {
+      eventsByType[event.type] = (eventsByType[event.type] ?? 0) + 1;
+    }
+
+    // Build event summaries (deduplicated)
+    const eventSummaries = awaySummary.events.map((e) => e.summary);
+    const uniqueSummaries = [...new Set(eventSummaries)];
+
+    cards.push({
+      cardType: "briefing-card",
+      priority: 100,
+      data: {
+        title: `Welcome back — you were away for ${awaySummary.durationFormatted}`,
+        summary: `${awaySummary.events.length} event${awaySummary.events.length !== 1 ? "s" : ""} occurred while you were away`,
+        eventCount: awaySummary.events.length,
+        eventBreakdown: eventsByType,
+        eventSummaries: uniqueSummaries.slice(0, 10),
+        durationMs: awaySummary.durationMs,
+        durationFormatted: awaySummary.durationFormatted,
+      },
+    });
+
+    // Sort cards by priority descending
+    cards.sort((a, b) => b.priority - a.priority);
+
+    const briefingData: BriefingSurfaceData = {
+      cards,
+      generatedAt: Date.now(),
+      mode: "away-summary",
+    };
+
+    const briefingSurface = SurfaceFactory.briefing(briefingData, {
+      sourceType: "system",
+      sourceId: "layout-composer",
+      trustLevel: "trusted",
+      timestamp: Date.now(),
+      freshness: "realtime",
+      dataState: "transformed",
+      transformations: ["away-summary-to-briefing"],
+    });
+
+    // Keep overlay surfaces alongside the briefing
+    const overlays = surfaces.filter(
+      (s) => s.layoutHints.position === "overlay",
+    );
+
+    const allSurfaces = [briefingSurface, ...overlays];
+    const layout = this.buildDirectives(allSurfaces);
+
+    const endMs = Date.now();
+
+    const composed: ComposedLayout = {
+      surfaces: allSurfaces,
+      layout,
+      timestamp: Date.now(),
+      traceId: context.traceId,
+    };
+
+    return {
+      ...this.createOutput(composed, 1.0, {
+        dataState: "transformed",
+        transformations: ["away-summary-to-briefing", "layout-composition"],
+        timestamp: startMs,
+      }),
+      timing: {
+        startMs,
+        endMs,
+        durationMs: endMs - startMs,
+      },
+    };
   }
 
   /**

--- a/packages/orchestrator/src/execution-planner.ts
+++ b/packages/orchestrator/src/execution-planner.ts
@@ -72,7 +72,7 @@ const AGENT_ORDERINGS: Record<string, AgentOrdering[]> = {
     {
       category: "context",
       groups: [
-        ["context.planner"],
+        ["context.planner", "context.memory-recall"],
         ["context.connector-selection"],
         ["context.data-retrieval"],
       ],


### PR DESCRIPTION
## Summary
- **AwayTracker** (`apps/backend/src/away-tracker.ts`): Detects user absence (30-minute threshold), accumulates background events (task completions, triage alerts), and provides a summary when the user returns
- **MemoryRecallAgent** (`packages/agents/src/context/memory-recall.ts`): Searches long-term FTS memory when relevant keywords (proper nouns, quoted phrases, "remember X" patterns) appear in user messages, running in parallel with ContextPlanner in the pipeline
- **LayoutComposer away-summary mode**: Generates a "While you were away" briefing card with event breakdown when away summary data is present in the pipeline event payload

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed)
- [ ] Verify AwayTracker accumulates events and returns summary after threshold
- [ ] Verify MemoryRecallAgent extracts search terms and queries LongTermMemory
- [ ] Verify LayoutComposer generates away-summary briefing when payload contains awaySummary
- [ ] Verify execution planner includes context.memory-recall in user.message.received pipeline

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)