### PR TITLE
fix: triage processes all emails, briefing shows all urgency levels

### DIFF
--- a/apps/frontend/src/blocks/components/domain/ActionCard.tsx
+++ b/apps/frontend/src/blocks/components/domain/ActionCard.tsx
@@ -6,6 +6,7 @@ interface ActionCardData {
   subject: string;
   snippet?: string;
   category: string;
+  urgency?: string;
   reasoning?: string;
   suggestedAction?: string;
   confidence?: number;
@@ -39,6 +40,7 @@ export function ActionCard({ block, onEvent }: BlockProps) {
     subject,
     snippet,
     category,
+    urgency,
     reasoning,
     suggestedAction,
     confidence,
@@ -46,9 +48,10 @@ export function ActionCard({ block, onEvent }: BlockProps) {
   } = block.props as ActionCardData;
 
   const actionList = actions ?? ["approve", "dismiss"];
+  const urgencyClass = urgency === "high" ? "urgent" : "review";
 
   return (
-    <div className="action-card action-card--urgent">
+    <div className={`action-card action-card--${urgencyClass}`}>
       <div className="action-card__header">
         <h3 className="action-card__title">{subject || "No subject"}</h3>
         <div className="action-card__badges">

--- a/apps/frontend/src/blocks/components/domain/BriefingCard.tsx
+++ b/apps/frontend/src/blocks/components/domain/BriefingCard.tsx
@@ -1,5 +1,11 @@
 import type { BlockProps } from "../../registry";
 
+interface LowItem {
+  from: string;
+  subject: string;
+  category: string;
+}
+
 interface BriefingCardData {
   title: string;
   summary?: string;
@@ -9,6 +15,8 @@ interface BriefingCardData {
   mediumCount?: number;
   lowCount?: number;
   handledCount?: number;
+  // Low-priority items list
+  lowItems?: LowItem[];
   // Away summary fields
   eventCount?: number;
   eventBreakdown?: Record<string, number>;
@@ -29,6 +37,7 @@ export function BriefingCard({ block }: BlockProps) {
     mediumCount,
     lowCount,
     handledCount,
+    lowItems,
     eventCount,
     eventBreakdown,
     eventSummaries,
@@ -84,6 +93,18 @@ export function BriefingCard({ block }: BlockProps) {
             </div>
           )}
         </div>
+      )}
+
+      {lowItems && lowItems.length > 0 && (
+        <ul className="briefing-card__low-items">
+          {lowItems.map((item, i) => (
+            <li key={i} className="briefing-card__low-item">
+              <span className="briefing-card__low-item-from">{item.from}</span>
+              <span className="briefing-card__low-item-subject">{item.subject}</span>
+              <span className="briefing-card__low-item-category">{item.category}</span>
+            </li>
+          ))}
+        </ul>
       )}
 
       {hasAwayData && (

--- a/packages/agents/src/context/data-retrieval.ts
+++ b/packages/agents/src/context/data-retrieval.ts
@@ -184,7 +184,7 @@ export class DataRetrievalAgent extends BaseAgent {
    */
   private truncateData(data: unknown): unknown {
     const MAX_DATA_SIZE = 50_000;
-    const MAX_ITEMS = 10;
+    const MAX_ITEMS = 50;
     const MAX_FIELD_LENGTH = 500;
 
     // MCP tools return [{type: "text", text: "..."}] — truncate the text content

--- a/packages/agents/src/triage/data-triage-agent.ts
+++ b/packages/agents/src/triage/data-triage-agent.ts
@@ -86,10 +86,10 @@ export class DataTriageAgent extends BaseAgent {
         continue;
       }
 
-      // Normalize data to an array
-      const rawItems = Array.isArray(result.data)
-        ? (result.data as unknown[])
-        : [result.data];
+      // Normalize data to an array of individual items.
+      // MCP connectors return [{type: "text", text: "[...json...]"}],
+      // so we need to extract and parse the JSON content.
+      const rawItems = this.extractItems(result.data);
 
       if (rawItems.length === 0) continue;
 
@@ -165,6 +165,56 @@ export class DataTriageAgent extends BaseAgent {
       durationMs: endMs - startMs,
     };
     return output;
+  }
+
+  /**
+   * Extract individual items from connector data.
+   *
+   * MCP connectors return data as [{type: "text", text: "[...json...]"}].
+   * This method parses the JSON text content into individual items.
+   * Non-MCP data that's already an array of objects is returned as-is.
+   */
+  private extractItems(data: unknown): unknown[] {
+    if (!data) return [];
+
+    if (Array.isArray(data)) {
+      // Check if this is MCP content blocks: [{type: "text", text: "..."}]
+      if (
+        data.length > 0 &&
+        typeof data[0] === "object" &&
+        data[0] !== null &&
+        (data[0] as Record<string, unknown>).type === "text" &&
+        typeof (data[0] as Record<string, unknown>).text === "string"
+      ) {
+        // Parse the JSON text content from each content block
+        const items: unknown[] = [];
+        for (const block of data) {
+          const text = (block as Record<string, string>).text;
+          try {
+            const parsed = JSON.parse(text);
+            if (Array.isArray(parsed)) {
+              items.push(...parsed);
+            } else {
+              items.push(parsed);
+            }
+          } catch {
+            // Not JSON — treat the text block as a single item
+            items.push({ text });
+          }
+        }
+        this.log("Extracted items from MCP content blocks", {
+          contentBlocks: data.length,
+          extractedItems: items.length,
+        });
+        return items;
+      }
+
+      // Already an array of items (non-MCP connector)
+      return data;
+    }
+
+    // Single object
+    return [data];
   }
 
   private isDataRetrievalOutput(output: unknown): output is DataRetrievalOutput {

--- a/packages/agents/src/ui/layout-composer.ts
+++ b/packages/agents/src/ui/layout-composer.ts
@@ -300,26 +300,58 @@ export class LayoutComposerAgent extends BaseAgent {
       },
     });
 
-    // --- Action Cards for high-urgency items ---
-    const urgentItems = items.filter(
-      (item: TriagedItem) => item.triage.urgency === "high",
+    // --- Action Cards for items needing attention ---
+    // Show high and medium urgency items as action cards.
+    // High-urgency items get priority 90, medium get 70.
+    const actionableItems = items.filter(
+      (item: TriagedItem) =>
+        item.triage.urgency === "high" || item.triage.urgency === "medium",
     );
 
-    for (const item of urgentItems) {
+    for (const item of actionableItems) {
       const raw = item.raw as Record<string, unknown>;
+      const isHigh = item.triage.urgency === "high";
       cards.push({
         cardType: "action-card",
-        priority: 90,
+        priority: isHigh ? 90 : 70,
         data: {
           itemId: item.triage.itemId,
           from: raw["from"] ?? raw["sender"] ?? "Unknown",
           subject: raw["subject"] ?? raw["title"] ?? "No subject",
           snippet: raw["snippet"] ?? raw["body"] ?? "",
           category: item.triage.category,
+          urgency: item.triage.urgency,
           reasoning: item.triage.reasoning,
           suggestedAction: item.triage.suggestedAction,
           confidence: item.triage.confidence,
-          actions: ["approve", "edit", "dismiss"],
+          actions: isHigh
+            ? ["approve", "edit", "dismiss"]
+            : ["dismiss", "archive"],
+        },
+      });
+    }
+
+    // --- Briefing list for low-urgency items ---
+    // Show remaining items as a compact list so nothing is hidden.
+    const lowItems = items.filter(
+      (item: TriagedItem) => item.triage.urgency === "low",
+    );
+
+    if (lowItems.length > 0) {
+      cards.push({
+        cardType: "briefing-card",
+        priority: 50,
+        data: {
+          title: `${lowItems.length} low-priority item${lowItems.length !== 1 ? "s" : ""}`,
+          summary: "These don't need immediate attention",
+          lowItems: lowItems.map((item: TriagedItem) => {
+            const raw = item.raw as Record<string, unknown>;
+            return {
+              from: raw["from"] ?? raw["sender"] ?? "Unknown",
+              subject: raw["subject"] ?? raw["title"] ?? "No subject",
+              category: item.triage.category,
+            };
+          }),
         },
       });
     }


### PR DESCRIPTION
## Summary
Three stacked bugs caused the briefing to show only 1 item when Gmail has 20+ emails:

1. **DataTriageAgent MCP parsing** (root cause): MCP connectors return `[{type:"text", text:"[...json...]"}]`. The triage agent was treating this as 1 item (the content block) instead of parsing the JSON text into individual email objects. New `extractItems()` method fixes this.

2. **DataRetrievalAgent truncation**: `MAX_ITEMS = 10` dropped emails before triage could see them. Increased to 50 — field trimming already keeps size manageable.

3. **LayoutComposer only showed high-urgency**: Only `urgency === "high"` items became action cards. Now medium-urgency items are action cards too, and low-priority items render as a compact list.

## Test plan
- [ ] Restart backend, refresh frontend
- [ ] Briefing shows multiple items, not just 1
- [ ] High-urgency emails show as action cards with approve/edit/dismiss
- [ ] Medium-urgency emails show as action cards with dismiss/archive  
- [ ] Low-priority emails appear in a compact list
- [ ] Stats in the greeting card reflect actual counts
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)