### PR TITLE
fix: briefing transformer + triage output extraction

### DIFF
--- a/apps/frontend/src/blocks/transformers/briefing.ts
+++ b/apps/frontend/src/blocks/transformers/briefing.ts
@@ -1,0 +1,58 @@
+import type { ComponentBlock, SurfaceSpec } from "@waibspace/types";
+import type { BriefingSurfaceData, BriefingCardSpec } from "@waibspace/surfaces";
+
+/**
+ * Transform a briefing surface into ComponentBlocks that use our
+ * briefing-card, action-card, insight-card, and status-card domain components.
+ */
+export function briefingToBlocks(spec: SurfaceSpec): ComponentBlock[] {
+  const data = spec.data as BriefingSurfaceData;
+  const sid = spec.surfaceId;
+
+  if (!data?.cards || data.cards.length === 0) {
+    return [
+      {
+        id: `${sid}-empty`,
+        type: "Container",
+        props: { direction: "column", padding: "var(--space-5)" },
+        children: [
+          {
+            id: `${sid}-empty-text`,
+            type: "Text",
+            props: { content: "No briefing items right now.", variant: "body" },
+          },
+        ],
+        meta: {
+          surfaceId: spec.surfaceId,
+          surfaceType: "briefing",
+          provenance: spec.provenance,
+          layoutHints: spec.layoutHints,
+        },
+      },
+    ];
+  }
+
+  // Each BriefingCardSpec becomes a block of its cardType
+  const children: ComponentBlock[] = data.cards.map(
+    (card: BriefingCardSpec, i: number) => ({
+      id: `${sid}-card-${i}`,
+      type: card.cardType,
+      props: card.data,
+    }),
+  );
+
+  return [
+    {
+      id: `${sid}-root`,
+      type: "Container",
+      props: { direction: "column", gap: "16px", padding: "var(--space-5)" },
+      children,
+      meta: {
+        surfaceId: spec.surfaceId,
+        surfaceType: "briefing",
+        provenance: spec.provenance,
+        layoutHints: spec.layoutHints,
+      },
+    },
+  ];
+}

--- a/apps/frontend/src/blocks/transformers/index.ts
+++ b/apps/frontend/src/blocks/transformers/index.ts
@@ -8,6 +8,7 @@ import { approvalToBlocks } from "./approval";
 import { connectionGuideToBlocks } from "./connection-guide";
 import { genericToBlocks } from "./generic";
 import { searchToBlocks } from "./search";
+import { briefingToBlocks } from "./briefing";
 
 export {
   inboxToBlocks,
@@ -17,6 +18,7 @@ export {
   connectionGuideToBlocks,
   genericToBlocks,
   searchToBlocks,
+  briefingToBlocks,
 };
 
 const transformerMap: Record<
@@ -29,6 +31,7 @@ const transformerMap: Record<
   approval: approvalToBlocks,
   "connection-guide": connectionGuideToBlocks,
   search: searchToBlocks,
+  briefing: briefingToBlocks,
 };
 
 /**

--- a/packages/agents/src/ui/layout-composer.ts
+++ b/packages/agents/src/ui/layout-composer.ts
@@ -62,32 +62,42 @@ export function extractSurfaces(outputs: AgentOutput[]): SurfaceSpec[] {
 /**
  * Extract TriageOutput from prior agent outputs, if any triage agent ran.
  */
+function isTriageOutput(obj: unknown): obj is TriageOutput {
+  if (!obj || typeof obj !== "object") return false;
+  const v = obj as Record<string, unknown>;
+  return (
+    Array.isArray(v["items"]) &&
+    v["stats"] != null &&
+    typeof v["classifierId"] === "string" &&
+    typeof v["connectorId"] === "string"
+  );
+}
+
 function extractTriageOutput(outputs: AgentOutput[]): TriageOutput | null {
   for (const out of outputs) {
-    const value = out.output as Record<string, unknown> | undefined;
-    if (!value || typeof value !== "object") continue;
+    const value = out.output;
+    if (!value) continue;
 
-    // TriageOutput has items[], stats, classifierId, connectorId
-    if (
-      Array.isArray(value["items"]) &&
-      value["stats"] &&
-      typeof value["classifierId"] === "string" &&
-      typeof value["connectorId"] === "string"
-    ) {
-      return value as unknown as TriageOutput;
+    // Prefer outputs from the triage category
+    const isTriage = out.category === "triage";
+
+    // DataTriageAgent outputs TriageOutput[] (an array)
+    if (Array.isArray(value)) {
+      const first = value.find((item: unknown) => isTriageOutput(item));
+      if (first) return first as TriageOutput;
+      if (!isTriage) continue;
     }
 
-    // Check nested `triageOutput` or `triage` fields
-    for (const key of ["triageOutput", "triage"] as const) {
-      const nested = value[key] as Record<string, unknown> | undefined;
-      if (
-        nested &&
-        typeof nested === "object" &&
-        Array.isArray(nested["items"]) &&
-        nested["stats"] &&
-        typeof nested["classifierId"] === "string"
-      ) {
-        return nested as unknown as TriageOutput;
+    // Single TriageOutput object
+    if (isTriageOutput(value)) {
+      return value;
+    }
+
+    // Check nested fields
+    if (typeof value === "object" && !Array.isArray(value)) {
+      for (const key of ["triageOutput", "triage"] as const) {
+        const nested = (value as Record<string, unknown>)[key];
+        if (isTriageOutput(nested)) return nested;
       }
     }
   }


### PR DESCRIPTION
## Summary
- **Added `briefing` transformer** (`apps/frontend/src/blocks/transformers/briefing.ts`) — maps `surfaceType: "briefing"` to the registered briefing-card, action-card, insight-card, and status-card block components. Without this, briefing surfaces fell through to `genericToBlocks` which rendered raw JSON.
- **Fixed `extractTriageOutput()` in LayoutComposer** — DataTriageAgent outputs `TriageOutput[]` (an array), but the function only checked for a single object with `items`. Now correctly handles array-shaped output by finding the first valid TriageOutput in the array.
- **Registered briefing transformer in the transformer map** so the routing in `transformSurface()` picks it up.

These two bugs together caused the UI to always render the old Gmail-style inbox instead of the new briefing cards.

## Test plan
- [ ] Load homepage with Gmail connected — should see briefing cards (BriefingCard, ActionCard, InsightCard, StatusCard) instead of the old GmailInboxList
- [ ] `npx tsc --noEmit` passes cleanly (CSS-only + TS changes)
- [ ] Empty briefing data renders "No briefing items right now." placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)